### PR TITLE
Remove shared_ptr

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,12 +52,6 @@ if (ENABLE_STATISTICS)
     OUTPUT_DIR ${UMPIRE_EXAMPLES_OUTPUT_DIR})
 endif()
 
-#blt_add_executable(
-#  NAME sandbox
-#  SOURCES sandbox.cpp
-#  DEPENDS_ON umpire
-#  OUTPUT_DIR ${UMPIRE_EXAMPLES_OUTPUT_DIR})
-
 add_subdirectory(tutorial)
 
 add_subdirectory(cookbook)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,6 +52,12 @@ if (ENABLE_STATISTICS)
     OUTPUT_DIR ${UMPIRE_EXAMPLES_OUTPUT_DIR})
 endif()
 
+#blt_add_executable(
+#  NAME sandbox
+#  SOURCES sandbox.cpp
+#  DEPENDS_ON umpire
+#  OUTPUT_DIR ${UMPIRE_EXAMPLES_OUTPUT_DIR})
+
 add_subdirectory(tutorial)
 
 add_subdirectory(cookbook)

--- a/examples/cookbook/recipe_coalesce_pool.cpp
+++ b/examples/cookbook/recipe_coalesce_pool.cpp
@@ -29,13 +29,13 @@ int main(int, char**) {
       "pool", rm.getAllocator("HOST"));
 
   auto strategy = pool.getAllocationStrategy();
-  auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+  auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
   if (tracker) {
     strategy = tracker->getAllocationStrategy();
   }
 
-  auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+  auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
   if (dynamic_pool) {
     dynamic_pool->coalesce();

--- a/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
+++ b/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
@@ -50,12 +50,12 @@ int main(int, char**) {
   // DynamicPool-specific statistics
   //
   auto strategy = pooled_allocator.getAllocationStrategy();
-  auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+  auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
   if (tracker)
     strategy = tracker->getAllocationStrategy();
 
-  auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+  auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
   void* a[4];
   for (int i = 0; i < 4; ++i)

--- a/examples/cookbook/recipe_pool_advice.cpp
+++ b/examples/cookbook/recipe_pool_advice.cpp
@@ -43,5 +43,7 @@ int main(int, char**) {
                             "GPU_POOL",
                             preferred_location_allocator);
 
+  UMPIRE_USE_VAR(pooled_allocator);
+
   return 0;
 }

--- a/examples/strategy_example.cpp
+++ b/examples/strategy_example.cpp
@@ -51,7 +51,7 @@ int main(int, char**)
   alloc = rm.makeAllocator<umpire::strategy::MonotonicAllocationStrategy>(
       "MONOTONIC 4096", 4096, rm.getAllocator("HOST"));
 
-  auto slot_alloc = rm.makeAllocator<umpire::strategy::SlotPool>(
+  alloc = rm.makeAllocator<umpire::strategy::SlotPool>(
       "host_slot_pool", 64, rm.getAllocator("HOST"));
 
   /*

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -25,7 +25,7 @@
 
 namespace umpire {
 
-Allocator::Allocator(std::shared_ptr<strategy::AllocationStrategy> allocator) noexcept:
+Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept:
   m_allocator(allocator)
 {
 }
@@ -109,7 +109,7 @@ Allocator::getId() const noexcept
   return m_allocator->getId();
 }
 
-std::shared_ptr<strategy::AllocationStrategy>
+strategy::AllocationStrategy*
 Allocator::getAllocationStrategy() noexcept
 {
   UMPIRE_LOG(Debug, "() returning " << m_allocator);

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -149,7 +149,7 @@ class Allocator {
      *
      * \return Pointer to the AllocationStrategy.
      */
-    std::shared_ptr<umpire::strategy::AllocationStrategy> getAllocationStrategy() noexcept;
+    strategy::AllocationStrategy* getAllocationStrategy() noexcept;
 
     /*!
      * \brief Get the Platform object appropriate for this Allocator.
@@ -170,13 +170,13 @@ class Allocator {
      * \param allocator Pointer to the AllocationStrategy object to use for
      * Allocations.
      */
-    Allocator(std::shared_ptr<strategy::AllocationStrategy> allocator) noexcept;
+    Allocator(strategy::AllocationStrategy* allocator) noexcept;
 
 
     /*!
      * \brief Pointer to the AllocationStrategy used by this Allocator.
      */
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    umpire::strategy::AllocationStrategy* m_allocator;
 };
 
 } // end of namespace umpire

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -177,7 +177,7 @@ ResourceManager::initialize()
   UMPIRE_LOG(Debug, "() leaving");
 }
 
-strategy::AllocationStrategy*&
+strategy::AllocationStrategy*
 ResourceManager::getAllocationStrategy(const std::string& name)
 {
   UMPIRE_LOG(Debug, "(\"" << name << "\")");
@@ -511,7 +511,7 @@ ResourceManager::getSize(void* ptr) const
   return record->m_size;
 }
 
-strategy::AllocationStrategy*& ResourceManager::findAllocatorForId(int id)
+strategy::AllocationStrategy* ResourceManager::findAllocatorForId(int id)
 {
   auto allocator_i = m_allocators_by_id.find(id);
 
@@ -523,7 +523,7 @@ strategy::AllocationStrategy*& ResourceManager::findAllocatorForId(int id)
   return allocator_i->second;
 }
 
-strategy::AllocationStrategy*& ResourceManager::findAllocatorForPointer(void* ptr)
+strategy::AllocationStrategy* ResourceManager::findAllocatorForPointer(void* ptr)
 {
   auto allocation_record = m_allocations.find(ptr);
 

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -77,28 +77,28 @@ ResourceManager::ResourceManager() :
     resource::MemoryResourceRegistry::getInstance();
 
   registry.registerMemoryResource(
-      std::make_shared<resource::HostResourceFactory>());
+      new resource::HostResourceFactory());
 
 #if defined(UMPIRE_ENABLE_CUDA)
   registry.registerMemoryResource(
-    std::make_shared<resource::CudaDeviceResourceFactory>());
+    new resource::CudaDeviceResourceFactory());
 
   registry.registerMemoryResource(
-    std::make_shared<resource::CudaUnifiedMemoryResourceFactory>());
+    new resource::CudaUnifiedMemoryResourceFactory());
 
   registry.registerMemoryResource(
-    std::make_shared<resource::CudaPinnedMemoryResourceFactory>());
+    new resource::CudaPinnedMemoryResourceFactory());
 
   registry.registerMemoryResource(
-    std::make_shared<resource::CudaConstantMemoryResourceFactory>());
+    new resource::CudaConstantMemoryResourceFactory());
 #endif
 
 #if defined(UMPIRE_ENABLE_ROCM)
   registry.registerMemoryResource(
-    std::make_shared<resource::RocmDeviceResourceFactory>());
+    new resource::RocmDeviceResourceFactory());
 
   registry.registerMemoryResource(
-    std::make_shared<resource::RocmPinnedMemoryResourceFactory>());
+    new resource::RocmPinnedMemoryResourceFactory());
 #endif
 
   initialize();
@@ -175,7 +175,7 @@ ResourceManager::initialize()
   UMPIRE_LOG(Debug, "() leaving");
 }
 
-std::shared_ptr<strategy::AllocationStrategy>&
+strategy::AllocationStrategy*&
 ResourceManager::getAllocationStrategy(const std::string& name)
 {
   UMPIRE_LOG(Debug, "(\"" << name << "\")");
@@ -411,15 +411,15 @@ ResourceManager::reallocate(void* src_ptr, size_t size, Allocator allocator)
 static std::shared_ptr<strategy::NumaPolicy> cast_as_numa_policy(Allocator& allocator) {
   std::shared_ptr<strategy::NumaPolicy> numa_alloc;
 
-  numa_alloc = std::dynamic_pointer_cast<strategy::NumaPolicy>(
+  numa_alloc = dynamic_cast<strategy::NumaPolicy*>(
     allocator.getAllocationStrategy());
 
   // ... or an AllocationTracker wrapping a NumaPolicy
   if (!numa_alloc) {
-    auto alloc_tracker = std::dynamic_pointer_cast<strategy::AllocationTracker>(
+    auto alloc_tracker = dynamic_cast<strategy::AllocationTracker*>(
       allocator.getAllocationStrategy());
     if (alloc_tracker) {
-      numa_alloc = std::dynamic_pointer_cast<strategy::NumaPolicy>(
+      numa_alloc = dynamic_cast<strategy::NumaPolicy*>(
         alloc_tracker->getAllocationStrategy());
     }
   }
@@ -506,7 +506,7 @@ ResourceManager::getSize(void* ptr) const
   return record->m_size;
 }
 
-std::shared_ptr<strategy::AllocationStrategy>& ResourceManager::findAllocatorForId(int id)
+strategy::AllocationStrategy*& ResourceManager::findAllocatorForId(int id)
 {
   auto allocator_i = m_allocators_by_id.find(id);
 
@@ -518,7 +518,7 @@ std::shared_ptr<strategy::AllocationStrategy>& ResourceManager::findAllocatorFor
   return allocator_i->second;
 }
 
-std::shared_ptr<strategy::AllocationStrategy>& ResourceManager::findAllocatorForPointer(void* ptr)
+strategy::AllocationStrategy*& ResourceManager::findAllocatorForPointer(void* ptr)
 {
   auto allocation_record = m_allocations.find(ptr);
 

--- a/src/umpire/ResourceManager.hpp
+++ b/src/umpire/ResourceManager.hpp
@@ -241,9 +241,9 @@ class ResourceManager {
     ResourceManager (const ResourceManager&) = delete;
     ResourceManager& operator= (const ResourceManager&) = delete;
 
-    strategy::AllocationStrategy*& findAllocatorForPointer(void* ptr);
-    strategy::AllocationStrategy*& findAllocatorForId(int id);
-    strategy::AllocationStrategy*& getAllocationStrategy(const std::string& name);
+    strategy::AllocationStrategy* findAllocatorForPointer(void* ptr);
+    strategy::AllocationStrategy* findAllocatorForId(int id);
+    strategy::AllocationStrategy* getAllocationStrategy(const std::string& name);
 
     int getNextId() noexcept;
 

--- a/src/umpire/ResourceManager.hpp
+++ b/src/umpire/ResourceManager.hpp
@@ -236,9 +236,9 @@ class ResourceManager {
     ResourceManager (const ResourceManager&) = delete;
     ResourceManager& operator= (const ResourceManager&) = delete;
 
-    std::shared_ptr<strategy::AllocationStrategy>& findAllocatorForPointer(void* ptr);
-    std::shared_ptr<strategy::AllocationStrategy>& findAllocatorForId(int id);
-    std::shared_ptr<strategy::AllocationStrategy>& getAllocationStrategy(const std::string& name);
+    strategy::AllocationStrategy*& findAllocatorForPointer(void* ptr);
+    strategy::AllocationStrategy*& findAllocatorForId(int id);
+    strategy::AllocationStrategy*& getAllocationStrategy(const std::string& name);
 
     int getNextId() noexcept;
 
@@ -246,14 +246,14 @@ class ResourceManager {
 
     std::list<std::string> m_allocator_names;
 
-    std::unordered_map<std::string, std::shared_ptr<strategy::AllocationStrategy> > m_allocators_by_name;
-    std::unordered_map<int, std::shared_ptr<strategy::AllocationStrategy> > m_allocators_by_id;
+    std::unordered_map<std::string, strategy::AllocationStrategy* > m_allocators_by_name;
+    std::unordered_map<int, strategy::AllocationStrategy* > m_allocators_by_id;
 
     util::AllocationMap m_allocations;
 
-    std::shared_ptr<strategy::AllocationStrategy> m_default_allocator;
+    strategy::AllocationStrategy* m_default_allocator;
 
-    std::unordered_map<resource::MemoryResourceType, std::shared_ptr<strategy::AllocationStrategy>, resource::MemoryResourceTypeHash > m_memory_resources;
+    std::unordered_map<resource::MemoryResourceType, strategy::AllocationStrategy*, resource::MemoryResourceTypeHash > m_memory_resources;
 
     long m_allocated;
 

--- a/src/umpire/ResourceManager.inl
+++ b/src/umpire/ResourceManager.inl
@@ -33,7 +33,7 @@ Allocator ResourceManager::makeAllocator(
     const std::string& name, 
     Args&&... args)
 {
-  std::shared_ptr<strategy::AllocationStrategy> allocator;
+  strategy::AllocationStrategy* allocator;
 
   try {
     UMPIRE_LOCK;
@@ -52,7 +52,7 @@ Allocator ResourceManager::makeAllocator(
     }
 
     if (!introspection) {
-      allocator = std::make_shared<Strategy>(name, getNextId(), std::forward<Args>(args)...);
+      allocator = new Strategy(name, getNextId(), std::forward<Args>(args)...);
 
       m_allocators_by_name[name] = allocator;
       m_allocators_by_id[allocator->getId()] = allocator;
@@ -60,9 +60,9 @@ Allocator ResourceManager::makeAllocator(
       std::stringstream base_name;
       base_name << name << "_base";
 
-      auto base_allocator = std::make_shared<Strategy>(base_name.str(), getNextId(), std::forward<Args>(args)...);
+      auto base_allocator = new Strategy(base_name.str(), getNextId(), std::forward<Args>(args)...);
 
-      allocator = std::make_shared<umpire::strategy::AllocationTracker>(name, getNextId(), Allocator(base_allocator));
+      allocator = new umpire::strategy::AllocationTracker(name, getNextId(), Allocator(base_allocator));
 
       m_allocators_by_name[name] = allocator;
       m_allocators_by_id[allocator->getId()] = allocator;

--- a/src/umpire/op/MemoryOperationRegistry.cpp
+++ b/src/umpire/op/MemoryOperationRegistry.cpp
@@ -195,8 +195,8 @@ MemoryOperationRegistry::registerOperation(
 std::shared_ptr<umpire::op::MemoryOperation>
 MemoryOperationRegistry::find(
     const std::string& name,
-    strategy::AllocationStrategy*& src_allocator,
-    strategy::AllocationStrategy*& dst_allocator)
+    strategy::AllocationStrategy* src_allocator,
+    strategy::AllocationStrategy* dst_allocator)
 {
   auto platforms = std::make_pair(
       src_allocator->getPlatform(),

--- a/src/umpire/op/MemoryOperationRegistry.cpp
+++ b/src/umpire/op/MemoryOperationRegistry.cpp
@@ -195,8 +195,8 @@ MemoryOperationRegistry::registerOperation(
 std::shared_ptr<umpire::op::MemoryOperation>
 MemoryOperationRegistry::find(
     const std::string& name,
-    std::shared_ptr<strategy::AllocationStrategy>& src_allocator,
-    std::shared_ptr<strategy::AllocationStrategy>& dst_allocator)
+    strategy::AllocationStrategy*& src_allocator,
+    strategy::AllocationStrategy*& dst_allocator)
 {
   auto platforms = std::make_pair(
       src_allocator->getPlatform(),

--- a/src/umpire/op/MemoryOperationRegistry.hpp
+++ b/src/umpire/op/MemoryOperationRegistry.hpp
@@ -82,8 +82,8 @@ class MemoryOperationRegistry {
      */
     std::shared_ptr<umpire::op::MemoryOperation> find(
         const std::string& name,
-        std::shared_ptr<strategy::AllocationStrategy>& source_allocator,
-        std::shared_ptr<strategy::AllocationStrategy>& dst_allocator);
+        strategy::AllocationStrategy*& source_allocator,
+        strategy::AllocationStrategy*& dst_allocator);
 
     /*!
      * \brief Add a new MemoryOperation to the registry

--- a/src/umpire/op/MemoryOperationRegistry.hpp
+++ b/src/umpire/op/MemoryOperationRegistry.hpp
@@ -82,8 +82,8 @@ class MemoryOperationRegistry {
      */
     std::shared_ptr<umpire::op::MemoryOperation> find(
         const std::string& name,
-        strategy::AllocationStrategy*& source_allocator,
-        strategy::AllocationStrategy*& dst_allocator);
+        strategy::AllocationStrategy* source_allocator,
+        strategy::AllocationStrategy* dst_allocator);
 
     /*!
      * \brief Add a new MemoryOperation to the registry

--- a/src/umpire/resource/CudaConstantMemoryResource.cu
+++ b/src/umpire/resource/CudaConstantMemoryResource.cu
@@ -52,7 +52,7 @@ void* CudaConstantMemoryResource::allocate(size_t bytes)
   }
 
   ResourceManager::getInstance().registerAllocation(
-      ret, new util::AllocationRecord{ret, bytes, this->shared_from_this()});
+      ret, new util::AllocationRecord{ret, bytes, this});
 
   m_current_size += bytes;
   if (m_current_size > m_highwatermark)

--- a/src/umpire/resource/CudaConstantMemoryResourceFactory.cpp
+++ b/src/umpire/resource/CudaConstantMemoryResourceFactory.cpp
@@ -32,7 +32,7 @@ CudaConstantMemoryResourceFactory::isValidMemoryResourceFor(const std::string& n
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 CudaConstantMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
   MemoryResourceTraits traits;
@@ -45,7 +45,7 @@ CudaConstantMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(n
 
   traits.used_for = MemoryResourceTraits::optimized_for::any;
 
-  return std::make_shared<resource::CudaConstantMemoryResource >("DEVICE_CONST", id, traits);
+  return new resource::CudaConstantMemoryResource("DEVICE_CONST", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaConstantMemoryResourceFactory.hpp
+++ b/src/umpire/resource/CudaConstantMemoryResourceFactory.hpp
@@ -29,7 +29,7 @@ class CudaConstantMemoryResourceFactory :
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
 
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaDeviceResourceFactory.cpp
+++ b/src/umpire/resource/CudaDeviceResourceFactory.cpp
@@ -33,7 +33,7 @@ CudaDeviceResourceFactory::isValidMemoryResourceFor(const std::string& name)
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 CudaDeviceResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
   MemoryResourceTraits traits;
@@ -52,7 +52,7 @@ CudaDeviceResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), in
   traits.kind = MemoryResourceTraits::memory_type::GDDR;
   traits.used_for = MemoryResourceTraits::optimized_for::any;
 
-  return std::make_shared<resource::DefaultMemoryResource<alloc::CudaMallocAllocator> >(Platform::cuda, "DEVICE", id, traits);
+  return new resource::DefaultMemoryResource<alloc::CudaMallocAllocator>(Platform::cuda, "DEVICE", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaDeviceResourceFactory.hpp
+++ b/src/umpire/resource/CudaDeviceResourceFactory.hpp
@@ -30,7 +30,7 @@ class CudaDeviceResourceFactory :
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
 
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaPinnedMemoryResourceFactory.cpp
+++ b/src/umpire/resource/CudaPinnedMemoryResourceFactory.cpp
@@ -32,7 +32,7 @@ CudaPinnedMemoryResourceFactory::isValidMemoryResourceFor(const std::string& nam
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 CudaPinnedMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
   MemoryResourceTraits traits;
@@ -44,7 +44,7 @@ CudaPinnedMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(nam
   traits.kind = MemoryResourceTraits::memory_type::DDR;
   traits.used_for = MemoryResourceTraits::optimized_for::access;
 
-  return std::make_shared<resource::DefaultMemoryResource<alloc::CudaPinnedAllocator> >(Platform::cuda, "PINNED", id, traits);
+  return new resource::DefaultMemoryResource<alloc::CudaPinnedAllocator>(Platform::cuda, "PINNED", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaPinnedMemoryResourceFactory.hpp
+++ b/src/umpire/resource/CudaPinnedMemoryResourceFactory.hpp
@@ -24,7 +24,7 @@ class CudaPinnedMemoryResourceFactory :
   public MemoryResourceFactory
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaUnifiedMemoryResourceFactory.cpp
+++ b/src/umpire/resource/CudaUnifiedMemoryResourceFactory.cpp
@@ -34,7 +34,7 @@ CudaUnifiedMemoryResourceFactory::isValidMemoryResourceFor(const std::string& na
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 CudaUnifiedMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
   MemoryResourceTraits traits;
@@ -53,7 +53,7 @@ CudaUnifiedMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(na
   traits.kind = MemoryResourceTraits::memory_type::GDDR;
   traits.used_for = MemoryResourceTraits::optimized_for::any;
 
-  return std::make_shared<resource::DefaultMemoryResource<alloc::CudaMallocManagedAllocator> >(Platform::cuda, "UM", id, traits);
+  return new resource::DefaultMemoryResource<alloc::CudaMallocManagedAllocator>(Platform::cuda, "UM", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/CudaUnifiedMemoryResourceFactory.hpp
+++ b/src/umpire/resource/CudaUnifiedMemoryResourceFactory.hpp
@@ -28,7 +28,7 @@ class CudaUnifiedMemoryResourceFactory :
   public MemoryResourceFactory
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/DefaultMemoryResource.inl
+++ b/src/umpire/resource/DefaultMemoryResource.inl
@@ -40,7 +40,7 @@ void* DefaultMemoryResource<_allocator>::allocate(size_t bytes)
 {
   void* ptr = m_allocator.allocate(bytes);
 
-  registerAllocation(ptr, bytes, this->shared_from_this());
+  registerAllocation(ptr, bytes, this);
 
   UMPIRE_LOG(Debug, "(bytes=" << bytes << ") returning " << ptr);
   UMPIRE_RECORD_STATISTIC(getName(), "ptr", reinterpret_cast<uintptr_t>(ptr), "size", bytes, "event", "allocate");

--- a/src/umpire/resource/HostResourceFactory.cpp
+++ b/src/umpire/resource/HostResourceFactory.cpp
@@ -36,7 +36,7 @@ HostResourceFactory::isValidMemoryResourceFor(const std::string& name) noexcept
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 HostResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
 #if defined(UMPIRE_ENABLE_NUMA)
@@ -62,7 +62,7 @@ HostResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
   traits.kind = MemoryResourceTraits::memory_type::UNKNOWN;
   traits.used_for = MemoryResourceTraits::optimized_for::any;
 
-  return std::make_shared<DefaultMemoryResource<HostAllocator> >(Platform::cpu, "HOST", id, traits);
+  return new DefaultMemoryResource<HostAllocator>(Platform::cpu, "HOST", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/HostResourceFactory.hpp
+++ b/src/umpire/resource/HostResourceFactory.hpp
@@ -28,7 +28,7 @@ class HostResourceFactory :
   public MemoryResourceFactory
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/MemoryResourceFactory.hpp
+++ b/src/umpire/resource/MemoryResourceFactory.hpp
@@ -49,7 +49,7 @@ class MemoryResourceFactory {
      * \param name Name of the MemoryResource.
      * \param id ID of the MemoryResource.
      */
-    virtual std::shared_ptr<MemoryResource> create(const std::string& name, int id) = 0;
+    virtual resource::MemoryResource* create(const std::string& name, int id) = 0;
 };
 
 } // end of namespace strategy

--- a/src/umpire/resource/MemoryResourceRegistry.cpp
+++ b/src/umpire/resource/MemoryResourceRegistry.cpp
@@ -38,12 +38,12 @@ MemoryResourceRegistry::MemoryResourceRegistry() noexcept :
 }
 
 void
-MemoryResourceRegistry::registerMemoryResource(std::shared_ptr<MemoryResourceFactory>&& factory)
+MemoryResourceRegistry::registerMemoryResource(MemoryResourceFactory* factory)
 {
   m_allocator_factories.push_front(factory);
 }
 
-std::shared_ptr<umpire::resource::MemoryResource>
+resource::MemoryResource*
 MemoryResourceRegistry::makeMemoryResource(const std::string& name, int id)
 {
   for (auto allocator_factory : m_allocator_factories) {

--- a/src/umpire/resource/MemoryResourceRegistry.hpp
+++ b/src/umpire/resource/MemoryResourceRegistry.hpp
@@ -28,9 +28,9 @@ class MemoryResourceRegistry {
   public:
     static MemoryResourceRegistry& getInstance() noexcept;
 
-    std::shared_ptr<umpire::resource::MemoryResource> makeMemoryResource(const std::string& name, int id);
+    resource::MemoryResource* makeMemoryResource(const std::string& name, int id);
 
-    void registerMemoryResource(std::shared_ptr<MemoryResourceFactory>&& factory);
+    void registerMemoryResource(MemoryResourceFactory* factory);
 
   protected:
     MemoryResourceRegistry() noexcept;
@@ -38,7 +38,7 @@ class MemoryResourceRegistry {
   private:
     static MemoryResourceRegistry* s_allocator_registry_instance;
 
-    std::list<std::shared_ptr<MemoryResourceFactory> > m_allocator_factories;
+    std::list<MemoryResourceFactory*> m_allocator_factories;
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/RocmDeviceResourceFactory.cpp
+++ b/src/umpire/resource/RocmDeviceResourceFactory.cpp
@@ -31,7 +31,7 @@ RocmDeviceResourceFactory::isValidMemoryResourceFor(const std::string& name)
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 RocmDeviceResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
   MemoryResourceTraits traits;
@@ -41,7 +41,7 @@ RocmDeviceResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), in
   traits.kind = MemoryResourceTraits::memory_type::GDDR;
   traits.used_for = MemoryResourceTraits::optimized_for::any;
 
-  return std::make_shared<resource::DefaultMemoryResource<alloc::AmAllocAllocator> >(Platform::rocm, "DEVICE", id, traits);
+  return new resource::DefaultMemoryResource<alloc::AmAllocAllocator>(Platform::rocm, "DEVICE", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/RocmDeviceResourceFactory.hpp
+++ b/src/umpire/resource/RocmDeviceResourceFactory.hpp
@@ -30,7 +30,7 @@ class RocmDeviceResourceFactory :
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
 
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/resource/RocmPinnedMemoryResourceFactory.cpp
+++ b/src/umpire/resource/RocmPinnedMemoryResourceFactory.cpp
@@ -31,7 +31,7 @@ RocmPinnedMemoryResourceFactory::isValidMemoryResourceFor(const std::string& nam
   }
 }
 
-std::shared_ptr<MemoryResource>
+resource::MemoryResource*
 RocmPinnedMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(name), int id)
 {
   MemoryResourceTraits traits;
@@ -41,7 +41,7 @@ RocmPinnedMemoryResourceFactory::create(const std::string& UMPIRE_UNUSED_ARG(nam
   traits.kind = MemoryResourceTraits::memory_type::DDR;
   traits.used_for = MemoryResourceTraits::optimized_for::access;
 
-  return std::make_shared<resource::DefaultMemoryResource<alloc::AmPinnedAllocator> >(Platform::rocm, "PINNED", id, traits);
+  return new resource::DefaultMemoryResource<alloc::AmPinnedAllocator>(Platform::rocm, "PINNED", id, traits);
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/RocmPinnedMemoryResourceFactory.hpp
+++ b/src/umpire/resource/RocmPinnedMemoryResourceFactory.hpp
@@ -30,7 +30,7 @@ class RocmPinnedMemoryResourceFactory :
 {
   bool isValidMemoryResourceFor(const std::string& name) noexcept;
 
-  std::shared_ptr<MemoryResource> create(const std::string& name, int id);
+  resource::MemoryResource* create(const std::string& name, int id);
 };
 
 } // end of namespace resource

--- a/src/umpire/strategy/AllocationAdvisor.cpp
+++ b/src/umpire/strategy/AllocationAdvisor.cpp
@@ -66,7 +66,7 @@ AllocationAdvisor::AllocationAdvisor(
 void* AllocationAdvisor::allocate(size_t bytes)
 {
   void* ptr = m_allocator->allocate(bytes);
-  auto alloc_record = new util::AllocationRecord{ptr, bytes, this->shared_from_this()};
+  auto alloc_record = new util::AllocationRecord{ptr, bytes, this};
 
   m_advice_operation->apply(
       ptr,

--- a/src/umpire/strategy/AllocationAdvisor.hpp
+++ b/src/umpire/strategy/AllocationAdvisor.hpp
@@ -67,7 +67,7 @@ class AllocationAdvisor :
   private:
     std::shared_ptr<op::MemoryOperation> m_advice_operation;
 
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 
     int m_device;
 };

--- a/src/umpire/strategy/AllocationStrategy.hpp
+++ b/src/umpire/strategy/AllocationStrategy.hpp
@@ -28,8 +28,7 @@ namespace strategy {
  * \brief AllocationStrategy provides a unified interface to all classes that
  * can be used to allocate and free data.
  */
-class AllocationStrategy :
-  public std::enable_shared_from_this<AllocationStrategy>
+class AllocationStrategy 
 {
   public:
     /*!

--- a/src/umpire/strategy/AllocationTracker.cpp
+++ b/src/umpire/strategy/AllocationTracker.cpp
@@ -32,7 +32,7 @@ AllocationTracker::allocate(size_t bytes)
 {
   void* ptr = m_allocator->allocate(bytes);
 
-  registerAllocation(ptr, bytes, this->shared_from_this());
+  registerAllocation(ptr, bytes, this);
 
   return ptr;
 }
@@ -74,7 +74,7 @@ AllocationTracker::getPlatform() noexcept
   return m_allocator->getPlatform();
 }
 
-std::shared_ptr<umpire::strategy::AllocationStrategy> 
+strategy::AllocationStrategy* 
 AllocationTracker::getAllocationStrategy()
 {
   return m_allocator;

--- a/src/umpire/strategy/AllocationTracker.hpp
+++ b/src/umpire/strategy/AllocationTracker.hpp
@@ -46,10 +46,10 @@ class AllocationTracker :
 
     Platform getPlatform() noexcept;
 
-    std::shared_ptr<umpire::strategy::AllocationStrategy> getAllocationStrategy();
+    strategy::AllocationStrategy* getAllocationStrategy();
 
   private:
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 
 };
 

--- a/src/umpire/strategy/DefaultAllocationStrategy.cpp
+++ b/src/umpire/strategy/DefaultAllocationStrategy.cpp
@@ -18,7 +18,7 @@
 namespace umpire {
 namespace strategy {
 
-DefaultAllocationStrategy::DefaultAllocationStrategy(std::shared_ptr<AllocationStrategy> allocator) :
+DefaultAllocationStrategy::DefaultAllocationStrategy(strategy::AllocationStrategy* allocator) :
   AllocationStrategy("DEFAULT"),
   m_allocator(allocator)
 {

--- a/src/umpire/strategy/DefaultAllocationStrategy.hpp
+++ b/src/umpire/strategy/DefaultAllocationStrategy.hpp
@@ -24,7 +24,7 @@ class DefaultAllocationStrategy :
   public AllocationStrategy
 {
   public:
-    DefaultAllocationStrategy(std::shared_ptr<AllocationStrategy> allocator);
+    DefaultAllocationStrategy(strategy::AllocationStrategy* allocator);
 
     void* allocate(size_t bytes);
 
@@ -41,7 +41,7 @@ class DefaultAllocationStrategy :
     Platform getPlatform();
 
   protected:
-    std::shared_ptr<AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 };
 
 } // end of namespace strategy

--- a/src/umpire/strategy/DynamicPool.hpp
+++ b/src/umpire/strategy/DynamicPool.hpp
@@ -106,7 +106,7 @@ class DynamicPool :
   private:
     DynamicSizePool<>* dpa;
 
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
     Coalesce_Heuristic do_coalesce;
 };
 

--- a/src/umpire/strategy/FixedPool.hpp
+++ b/src/umpire/strategy/FixedPool.hpp
@@ -83,7 +83,7 @@ class FixedPool
     long m_highwatermark;
     long m_current_size;
 
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 };
 
 } // end of namespace strategy

--- a/src/umpire/strategy/MonotonicAllocationStrategy.hpp
+++ b/src/umpire/strategy/MonotonicAllocationStrategy.hpp
@@ -49,7 +49,7 @@ class MonotonicAllocationStrategy :
     size_t m_size;
     size_t m_capacity;
 
-    std::shared_ptr<AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 };
 
 } // end of namespace strategy

--- a/src/umpire/strategy/NumaPolicy.hpp
+++ b/src/umpire/strategy/NumaPolicy.hpp
@@ -53,7 +53,7 @@ class NumaPolicy :
     int getNode() const noexcept;
 
   private:
-    std::shared_ptr<AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
     Platform m_platform;
     int m_node;
 };

--- a/src/umpire/strategy/SizeLimiter.hpp
+++ b/src/umpire/strategy/SizeLimiter.hpp
@@ -49,7 +49,7 @@ class SizeLimiter :
 
     Platform getPlatform() noexcept;
   private:
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 
     size_t m_size_limit;
     size_t m_total_size;

--- a/src/umpire/strategy/SlotPool.hpp
+++ b/src/umpire/strategy/SlotPool.hpp
@@ -52,7 +52,7 @@ class SlotPool :
 
     size_t m_slots;
 
-    std::shared_ptr<umpire::strategy::AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 };
 
 } // end of namespace strategy

--- a/src/umpire/strategy/ThreadSafeAllocator.hpp
+++ b/src/umpire/strategy/ThreadSafeAllocator.hpp
@@ -41,7 +41,7 @@ class ThreadSafeAllocator :
     Platform getPlatform() noexcept;
 
   protected:
-    std::shared_ptr<AllocationStrategy> m_allocator;
+    strategy::AllocationStrategy* m_allocator;
 
     std::mutex* m_mutex;
 };

--- a/src/umpire/strategy/mixins/Inspector.cpp
+++ b/src/umpire/strategy/mixins/Inspector.cpp
@@ -31,7 +31,7 @@ void
 Inspector::registerAllocation(
     void* ptr, 
     size_t size, 
-    std::shared_ptr<AllocationStrategy> strategy)
+    strategy::AllocationStrategy* strategy)
 {
   m_current_size += size;
 

--- a/src/umpire/strategy/mixins/Inspector.hpp
+++ b/src/umpire/strategy/mixins/Inspector.hpp
@@ -32,7 +32,7 @@ class Inspector
     void registerAllocation(
         void* ptr,
         size_t size,
-        std::shared_ptr<umpire::strategy::AllocationStrategy> strategy);
+        strategy::AllocationStrategy* strategy);
 
     void deregisterAllocation(void* ptr);
 

--- a/src/umpire/tpl/simpool/DynamicSizePool.hpp
+++ b/src/umpire/tpl/simpool/DynamicSizePool.hpp
@@ -52,7 +52,7 @@ protected:
   std::size_t highWatermark;
 
   // Pointer to our allocator's allocation strategy
-  std::shared_ptr<umpire::strategy::AllocationStrategy> allocator;
+  umpire::strategy::AllocationStrategy* allocator;
 
   // Search the list of free blocks and return a usable one if that exists, else NULL
   void findUsableBlock(struct Block *&best, struct Block *&prev, std::size_t size) {
@@ -262,7 +262,7 @@ protected:
 
 public:
   DynamicSizePool(
-      std::shared_ptr<umpire::strategy::AllocationStrategy> strat,
+      umpire::strategy::AllocationStrategy* strat,
       const std::size_t _minInitialBytes = (16 * 1024),
       const std::size_t _minBytes = 256
       )

--- a/src/umpire/util/AllocationRecord.hpp
+++ b/src/umpire/util/AllocationRecord.hpp
@@ -31,7 +31,7 @@ struct AllocationRecord
 {
   void* m_ptr;
   size_t m_size;
-  std::shared_ptr<strategy::AllocationStrategy> m_strategy;
+  strategy::AllocationStrategy* m_strategy;
 };
 
 } // end of namespace util

--- a/tests/integration/allocator_integration_tests.cpp
+++ b/tests/integration/allocator_integration_tests.cpp
@@ -173,6 +173,7 @@ TEST(Allocator, GetSetDefault)
 
   ASSERT_NO_THROW(
     auto alloc = rm.getDefaultAllocator();
+    UMPIRE_USE_VAR(alloc);
   );
 
   ASSERT_NO_THROW(

--- a/tests/integration/replay/replay_tests.cpp
+++ b/tests/integration/replay/replay_tests.cpp
@@ -88,13 +88,13 @@ public:
     auto& rm = umpire::ResourceManager::getInstance();
     auto pooled_allocator = rm.getAllocator("host_simpool_spec1");
     auto strategy = pooled_allocator.getAllocationStrategy();
-    auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+    auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
     if (tracker) {
       strategy = tracker->getAllocationStrategy();
     }
 
-    auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+    auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
     if (! dynamic_pool ) {
       std::cerr << "host_simpool_spec1 is not a dynamic pool!\n";

--- a/tests/integration/strategy_tests.cpp
+++ b/tests/integration/strategy_tests.cpp
@@ -377,13 +377,13 @@ TEST(HeuristicTest, EdgeCases_75)
       1024ul, 1024ul, h_fun);
 
   auto strategy = alloc.getAllocationStrategy();
-  auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+  auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
   if (tracker) {
     strategy = tracker->getAllocationStrategy();
   }
 
-  auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+  auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
   ASSERT_NE(dynamic_pool, nullptr);
 
@@ -421,13 +421,13 @@ TEST(HeuristicTest, EdgeCases_100)
       initial_min_size, subsequent_min_size, h_fun);
 
   auto strategy = alloc.getAllocationStrategy();
-  auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+  auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
   if (tracker) {
     strategy = tracker->getAllocationStrategy();
   }
 
-  auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+  auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
   ASSERT_NE(dynamic_pool, nullptr);
 
@@ -486,13 +486,13 @@ TEST(HeuristicTest, EdgeCases_0)
       initial_min_size, subsequent_min_size, h_fun);
 
   auto strategy = alloc.getAllocationStrategy();
-  auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+  auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
   if (tracker) {
     strategy = tracker->getAllocationStrategy();
   }
 
-  auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+  auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
   ASSERT_NE(dynamic_pool, nullptr);
 

--- a/tests/unit/allocator_tests.cpp
+++ b/tests/unit/allocator_tests.cpp
@@ -62,7 +62,7 @@ protected:
     free(data);
   }
 
-  std::shared_ptr<MockAllocationStrategy> m_strategy;
+  strategy::AllocationStrategy* m_strategy;
   umpire::Allocator m_allocator;
   void* data;
 };

--- a/tests/unit/op/cuda_mem_advise_op_tests.cpp
+++ b/tests/unit/op/cuda_mem_advise_op_tests.cpp
@@ -20,20 +20,6 @@
 #include "umpire/op/MemoryOperationRegistry.hpp"
 #include "umpire/util/AllocationRecord.hpp"
 
-class CudaAdviseOpTest : public ::testing::Test {
-  protected:
-    virtual void SetUp() {
-      auto& rm = umpire::ResourceManager::getInstance();
-      auto allocator = rm.getAllocator("UM");
-      auto strategy = allocator.getAllocationStrategy();
-    }
-
-    virtual void TearDown() {
-    }
-
-    umpire::util::AllocationRecord* record;
-};
-
 TEST(CudaAdviseAccessedBy, Find)
 {
   auto& rm = umpire::ResourceManager::getInstance();

--- a/tests/unit/resource_manager_tests.cpp
+++ b/tests/unit/resource_manager_tests.cpp
@@ -48,6 +48,7 @@ TEST(ResourceManager, getAllocatorByName)
 
   EXPECT_NO_THROW({
     auto alloc = rm.getAllocator("HOST");
+    UMPIRE_USE_VAR(alloc);
   });
 
   ASSERT_THROW(
@@ -62,6 +63,7 @@ TEST(ResourceManager, getAllocatorById)
 
   EXPECT_NO_THROW({
     auto alloc = rm.getAllocator(0);
+    UMPIRE_USE_VAR(alloc);
   });
 
   ASSERT_THROW(

--- a/tools/replay.cpp
+++ b/tools/replay.cpp
@@ -151,12 +151,12 @@ class Replay {
       try {
         auto alloc = m_rm.getAllocator(allocName);
         auto strategy = alloc.getAllocationStrategy();
-        auto tracker = std::dynamic_pointer_cast<umpire::strategy::AllocationTracker>(strategy);
+        auto tracker = dynamic_cast<umpire::strategy::AllocationTracker*>(strategy);
 
         if (tracker)
           strategy = tracker->getAllocationStrategy();
 
-        auto dynamic_pool = std::dynamic_pointer_cast<umpire::strategy::DynamicPool>(strategy);
+        auto dynamic_pool = dynamic_cast<umpire::strategy::DynamicPool*>(strategy);
 
         if (dynamic_pool) {
           dynamic_pool->coalesce();


### PR DESCRIPTION
Unnecessary because we don't have shared ownership of objects, and `shared_ptr` adds overhead.