### PR TITLE
Gaurd replay abi usage against ROCM compilation

### DIFF
--- a/src/umpire/ResourceManager.inl
+++ b/src/umpire/ResourceManager.inl
@@ -39,7 +39,11 @@ Allocator ResourceManager::makeAllocator(
     UMPIRE_LOG(Debug, "(name=\"" << name << "\")");
 
     UMPIRE_REPLAY("makeAllocator,"
+#if defined(UMPIRE_ENABLE_ROCM)
+        << typeid(Strategy).name();
+#else
         << abi::__cxa_demangle(typeid(Strategy).name(),nullptr,nullptr,nullptr)
+#endif
         << "," << (introspection ? "true" : "false")
         << "," << name
         << umpire::util::Replay::printReplayAllocator(std::forward<Args>(args)...)

--- a/tools/replay.cpp
+++ b/tools/replay.cpp
@@ -277,9 +277,11 @@ int main(int ac, char** av)
   if ( ac != 2 )
     Replay::usage_and_exit( "Incorrect number of program arguments" );
 
+#if !defined(UMPIRE_ENABLE_ROCM)
   Replay replay(av[1]);
 
   replay.run();
+#endif
 
   return 0;
 }


### PR DESCRIPTION
This first step simply guards against replay usage on AMD platform.