### PR TITLE
Allow explicitly setting the device id when constructing an AllocationAdvisor

### DIFF
--- a/src/umpire/strategy/AllocationAdvisor.cpp
+++ b/src/umpire/strategy/AllocationAdvisor.cpp
@@ -40,10 +40,22 @@ AllocationAdvisor::AllocationAdvisor(
     int id,
     Allocator allocator,
     const std::string& advice_operation,
-    Allocator accessing_allocator) :
+    int device_id) :
+  AllocationAdvisor(
+      name, id, allocator, advice_operation, allocator, device_id)
+{
+}
+
+AllocationAdvisor::AllocationAdvisor(
+    const std::string& name,
+    int id,
+    Allocator allocator,
+    const std::string& advice_operation,
+    Allocator accessing_allocator,
+    int device_id) :
   AllocationStrategy(name, id),
   m_allocator(allocator.getAllocationStrategy()),
-  m_device(0)
+  m_device(device_id)
 {
   auto& op_registry = op::MemoryOperationRegistry::getInstance();
 

--- a/src/umpire/strategy/AllocationAdvisor.cpp
+++ b/src/umpire/strategy/AllocationAdvisor.cpp
@@ -29,16 +29,6 @@ AllocationAdvisor::AllocationAdvisor(
     const std::string& name,
     int id,
     Allocator allocator,
-    const std::string& advice_operation) :
-  AllocationAdvisor(
-      name, id, allocator, advice_operation, allocator)
-{
-}
-
-AllocationAdvisor::AllocationAdvisor(
-    const std::string& name,
-    int id,
-    Allocator allocator,
     const std::string& advice_operation,
     int device_id) :
   AllocationAdvisor(

--- a/src/umpire/strategy/AllocationAdvisor.hpp
+++ b/src/umpire/strategy/AllocationAdvisor.hpp
@@ -46,14 +46,16 @@ class AllocationAdvisor :
         const std::string& name,
         int id,
         Allocator allocator,
-        const std::string& advice_operation);
+        const std::string& advice_operation,
+        int device_id);
 
       AllocationAdvisor(
         const std::string& name,
         int id,
         Allocator allocator,
         const std::string& advice_operation,
-        Allocator accessing_allocator);
+        Allocator accessing_allocator,
+        int device_id);
 
     void* allocate(size_t bytes);
     void deallocate(void* ptr);

--- a/src/umpire/strategy/AllocationAdvisor.hpp
+++ b/src/umpire/strategy/AllocationAdvisor.hpp
@@ -42,18 +42,12 @@ class AllocationAdvisor :
   public AllocationStrategy
 {
   public:
-    AllocationAdvisor(
-        const std::string& name,
-        int id,
-        Allocator allocator,
-        const std::string& advice_operation);
-
       AllocationAdvisor(
         const std::string& name,
         int id,
         Allocator allocator,
         const std::string& advice_operation,
-        int device_id);
+        int device_id = 0);
 
       AllocationAdvisor(
         const std::string& name,

--- a/src/umpire/strategy/AllocationAdvisor.hpp
+++ b/src/umpire/strategy/AllocationAdvisor.hpp
@@ -42,6 +42,12 @@ class AllocationAdvisor :
   public AllocationStrategy
 {
   public:
+    AllocationAdvisor(
+        const std::string& name,
+        int id,
+        Allocator allocator,
+        const std::string& advice_operation);
+
       AllocationAdvisor(
         const std::string& name,
         int id,


### PR DESCRIPTION
If the "accessing_allocator" is a CPU-based Allocator, the device id will be ignored.