### PR TITLE
Use 0.3.0 heuristic instead of noop heuristic as default

### DIFF
--- a/src/umpire/strategy/DynamicPool.hpp
+++ b/src/umpire/strategy/DynamicPool.hpp
@@ -68,7 +68,7 @@ class DynamicPool :
         Allocator allocator,
         const std::size_t min_initial_alloc_size = (512 * 1024 * 1024),
         const std::size_t min_alloc_size = (1 * 1024 *1024),
-        Coalesce_Heuristic coalesce_heuristic = heuristic_all_allocations_are_releaseable) noexcept;
+        Coalesce_Heuristic coalesce_heuristic = &heuristic_all_allocations_are_releaseable) noexcept;
 
     void* allocate(size_t bytes) override;
 

--- a/src/umpire/strategy/DynamicPool.hpp
+++ b/src/umpire/strategy/DynamicPool.hpp
@@ -68,7 +68,7 @@ class DynamicPool :
         Allocator allocator,
         const std::size_t min_initial_alloc_size = (512 * 1024 * 1024),
         const std::size_t min_alloc_size = (1 * 1024 *1024),
-        Coalesce_Heuristic coalesce_heuristic = heuristic_noop) noexcept;
+        Coalesce_Heuristic coalesce_heuristic = heuristic_all_allocations_are_releaseable) noexcept;
 
     void* allocate(size_t bytes) override;
 

--- a/tests/integration/strategy_tests.cpp
+++ b/tests/integration/strategy_tests.cpp
@@ -63,7 +63,9 @@ class StrategyTest :
                     (  poolName.str()
                      , rm.getAllocator(allocatorName)
                      , initial_min_size
-                     , subsequent_min_size);
+                     , subsequent_min_size,
+                       umpire::strategy::heuristic_noop);
+
      allocator = new umpire::Allocator(rm.getAllocator(poolName.str()));
     }
 
@@ -408,7 +410,8 @@ TEST(HeuristicTest, AllReleaseableHeuristic)
 
   auto alloc = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "host_dyn_pool_h", rm.getAllocator("HOST"),
-      initial_min_size, subsequent_min_size, h_fun);
+      initial_min_size, subsequent_min_size, 
+      umpire::strategy::heuristic_all_allocations_are_releaseable);
 
   auto strategy = alloc.getAllocationStrategy();
   auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);

--- a/tests/integration/strategy_tests.cpp
+++ b/tests/integration/strategy_tests.cpp
@@ -63,8 +63,8 @@ class StrategyTest :
                     (  poolName.str()
                      , rm.getAllocator(allocatorName)
                      , initial_min_size
-                     , subsequent_min_size,
-                       umpire::strategy::heuristic_noop);
+                     , subsequent_min_size
+                     , &umpire::strategy::heuristic_noop);
 
      allocator = new umpire::Allocator(rm.getAllocator(poolName.str()));
     }
@@ -403,15 +403,12 @@ TEST(ReleaseTest, Works)
 
 TEST(HeuristicTest, AllReleaseableHeuristic)
 {
-  umpire::strategy::DynamicPool::Coalesce_Heuristic h_fun =
-              umpire::strategy::heuristic_all_allocations_are_releaseable;
-
   auto& rm = umpire::ResourceManager::getInstance();
 
   auto alloc = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "host_dyn_pool_h", rm.getAllocator("HOST"),
       initial_min_size, subsequent_min_size, 
-      umpire::strategy::heuristic_all_allocations_are_releaseable);
+      &umpire::strategy::heuristic_all_allocations_are_releaseable);
 
   auto strategy = alloc.getAllocationStrategy();
   auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);

--- a/tests/integration/strategy_tests.cpp
+++ b/tests/integration/strategy_tests.cpp
@@ -407,8 +407,7 @@ TEST(HeuristicTest, AllReleaseableHeuristic)
 
   auto alloc = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "host_dyn_pool_h", rm.getAllocator("HOST"),
-      initial_min_size, subsequent_min_size, 
-      &umpire::strategy::heuristic_all_allocations_are_releaseable);
+      initial_min_size, subsequent_min_size);
 
   auto strategy = alloc.getAllocationStrategy();
   auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);


### PR DESCRIPTION
This is further defined in UM-291

@davidbeckingsale, if you decide to approve this, please go ahead and merge this into the develop branch prior to creating the release.

Thanks,

It's up to you.

Marty