### PR TITLE
CMake bug workaround when using clang on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 # Please also see the LICENSE file for MIT license.
 ##############################################################################
 
+cmake_policy(SET CMP0025 NEW)
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0057 NEW)
 


### PR DESCRIPTION
This commit fixes an issue wherein setting CMAKE_CXX_STANDARD to 11
was not adding the "-std=c++11" flag to the command line when
using Clang on OS X. This is a known CMake issue reported in
https://gitlab.kitware.com/cmake/cmake/issues/15943. The suggested
workaround is to set the CMake policy CMP0025.