### PR TITLE
Add multistage Dockerfile for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+build*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,9 @@ replayed events are correct.
 `print_allocator_records()` to get all records from a specific
 allocator, and a cookbook recipe to do that.
 
+- Dockerfile for multi-stage builds. Supports building Umpire with GCC, Clang,
+and CUDA
+
 ### Changed
 
 - Umpire now builds as a single library, libumpire.a or libumpire.so, rather

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM axom/compilers:gcc-8 AS gcc
+COPY --chown=axom:axom . /home/axom/workspace
+WORKDIR /home/axom/workspace
+RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=OFF ..
+RUN cd build && make -j 3 
+RUN cd build && make test
+
+
+FROM axom/compilers:clang-6 AS clang
+COPY --chown=axom:axom . /home/axom/workspace
+WORKDIR /home/axom/workspace
+RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=OFF ..
+RUN cd build && make -j 3 
+RUN cd build && make test
+
+
+FROM axom/compilers:nvcc-9 AS nvcc
+COPY --chown=axom:axom . /home/axom/workspace
+WORKDIR /home/axom/workspace
+RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On ..
+RUN cd build && make -j 3 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM axom/compilers:gcc-8 AS gcc
 COPY --chown=axom:axom . /home/axom/workspace
 WORKDIR /home/axom/workspace
 RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=OFF ..
-RUN cd build && make -j 3 
+RUN cd build && make -j 16
 RUN cd build && make test
 
 
 FROM axom/compilers:clang-6 AS clang
 COPY --chown=axom:axom . /home/axom/workspace
 WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=OFF ..
-RUN cd build && make -j 3 
+RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=clang++ -DENABLE_CUDA=OFF ..
+RUN cd build && make -j 16
 RUN cd build && make test
 
 
@@ -18,4 +18,4 @@ FROM axom/compilers:nvcc-9 AS nvcc
 COPY --chown=axom:axom . /home/axom/workspace
 WORKDIR /home/axom/workspace
 RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On ..
-RUN cd build && make -j 3 
+RUN cd build && make -j 16

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+gcc:
+ifeq ($(DEBUG),1)
+	DOCKER_BUILDKIT=1 docker build --target gcc --no-cache --progress plain .
+else
+	DOCKER_BUILDKIT=1 docker build --target gcc --no-cache .
+endif
+
+clang:
+ifeq ($(DEBUG),1)
+	DOCKER_BUILDKIT=1 docker build --target clang --no-cache --progress plain .
+else
+	DOCKER_BUILDKIT=1 docker build --target clang --no-cache .
+endif
+
+nvcc:
+ifeq ($(DEBUG),1)
+	DOCKER_BUILDKIT=1 docker build --target nvcc --no-cache --progress plain .
+else
+	DOCKER_BUILDKIT=1 docker build --target nvcc --no-cache .
+endif

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,22 @@ ifeq ($(DEBUG),1)
 else
 	DOCKER_BUILDKIT=1 docker build --target nvcc --no-cache .
 endif
+
+help:
+	@echo 'usage: make [variable] [target]'
+	@echo ''
+	@echo 'Build Umpire using Docker!'
+	@echo ''
+	@echo 'target:'
+	@echo '    gcc                            build with GCC 8'
+	@echo '    clang                          build with Clang 6'
+	@echo '    nvcc                           build with CUDA 9'
+	@echo ''
+	@echo 'variable:'
+	@echo '    DEBUG                          display all output if set to 1'
+	@echo ''
+	@echo 'For example'
+	@echo ''
+	@echo '    make DEBUG=1 nvcc'
+	@echo ''
+	@echo 'builds with the nvcc Docker image and displays all output.'


### PR DESCRIPTION
This Dockerfile has 3 targets: gcc, clang, and nvcc; which compile Umpire using GCC 8, Clang 6, and CUDA 9.

You can do a `docker build .` to build everything, but if you want to only build a single target, use the following:

```
DOCKER_BUILDKIT=1 docker build --target clang .
```

You can replace `clang` with `gcc` or `nvcc` to build with those compilers. To get the terminal output from CMake & make, you need to add the argument `--progress plain` to the `docker build` command.

Example output:

```
$ DOCKER_BUILDKIT=1 docker build --target clang .
[+] Building 93.3s (11/11) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                      0.1s
 => => transferring context: 34B                                                                                                                                                                                                                                                                                                                                       0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                   0.1s
 => => transferring dockerfile: 762B                                                                                                                                                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/axom/compilers:clang-6                                                                                                                                                                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                      0.4s
 => => transferring context: 310.46kB                                                                                                                                                                                                                                                                                                                                  0.3s
 => CACHED [clang 1/5] FROM docker.io/axom/compilers:clang-6                                                                                                                                                                                                                                                                                                           0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => [clang 2/5] COPY --chown=axom:axom . /home/axom/workspace                                                                                                                                                                                                                                                                                                          0.8s
 => [clang 3/5] RUN mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=OFF ..                                                                                                                                                                                                                                                                     8.0s
 => [clang 4/5] RUN cd build && make -j 16                                                                                                                                                                                                                                                                                                                            77.0s
 => [clang 5/5] RUN cd build && make test                                                                                                                                                                                                                                                                                                                              2.1s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 4.9s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                4.9s
 => => writing image sha256:a7c62d30fb02ed90b33fb88a356b8ab3cba48ee0ce2e79ee914bb98c756460e4
```