### PR TITLE
Replay can output Allocator operations by name and sequence ID

### DIFF
--- a/tests/integration/replay/CMakeLists.txt
+++ b/tests/integration/replay/CMakeLists.txt
@@ -20,6 +20,13 @@ set (replay_integration_tests_depends
   umpire)
 
 if (BASH_PROGRAM)
+
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_output.good"
+    "${CMAKE_CURRENT_BINARY_DIR}/test_output.good"
+    COPYONLY
+  )
+
   blt_add_executable(
     NAME replay_tests
     SOURCES replay_tests.cpp

--- a/tests/integration/replay/CMakeLists.txt
+++ b/tests/integration/replay/CMakeLists.txt
@@ -23,7 +23,7 @@ if (BASH_PROGRAM)
 
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/test_output.good"
-    "${CMAKE_CURRENT_BINARY_DIR}/test_output.good"
+    "${replay_dir}/test_output.good"
     COPYONLY
   )
 

--- a/tests/integration/replay/replay_tests.bash
+++ b/tests/integration/replay/replay_tests.bash
@@ -24,16 +24,16 @@ replayprogram=$tools_dir/replay
 #
 UMPIRE_REPLAY="On" $testprogram >& replay_test1.csv
 if [ $? -ne 0 ]; then
-    echo FAIL
+    echo "Failed: Unable to run $testprogram"
     exit 1
 fi
 
 #
 # Now replay from the activity captured in the replay_test1.csv file
 #
-UMPIRE_REPLAY="On" $replayprogram replay_test1.csv >& replay_test2.csv
+$replayprogram replay_test1.csv replay.out
 if [ $? -ne 0 ]; then
-    echo FAIL
+    echo "Failed: Unable to run $replayprogram"
     exit 1
 fi
 
@@ -41,4 +41,9 @@ fi
 # Now, compare the results being careful to allow for different object
 # references (everything else should be the same).
 #
+diff replay.out $replay_tests_dir/test_output.good
+if [ $? -ne 0 ]; then
+    echo "Diff failed"
+    exit 1
+fi
 exit 0

--- a/tests/integration/replay/replay_tests.cpp
+++ b/tests/integration/replay/replay_tests.cpp
@@ -16,18 +16,16 @@
 #include <vector>
 #include <string>
 
-#include "umpire/config.hpp"
-#include "umpire/ResourceManager.hpp"
-
-#include "umpire/strategy/SlotPool.hpp"
-#include "umpire/strategy/MonotonicAllocationStrategy.hpp"
-#include "umpire/strategy/DynamicPool.hpp"
-#include "umpire/strategy/AllocationStrategy.hpp"
 #include "umpire/Allocator.hpp"
+#include "umpire/ResourceManager.hpp"
 #include "umpire/op/MemoryOperation.hpp"
+#include "umpire/strategy/AllocationStrategy.hpp"
 #include "umpire/strategy/AllocationAdvisor.hpp"
-#include "umpire/strategy/ThreadSafeAllocator.hpp"
+#include "umpire/strategy/DynamicPool.hpp"
 #include "umpire/strategy/FixedPool.hpp"
+#include "umpire/strategy/MonotonicAllocationStrategy.hpp"
+#include "umpire/strategy/SlotPool.hpp"
+#include "umpire/strategy/ThreadSafeAllocator.hpp"
 
 class replayTest {
 public:
@@ -46,19 +44,6 @@ public:
     rm.makeAllocator<umpire::strategy::DynamicPool, false>(
         "host_simpool_spec2", rm.getAllocator("HOST"), 9876, 1234);
     allocatorNames.push_back("host_simpool_spec2");
-
-#if defined(UMPIRE_ENABLE_DEVICE)
-    rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
-      "read_only_um", rm.getAllocator("UM"), "READ_MOSTLY");
-    allocatorNames.push_back("read_only_um");
-#endif
-
-#if defined(UMPIRE_ENABLE_UM)
-    rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
-      "preferred_location_host", rm.getAllocator("UM"),
-      "PREFERRED_LOCATION", rm.getAllocator("HOST"));
-    allocatorNames.push_back("preferred_location_host");
-#endif
 
     rm.makeAllocator<umpire::strategy::MonotonicAllocationStrategy>(
       "MONOTONIC 1024", 1024, rm.getAllocator("HOST"));

--- a/tests/integration/replay/replay_tests.cpp
+++ b/tests/integration/replay/replay_tests.cpp
@@ -58,6 +58,11 @@ public:
     allocatorNames.push_back("thread_safe_allocator");
 
 #if 0
+    //
+    // Replay currently cannot support replaying FixedPool allocations.
+    // This is because replay does its work at runtime and the FixedPool
+    // is a template where sizes are generated at compile time.
+    //
     struct data { char _[1024*1024]; };
 
     rm.makeAllocator<umpire::strategy::FixedPool<data>>(

--- a/tests/integration/replay/replay_tests.cpp
+++ b/tests/integration/replay/replay_tests.cpp
@@ -72,11 +72,13 @@ public:
       "thread_safe_allocator", rm.getAllocator("HOST"));
     allocatorNames.push_back("thread_safe_allocator");
 
+#if 0
     struct data { char _[1024*1024]; };
 
     rm.makeAllocator<umpire::strategy::FixedPool<data>>(
         "fixed_pool_allocator", rm.getAllocator("HOST"));
     allocatorNames.push_back("fixed_pool_allocator");
+#endif
   }
 
   ~replayTest( void )

--- a/tests/integration/replay/test_output.good
+++ b/tests/integration/replay/test_output.good
@@ -1,4 +1,3 @@
-makeMemoryResource HOST
 makeAllocator <umpire::strategy::DynamicPool>(host_simpool_defaults, getAllocator(HOST))
 makeAllocator <umpire::strategy::DynamicPool>(host_simpool_spec1, getAllocator(HOST), 9876, 1234)
 makeAllocator <umpire::strategy::DynamicPool>(host_simpool_spec2, getAllocator(HOST), 9876, 1234)

--- a/tests/integration/replay/test_output.good
+++ b/tests/integration/replay/test_output.good
@@ -1,64 +1,46 @@
 makeMemoryResource HOST
-makeMemoryResource DEVICE
-makeMemoryResource PINNED
-makeMemoryResource UM
-makeMemoryResource DEVICE_CONST
 makeAllocator <umpire::strategy::DynamicPool>(host_simpool_defaults, getAllocator(HOST))
 makeAllocator <umpire::strategy::DynamicPool>(host_simpool_spec1, getAllocator(HOST), 9876, 1234)
 makeAllocator <umpire::strategy::DynamicPool>(host_simpool_spec2, getAllocator(HOST), 9876, 1234)
-makeAllocator <umpire::strategy::AllocationAdvisor>(read_only_um, getAllocator(UM), READ_MOSTLY)
-makeAllocator <umpire::strategy::AllocationAdvisor>(preferred_location_host, getAllocator(UM), PREFERRED_LOCATION, getAllocator(HOST))
 makeAllocator <umpire::strategy::MonotonicAllocationStrategy>(MONOTONIC 1024, 1024, getAllocator(HOST))
 makeAllocator <umpire::strategy::SlotPool>(host_slot_pool, 64, getAllocator(HOST))
 makeAllocator <umpire::strategy::ThreadSafeAllocator>(thread_safe_allocator, getAllocator(HOST))
 allocate (17) host_simpool_defaults --> 1
 allocate (18) host_simpool_spec1 --> 2
 allocate (19) host_simpool_spec2 --> 3
-allocate (20) read_only_um --> 4
-allocate (21) preferred_location_host --> 5
-allocate (22) MONOTONIC 1024 --> 6
-allocate (23) host_slot_pool --> 7
-allocate (24) thread_safe_allocator --> 8
-allocate (25) host_simpool_defaults --> 9
-allocate (26) host_simpool_spec1 --> 10
-allocate (27) host_simpool_spec2 --> 11
-allocate (28) read_only_um --> 12
-allocate (29) preferred_location_host --> 13
-allocate (30) MONOTONIC 1024 --> 14
-allocate (31) host_slot_pool --> 15
-allocate (32) thread_safe_allocator --> 16
-allocate (33) host_simpool_defaults --> 17
-allocate (34) host_simpool_spec1 --> 18
-allocate (35) host_simpool_spec2 --> 19
-allocate (36) read_only_um --> 20
-allocate (37) preferred_location_host --> 21
-allocate (38) MONOTONIC 1024 --> 22
-allocate (39) host_slot_pool --> 23
-allocate (40) thread_safe_allocator --> 24
+allocate (20) MONOTONIC 1024 --> 4
+allocate (21) host_slot_pool --> 5
+allocate (22) thread_safe_allocator --> 6
+allocate (23) host_simpool_defaults --> 7
+allocate (24) host_simpool_spec1 --> 8
+allocate (25) host_simpool_spec2 --> 9
+allocate (26) MONOTONIC 1024 --> 10
+allocate (27) host_slot_pool --> 11
+allocate (28) thread_safe_allocator --> 12
+allocate (29) host_simpool_defaults --> 13
+allocate (30) host_simpool_spec1 --> 14
+allocate (31) host_simpool_spec2 --> 15
+allocate (32) MONOTONIC 1024 --> 16
+allocate (33) host_slot_pool --> 17
+allocate (34) thread_safe_allocator --> 18
 coalesce host_simpool_spec1
 deallocate host_simpool_defaults(1)
 deallocate host_simpool_spec1(2)
 deallocate host_simpool_spec2(3)
-deallocate read_only_um(4)
-deallocate preferred_location_host(5)
-deallocate MONOTONIC 1024(6)
-deallocate host_slot_pool(7)
-deallocate thread_safe_allocator(8)
-deallocate host_simpool_defaults(9)
-deallocate host_simpool_spec1(10)
-deallocate host_simpool_spec2(11)
-deallocate read_only_um(12)
-deallocate preferred_location_host(13)
-deallocate MONOTONIC 1024(14)
-deallocate host_slot_pool(15)
-deallocate thread_safe_allocator(16)
-deallocate host_simpool_defaults(17)
-deallocate host_simpool_spec1(18)
-deallocate host_simpool_spec2(19)
-deallocate read_only_um(20)
-deallocate preferred_location_host(21)
-deallocate MONOTONIC 1024(22)
-deallocate host_slot_pool(23)
-deallocate thread_safe_allocator(24)
+deallocate MONOTONIC 1024(4)
+deallocate host_slot_pool(5)
+deallocate thread_safe_allocator(6)
+deallocate host_simpool_defaults(7)
+deallocate host_simpool_spec1(8)
+deallocate host_simpool_spec2(9)
+deallocate MONOTONIC 1024(10)
+deallocate host_slot_pool(11)
+deallocate thread_safe_allocator(12)
+deallocate host_simpool_defaults(13)
+deallocate host_simpool_spec1(14)
+deallocate host_simpool_spec2(15)
+deallocate MONOTONIC 1024(16)
+deallocate host_slot_pool(17)
+deallocate thread_safe_allocator(18)
 coalesce host_simpool_spec1
 release host_simpool_spec1

--- a/tests/integration/replay/test_output.good
+++ b/tests/integration/replay/test_output.good
@@ -1,0 +1,64 @@
+makeMemoryResource HOST
+makeMemoryResource DEVICE
+makeMemoryResource PINNED
+makeMemoryResource UM
+makeMemoryResource DEVICE_CONST
+makeAllocator <umpire::strategy::DynamicPool>(host_simpool_defaults, getAllocator(HOST))
+makeAllocator <umpire::strategy::DynamicPool>(host_simpool_spec1, getAllocator(HOST), 9876, 1234)
+makeAllocator <umpire::strategy::DynamicPool>(host_simpool_spec2, getAllocator(HOST), 9876, 1234)
+makeAllocator <umpire::strategy::AllocationAdvisor>(read_only_um, getAllocator(UM), READ_MOSTLY)
+makeAllocator <umpire::strategy::AllocationAdvisor>(preferred_location_host, getAllocator(UM), PREFERRED_LOCATION, getAllocator(HOST))
+makeAllocator <umpire::strategy::MonotonicAllocationStrategy>(MONOTONIC 1024, 1024, getAllocator(HOST))
+makeAllocator <umpire::strategy::SlotPool>(host_slot_pool, 64, getAllocator(HOST))
+makeAllocator <umpire::strategy::ThreadSafeAllocator>(thread_safe_allocator, getAllocator(HOST))
+allocate (17) host_simpool_defaults --> 1
+allocate (18) host_simpool_spec1 --> 2
+allocate (19) host_simpool_spec2 --> 3
+allocate (20) read_only_um --> 4
+allocate (21) preferred_location_host --> 5
+allocate (22) MONOTONIC 1024 --> 6
+allocate (23) host_slot_pool --> 7
+allocate (24) thread_safe_allocator --> 8
+allocate (25) host_simpool_defaults --> 9
+allocate (26) host_simpool_spec1 --> 10
+allocate (27) host_simpool_spec2 --> 11
+allocate (28) read_only_um --> 12
+allocate (29) preferred_location_host --> 13
+allocate (30) MONOTONIC 1024 --> 14
+allocate (31) host_slot_pool --> 15
+allocate (32) thread_safe_allocator --> 16
+allocate (33) host_simpool_defaults --> 17
+allocate (34) host_simpool_spec1 --> 18
+allocate (35) host_simpool_spec2 --> 19
+allocate (36) read_only_um --> 20
+allocate (37) preferred_location_host --> 21
+allocate (38) MONOTONIC 1024 --> 22
+allocate (39) host_slot_pool --> 23
+allocate (40) thread_safe_allocator --> 24
+coalesce host_simpool_spec1
+deallocate host_simpool_defaults(1)
+deallocate host_simpool_spec1(2)
+deallocate host_simpool_spec2(3)
+deallocate read_only_um(4)
+deallocate preferred_location_host(5)
+deallocate MONOTONIC 1024(6)
+deallocate host_slot_pool(7)
+deallocate thread_safe_allocator(8)
+deallocate host_simpool_defaults(9)
+deallocate host_simpool_spec1(10)
+deallocate host_simpool_spec2(11)
+deallocate read_only_um(12)
+deallocate preferred_location_host(13)
+deallocate MONOTONIC 1024(14)
+deallocate host_slot_pool(15)
+deallocate thread_safe_allocator(16)
+deallocate host_simpool_defaults(17)
+deallocate host_simpool_spec1(18)
+deallocate host_simpool_spec2(19)
+deallocate read_only_um(20)
+deallocate preferred_location_host(21)
+deallocate MONOTONIC 1024(22)
+deallocate host_slot_pool(23)
+deallocate thread_safe_allocator(24)
+coalesce host_simpool_spec1
+release host_simpool_spec1

--- a/tests/integration/strategy_tests.cpp
+++ b/tests/integration/strategy_tests.cpp
@@ -230,13 +230,15 @@ TEST(AllocationAdvisor, Create)
 
   ASSERT_NO_THROW(
     auto read_only_alloc =
-    rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
-      "read_only_um", rm.getAllocator("UM"), "READ_MOSTLY"));
+      rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
+        "read_only_um", rm.getAllocator("UM"), "READ_MOSTLY");
+    UMPIRE_USE_VAR(read_only_alloc));
 
   ASSERT_ANY_THROW(
-      auto failed_alloc =
-    rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
-      "read_only_um_nonsense_operator", rm.getAllocator("UM"), "FOOBAR"));
+    auto failed_alloc =
+      rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
+          "read_only_um_nonsense_operator", rm.getAllocator("UM"), "FOOBAR");
+    UMPIRE_USE_VAR(failed_alloc));
 }
 
 TEST(AllocationAdvisor, CreateWithId)
@@ -248,13 +250,15 @@ TEST(AllocationAdvisor, CreateWithId)
   ASSERT_NO_THROW(
     auto read_only_alloc =
     rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
-      "read_only_um_device_id", rm.getAllocator("UM"), "READ_MOSTLY", device_id));
+      "read_only_um_device_id", rm.getAllocator("UM"), "READ_MOSTLY", device_id);
+    UMPIRE_USE_VAR(read_only_alloc));
 
   ASSERT_ANY_THROW(
-      auto failed_alloc =
-    rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
-      "read_only_um_nonsense_operator_device_id",
-      rm.getAllocator("UM"), "FOOBAR", device_id));
+    auto failed_alloc =
+      rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
+        "read_only_um_nonsense_operator_device_id",
+      rm.getAllocator("UM"), "FOOBAR", device_id);
+    UMPIRE_USE_VAR(failed_alloc));
 }
 
 TEST(AllocationAdvisor, Host)

--- a/tools/replay.cpp
+++ b/tools/replay.cpp
@@ -106,30 +106,40 @@ class Replay {
         if ( m_row[0] != "REPLAY" )
           continue;
 
-        replay_out() << m_row[1] << " ";
         if ( m_row[1] == "makeAllocator" ) {
+          replay_out() << m_row[1] << " ";
           replay_makeAllocator();
+          replay_out() << "\n";
         }
         else if ( m_row[1] == "makeMemoryResource" ) {
           replay_makeMemoryResource();
         }
         else if ( m_row[1] == "allocate" ) {
+          replay_out() << m_row[1] << " ";
           replay_allocate();
+          replay_out() << "\n";
         }
         else if ( m_row[1] == "deallocate" ) {
+          replay_out() << m_row[1] << " ";
           replay_deallocate();
+          replay_out() << "\n";
         }
         else if ( m_row[1] == "coalesce" ) {
+          replay_out() << m_row[1] << " ";
           replay_coalesce();
+          replay_out() << "\n";
         }
         else if ( m_row[1] == "release" ) {
+          replay_out() << m_row[1] << " ";
           replay_release();
+          replay_out() << "\n";
         }
         else {
+          replay_out() << m_row[1] << " ";
           std::cerr << "Unknown Replay (" << m_row[1] << ")\n";
+          replay_out() << "\n";
           exit (1);
         }
-        replay_out() << "\n";
       }
     }
 
@@ -294,7 +304,6 @@ class Replay {
       const std::string& name = m_row[2];
       get_from_string(m_row[3], alloc_obj_ref);
 
-      replay_out() << name;
       m_allocators[alloc_obj_ref] = name;
     }
 

--- a/tools/replay.cpp
+++ b/tools/replay.cpp
@@ -451,6 +451,11 @@ class Replay {
         replay_out() << " (ignored) ";
         return;
 #if 0
+        //
+        // Replay currently cannot support replaying FixedPool allocations.
+        // This is because replay does its work at runtime and the FixedPool
+        // is a template where sizes are generated at compile time.
+        //
         const std::string& allocName = m_row[5];
         std::size_t PoolSize = hmm...
 

--- a/tools/replay.cpp
+++ b/tools/replay.cpp
@@ -69,14 +69,17 @@ std::istream& operator>>(std::istream& str, CSVRow& data)
 
 class Replay {
   public:
-    // Replay( const std::string& filename ) :
-    Replay( const char* _fname ) :
-       m_filename(_fname)
-      , m_file(m_filename)
+    Replay( std::string in_file_name, std::string out_file_name ):
+        m_sequence_id(0)
+      , m_input_file(in_file_name)
+      , m_replayout(out_file_name)
       , m_rm(umpire::ResourceManager::getInstance())
     {
-      if ( ! m_file.is_open() )
-        usage_and_exit( "Unable to open file " + m_filename );
+      if ( ! m_input_file.is_open() )
+        usage_and_exit( "Unable to open input file " + in_file_name );
+
+      if ( ! m_replayout.is_open() )
+        usage_and_exit( "Unable to open output file " + out_file_name );
     }
 
     static void usage_and_exit( const std::string& errorMessage ) {
@@ -89,10 +92,11 @@ class Replay {
 
     void run(void)
     {
-      while ( m_file >> m_row ) {
+      while ( m_input_file >> m_row ) {
         if ( m_row[0] != "REPLAY" )
           continue;
 
+        m_replayout << m_row[1] << " ";
         if ( m_row[1] == "makeAllocator" ) {
           replay_makeAllocator();
         }
@@ -112,17 +116,21 @@ class Replay {
           replay_release();
         }
         else {
-          std::cout << m_row[1] << "\n";
+          std::cerr << "Unknown Replay (" << m_row[1] << ")\n";
+          exit (1);
         }
+        m_replayout << "\n";
       }
     }
 
   private:
-    std::string m_filename;
-    std::ifstream m_file;
+    uint64_t m_sequence_id;
+    std::ifstream m_input_file;
+    std::ofstream m_replayout;
     umpire::ResourceManager& m_rm;
     std::unordered_map<void*, std::string> m_allocators;  // key(alloc_obj), val(alloc name)
     std::unordered_map<void*, void*> m_allocated_ptrs;    // key(alloc_ptr), val(replay_alloc_ptr)
+    std::unordered_map<void*, uint64_t> m_allocation_seq;    // key(alloc_ptr), val(m_sequence_id)
     CSVRow m_row;
 
     template <typename T>
@@ -147,6 +155,8 @@ class Replay {
     {
       std::string allocName = m_row[m_row.size() - 1];
       strip_off_base(allocName);
+
+      m_replayout << allocName;
 
       try {
         auto alloc = m_rm.getAllocator(allocName);
@@ -189,6 +199,8 @@ class Replay {
 
       const std::string& allocName = n_iter->second;
 
+      m_replayout << allocName;
+
       auto alloc = m_rm.getAllocator(allocName);
       alloc.release();
     }
@@ -217,6 +229,10 @@ class Replay {
       replay_alloc_ptr = alloc.allocate(alloc_size);
 
       m_allocated_ptrs[alloc_ptr] = replay_alloc_ptr;
+      m_sequence_id++;
+      m_allocation_seq[alloc_ptr] = m_sequence_id;
+
+      m_replayout << "(" << alloc_size << ") " << allocName << " --> " << m_sequence_id;
     }
 
     void replay_deallocate( void )
@@ -234,16 +250,22 @@ class Replay {
         return;           // Just skip unknown allocators
       }
 
+      const std::string& allocName = n_iter->second;
+
+      m_replayout << allocName;
+
       auto p_iter = m_allocated_ptrs.find(alloc_ptr);
       if ( p_iter == m_allocated_ptrs.end() ) {
         std::cout << "Duplicate deallocate for:" << alloc_ptr << " ignored" <<  std::endl;
         return;           // Just skip unknown allocators
       }
 
+      auto s_iter = m_allocation_seq.find(alloc_ptr);
+      m_replayout << "(" << s_iter->second << ")";
+      m_allocation_seq.erase(s_iter);
+
       void* replay_alloc_ptr = p_iter->second;
       m_allocated_ptrs.erase(p_iter);
-
-      const std::string& allocName = n_iter->second;
 
       auto alloc = m_rm.getAllocator(allocName);
       alloc.deallocate(replay_alloc_ptr);
@@ -256,6 +278,7 @@ class Replay {
       const std::string& name = m_row[2];
       get_from_string(m_row[3], alloc_obj_ref);
 
+      m_replayout << name;
       m_allocators[alloc_obj_ref] = name;
     }
 
@@ -267,16 +290,33 @@ class Replay {
 
       get_from_string(m_row[m_row.size() - 1], alloc_obj_ref);
 
+      m_replayout << "<" << m_row[2] << ">" ;
+
       if ( m_row[2] == "umpire::strategy::AllocationAdvisor" ) {
         const std::string& allocName = m_row[5];
         const std::string& adviceOperation = m_row[6];
         // Now grab the optional fields
         if (m_row.size() > 8) {
           const std::string& accessingAllocatorName = m_row[7];
+
+          m_replayout 
+            << "(" << name
+            << ", getAllocator(" << allocName << ")"
+            << ", " << adviceOperation
+            << ", getAllocator(" << accessingAllocatorName << ")"
+            << ")";
+
           if ( introspection )  m_rm.makeAllocator<umpire::strategy::AllocationAdvisor, true>( name, m_rm.getAllocator(allocName), adviceOperation, m_rm.getAllocator(accessingAllocatorName));
           else                  m_rm.makeAllocator<umpire::strategy::AllocationAdvisor, false>(name, m_rm.getAllocator(allocName), adviceOperation, m_rm.getAllocator(accessingAllocatorName));
         }
         else {
+
+          m_replayout 
+            << "(" << name
+            << ", getAllocator(" << allocName << ")"
+            << ", " << adviceOperation
+            << ")";
+
           if ( introspection )  m_rm.makeAllocator<umpire::strategy::AllocationAdvisor, true>( name, m_rm.getAllocator(allocName), adviceOperation);
           else                  m_rm.makeAllocator<umpire::strategy::AllocationAdvisor, false>(name, m_rm.getAllocator(allocName), adviceOperation);
         }
@@ -290,15 +330,36 @@ class Replay {
         if (m_row.size() > 8) {
           get_from_string(m_row[6], min_initial_alloc_size);
           get_from_string(m_row[7], min_alloc_size);
+
+          m_replayout 
+            << "(" << name
+            << ", getAllocator(" << allocName << ")"
+            << ", " << min_initial_alloc_size
+            << ", " << min_alloc_size
+            << ")";
+
           if ( introspection )  m_rm.makeAllocator<umpire::strategy::DynamicPool, true>(name, m_rm.getAllocator(allocName), min_initial_alloc_size, min_alloc_size, umpire::strategy::heuristic_percent_releasable(0));
           else                  m_rm.makeAllocator<umpire::strategy::DynamicPool, false>(name, m_rm.getAllocator(allocName), min_initial_alloc_size, min_alloc_size, umpire::strategy::heuristic_percent_releasable(0));
         }
         else if ( m_row.size() > 7 ) {
           get_from_string(m_row[6], min_initial_alloc_size);
+
+          m_replayout 
+            << "(" << name
+            << ", getAllocator(" << allocName << ")"
+            << ", " << min_initial_alloc_size
+            << ")";
+
           if ( introspection )  m_rm.makeAllocator<umpire::strategy::DynamicPool, true>(name, m_rm.getAllocator(allocName), min_initial_alloc_size);
           else                  m_rm.makeAllocator<umpire::strategy::DynamicPool, false>(name, m_rm.getAllocator(allocName), min_initial_alloc_size);
         }
         else {
+
+          m_replayout 
+            << "(" << name
+            << ", getAllocator(" << allocName << ")"
+            << ")";
+
           if ( introspection )  m_rm.makeAllocator<umpire::strategy::DynamicPool, true>(name, m_rm.getAllocator(allocName));
           else                  m_rm.makeAllocator<umpire::strategy::DynamicPool, false>(name, m_rm.getAllocator(allocName));
         }
@@ -309,6 +370,12 @@ class Replay {
 
         const std::string& allocName = m_row[6];
 
+        m_replayout 
+          << "(" << name
+          << ", " << capacity
+            << ", getAllocator(" << allocName << ")"
+          << ")";
+
         if ( introspection )  m_rm.makeAllocator<umpire::strategy::MonotonicAllocationStrategy, true>(name, capacity, m_rm.getAllocator(allocName));
         else                  m_rm.makeAllocator<umpire::strategy::MonotonicAllocationStrategy, false>(name, capacity, m_rm.getAllocator(allocName));
       }
@@ -316,6 +383,12 @@ class Replay {
         const std::string& allocName = m_row[5];
         std::size_t size_limit;
         get_from_string(m_row[6], size_limit);
+
+        m_replayout 
+          << "(" << name
+          << ", getAllocator(" << allocName << ")"
+          << ", " << size_limit
+          << ")";
 
         if ( introspection )  m_rm.makeAllocator<umpire::strategy::SizeLimiter, true>(name, m_rm.getAllocator(allocName), size_limit);
         else                  m_rm.makeAllocator<umpire::strategy::SizeLimiter, false>(name, m_rm.getAllocator(allocName), size_limit);
@@ -325,11 +398,22 @@ class Replay {
         std::size_t slots;
         get_from_string(m_row[5], slots);
 
+        m_replayout 
+          << "(" << name
+          << ", " << slots
+          << ", getAllocator(" << allocName << ")"
+          << ")";
+
         if ( introspection )  m_rm.makeAllocator<umpire::strategy::SlotPool, true>(name, slots, m_rm.getAllocator(allocName));
         else                  m_rm.makeAllocator<umpire::strategy::SlotPool, false>(name, slots, m_rm.getAllocator(allocName));
       }
       else if ( m_row[2] == "umpire::strategy::ThreadSafeAllocator" ) {
         const std::string& allocName = m_row[5];
+
+        m_replayout 
+          << "(" << name
+          << ", getAllocator(" << allocName << ")"
+          << ")";
 
         if ( introspection )  m_rm.makeAllocator<umpire::strategy::ThreadSafeAllocator, true>(name, m_rm.getAllocator(allocName));
         else                  m_rm.makeAllocator<umpire::strategy::ThreadSafeAllocator, false>(name, m_rm.getAllocator(allocName));
@@ -339,6 +423,7 @@ class Replay {
         // Need to skip FixedPool for now since I haven't figured out how to
         // dynamically parse/creat the data type parameter
         //
+        m_replayout << " (ignored) ";
         return;
 #if 0
         const std::string& allocName = m_row[5];
@@ -359,10 +444,18 @@ class Replay {
 
 int main(int ac, char** av)
 {
-  if ( ac != 2 )
+  if ( ac < 2 || ac > 3 )
     Replay::usage_and_exit( "Incorrect number of program arguments" );
 
-  Replay replay(av[1]);
+  std::string infile(av[1]);
+  std::string outfile;
+  
+  if (ac == 3)
+    outfile = av[2];
+  else 
+    outfile = "/dev/null";
+
+  Replay replay(infile, outfile);
 
   replay.run();
 


### PR DESCRIPTION
Replay can produce an output file containing all of the allocation operations using the string name of the Allocator and a sequence ID of the allocation.