### PR TITLE
Print list of Allocators when one isn't found

### DIFF
--- a/examples/strategy_example.cpp
+++ b/examples/strategy_example.cpp
@@ -25,7 +25,7 @@ int main(int, char**)
   auto& rm = umpire::ResourceManager::getInstance();
 
   std::cout << "Available allocators: ";
-  for (auto s : rm.getAvailableAllocators()){
+  for (auto s : rm.getAllocatorNames()){
     std::cout << s << "  ";
   }
   std::cout << std::endl;
@@ -82,7 +82,7 @@ int main(int, char**)
   std::cout << "Size: " << alloc.getSize(test) << std::endl;
 
   std::cout << "Available allocators: ";
-  for (auto s : rm.getAvailableAllocators()){
+  for (auto s : rm.getAllocatorNames()){
     std::cout << s << ", ";
   }
   std::cout << std::endl;

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -122,4 +122,9 @@ Allocator::getPlatform() noexcept
   return m_allocator->getPlatform();
 }
 
+std::ostream& operator<<(std::ostream& os, const Allocator& allocator) {
+    os << *allocator.m_allocator;
+    return os;
+}
+
 } // end of namespace umpire

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <ostream>
 
 #include "umpire/util/Platform.hpp"
 
@@ -159,6 +160,8 @@ class Allocator {
     Platform getPlatform() noexcept;
 
     Allocator() = default;
+    
+    friend std::ostream& operator<<(std::ostream&, const Allocator&);
 
   private:
     /*!

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -183,7 +183,7 @@ ResourceManager::getAllocationStrategy(const std::string& name)
   UMPIRE_LOG(Debug, "(\"" << name << "\")");
   auto allocator = m_allocators_by_name.find(name);
   if (allocator == m_allocators_by_name.end()) {
-    auto available_names = getAvailableAllocators();
+    auto available_names = getAllocatorNames();
 
     const char* const delim = " ";
 
@@ -225,7 +225,14 @@ ResourceManager::getAllocator(int id)
 
   auto allocator = m_allocators_by_id.find(id);
   if (allocator == m_allocators_by_id.end()) {
-    UMPIRE_ERROR("Allocator \"" << id << "\" not found.");
+    auto available_ids = getAllocatorIds();
+
+    const char* const delim = " ";
+
+    std::ostringstream id_list;
+    std::copy(available_ids.begin(), available_ids.end(),
+               std::ostream_iterator<int>(id_list, delim));
+    UMPIRE_ERROR("Allocator \"" << id << "\" not found. Available allocators: " << id_list.str());
   }
 
   return Allocator(m_allocators_by_id[id]);
@@ -563,7 +570,7 @@ std::shared_ptr<strategy::AllocationStrategy>& ResourceManager::findAllocatorFor
 }
 
 std::vector<std::string>
-ResourceManager::getAvailableAllocators() noexcept
+ResourceManager::getAllocatorNames() const noexcept
 {
   std::vector<std::string> names;
   for(auto it = m_allocators_by_name.begin(); it != m_allocators_by_name.end(); ++it) {
@@ -572,6 +579,17 @@ ResourceManager::getAvailableAllocators() noexcept
 
   UMPIRE_LOG(Debug, "() returning " << names.size() << " allocators");
   return names;
+}
+
+std::vector<int>
+ResourceManager::getAllocatorIds() const noexcept
+{
+  std::vector<int> ids;
+  for (auto& it : m_allocators_by_id) {
+    ids.push_back(it.first);
+  }
+
+  return ids;
 }
 
 int

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -591,7 +591,7 @@ ResourceManager::getAllocatorInformation() const noexcept
   std::ostringstream info;
 
   for (auto& it : m_allocators_by_name) {
-    info << it.second << " ";
+    info << *it.second << " ";
   }
 
   return info.str();

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -183,16 +183,8 @@ ResourceManager::getAllocationStrategy(const std::string& name)
   UMPIRE_LOG(Debug, "(\"" << name << "\")");
   auto allocator = m_allocators_by_name.find(name);
   if (allocator == m_allocators_by_name.end()) {
-    auto available_names = getAllocatorNames();
-
-    const char* const delim = " ";
-
-    std::ostringstream name_list;
-    std::copy(available_names.begin(), available_names.end(),
-               std::ostream_iterator<std::string>(name_list, delim));
-
-    
-    UMPIRE_ERROR("Allocator \"" << name << "\" not found. Available allocators: " << name_list.str());
+    UMPIRE_ERROR("Allocator \"" << name << "\" not found. Available allocators: " 
+        << getAllocatorInformation());
   }
 
   return m_allocators_by_name[name];
@@ -212,7 +204,8 @@ ResourceManager::getAllocator(resource::MemoryResourceType resource_type)
 
   auto allocator = m_memory_resources.find(resource_type);
   if (allocator == m_memory_resources.end()) {
-    UMPIRE_ERROR("Allocator \"" << static_cast<size_t>(resource_type) << "\" not found.");
+    UMPIRE_ERROR("Allocator \"" << static_cast<size_t>(resource_type)
+        << "\" not found. Available allocators: " << getAllocatorInformation());
   }
 
   return Allocator(m_memory_resources[resource_type]);
@@ -225,14 +218,8 @@ ResourceManager::getAllocator(int id)
 
   auto allocator = m_allocators_by_id.find(id);
   if (allocator == m_allocators_by_id.end()) {
-    auto available_ids = getAllocatorIds();
-
-    const char* const delim = " ";
-
-    std::ostringstream id_list;
-    std::copy(available_ids.begin(), available_ids.end(),
-               std::ostream_iterator<int>(id_list, delim));
-    UMPIRE_ERROR("Allocator \"" << id << "\" not found. Available allocators: " << id_list.str());
+    UMPIRE_ERROR("Allocator \"" << id << "\" not found. Available allocators: "
+        << getAllocatorInformation());
   }
 
   return Allocator(m_allocators_by_id[id]);
@@ -596,6 +583,18 @@ int
 ResourceManager::getNextId() noexcept
 {
   return m_id++;
+}
+
+std::string
+ResourceManager::getAllocatorInformation() const noexcept
+{
+  std::ostringstream info;
+
+  for (auto& it : m_allocators_by_name) {
+    info << it.second << " ";
+  }
+
+  return info.str();
 }
 
 } // end of namespace umpire

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -20,8 +20,6 @@
 
 #include "umpire/resource/HostResourceFactory.hpp"
 
-#include <memory>
-
 #if defined(UMPIRE_ENABLE_NUMA)
 #include "umpire/strategy/NumaPolicy.hpp"
 #endif
@@ -46,6 +44,10 @@
 #include "umpire/strategy/AllocationTracker.hpp"
 
 #include "umpire/util/Macros.hpp"
+
+#include <iterator>
+#include <memory>
+#include <sstream>
 
 namespace umpire {
 
@@ -181,7 +183,16 @@ ResourceManager::getAllocationStrategy(const std::string& name)
   UMPIRE_LOG(Debug, "(\"" << name << "\")");
   auto allocator = m_allocators_by_name.find(name);
   if (allocator == m_allocators_by_name.end()) {
-    UMPIRE_ERROR("Allocator \"" << name << "\" not found.");
+    auto available_names = getAvailableAllocators();
+
+    const char* const delim = " ";
+
+    std::ostringstream name_list;
+    std::copy(available_names.begin(), available_names.end(),
+               std::ostream_iterator<std::string>(name_list, delim));
+
+    
+    UMPIRE_ERROR("Allocator \"" << name << "\" not found. Available allocators: " << name_list.str());
   }
 
   return m_allocators_by_name[name];

--- a/src/umpire/ResourceManager.hpp
+++ b/src/umpire/ResourceManager.hpp
@@ -52,7 +52,12 @@ class ResourceManager {
     /*!
      * \brief Get the names of all available Allocator objects.
      */
-    std::vector<std::string> getAvailableAllocators() noexcept;
+    std::vector<std::string> getAllocatorNames() const noexcept;
+
+    /*!
+     * \brief Get the ids of all available Allocator objects.
+     */
+    std::vector<int> getAllocatorIds() const noexcept;
 
     /*!
      * \brief Get the Allocator with the given name.

--- a/src/umpire/ResourceManager.hpp
+++ b/src/umpire/ResourceManager.hpp
@@ -245,7 +245,6 @@ class ResourceManager {
      */
     void coalesce(Allocator allocator);
 
-
   private:
     ResourceManager();
 
@@ -257,6 +256,8 @@ class ResourceManager {
     std::shared_ptr<strategy::AllocationStrategy>& getAllocationStrategy(const std::string& name);
 
     int getNextId() noexcept;
+
+    std::string getAllocatorInformation() const noexcept;
 
     static ResourceManager* s_resource_manager_instance;
 

--- a/src/umpire/strategy/AllocationStrategy.cpp
+++ b/src/umpire/strategy/AllocationStrategy.cpp
@@ -49,5 +49,11 @@ AllocationStrategy::getActualSize() const noexcept
   return getCurrentSize();
 }
 
+std::ostream& operator<<(std::ostream& os, const AllocationStrategy& strategy)
+{
+  os << "[" << strategy.m_name << "," << strategy.m_id << "]";
+  return os;
+}
+
 } // end of namespace strategy
 } // end of namespace umpire

--- a/src/umpire/strategy/AllocationStrategy.hpp
+++ b/src/umpire/strategy/AllocationStrategy.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <memory>
 #include <cstddef>
+#include <ostream>
 
 namespace umpire {
 namespace strategy {
@@ -118,6 +119,8 @@ class AllocationStrategy :
      * \return The id of this AllocationStrategy.
      */
     int getId() noexcept;
+
+    friend std::ostream& operator<<(std::ostream& os, const AllocationStrategy& strategy);
 
   protected:
     std::string m_name;

--- a/tests/unit/resource_manager_tests.cpp
+++ b/tests/unit/resource_manager_tests.cpp
@@ -41,7 +41,7 @@ TEST(ResourceManager, findAllocationRecord)
   ASSERT_THROW(rm.findAllocationRecord(nullptr), umpire::util::Exception);
 }
 
-TEST(ResourceManager, getAllocator)
+TEST(ResourceManager, getAllocatorByName)
 {
 
   auto& rm = umpire::ResourceManager::getInstance();
@@ -52,5 +52,19 @@ TEST(ResourceManager, getAllocator)
 
   ASSERT_THROW(
       rm.getAllocator("BANANA"),
+      umpire::util::Exception);
+}
+
+TEST(ResourceManager, getAllocatorById)
+{
+
+  auto& rm = umpire::ResourceManager::getInstance();
+
+  EXPECT_NO_THROW({
+    auto alloc = rm.getAllocator(0);
+  });
+
+  ASSERT_THROW(
+      rm.getAllocator(-4),
       umpire::util::Exception);
 }

--- a/tests/unit/resource_manager_tests.cpp
+++ b/tests/unit/resource_manager_tests.cpp
@@ -40,3 +40,17 @@ TEST(ResourceManager, findAllocationRecord)
 
   ASSERT_THROW(rm.findAllocationRecord(nullptr), umpire::util::Exception);
 }
+
+TEST(ResourceManager, getAllocator)
+{
+
+  auto& rm = umpire::ResourceManager::getInstance();
+
+  EXPECT_NO_THROW({
+    auto alloc = rm.getAllocator("HOST");
+  });
+
+  ASSERT_THROW(
+      rm.getAllocator("BANANA"),
+      umpire::util::Exception);
+}


### PR DESCRIPTION
Example error:

```
[ERROR][/Users/beckingsale1/Projects/umpire/code/umpire/src/umpire/ResourceManager.cpp:195]: getAllocationStrategy Allocator "BANANA" not found. Available allocators: HOST
```