### PR TITLE
Um 313 make replay output mpi aware

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,10 +37,10 @@ and CUDA
 
 - GitHub action to run Clang static analysis.
 
-- Replay now includes the process ID of the logging process to help
+- Replay now includes unique replay ID of the logging process to help
 distinguish processes in an multi-process run.
 
-- Umpire replay now takes a "-help" option and displays usage information.
+- Umpire replay now takes a "--help" option and displays usage information.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,8 @@ and CUDA
 
 - GitHub action to run Clang static analysis.
 
+- Replay now includes the process ID of the logging process to help
+distinguish processes in an multi-process run.
 ### Changed
 
 - Umpire now builds as a single library, libumpire.a or libumpire.so, rather

--- a/src/umpire/Replay.cpp
+++ b/src/umpire/Replay.cpp
@@ -16,6 +16,7 @@
 #include <iostream>   // for std::cout, std::cerr
 #include <stdlib.h>   // for getenv()
 #include <strings.h>  // for strcasecmp()
+#include <unistd.h>   // getpid()
 
 #include "umpire/Allocator.hpp"
 #include "umpire/strategy/AllocationStrategy.hpp"
@@ -29,7 +30,7 @@ namespace replay {
 static const char* env_name = "UMPIRE_REPLAY";
 Replay* Replay::s_Replay = nullptr;
 
-Replay::Replay(bool enable_replay) : replayEnabled(enable_replay)
+Replay::Replay(bool enable_replay) : replayEnabled(enable_replay), m_replayPid(getpid())
 {
 }
 

--- a/src/umpire/Replay.cpp
+++ b/src/umpire/Replay.cpp
@@ -30,7 +30,7 @@ namespace replay {
 static const char* env_name = "UMPIRE_REPLAY";
 Replay* Replay::s_Replay = nullptr;
 
-Replay::Replay(bool enable_replay) : replayEnabled(enable_replay), m_replayPid(getpid())
+Replay::Replay(bool enable_replay) : replayEnabled(enable_replay), m_replayUid(getpid())
 {
 }
 

--- a/src/umpire/Replay.hpp
+++ b/src/umpire/Replay.hpp
@@ -36,6 +36,7 @@ public:
   void logMessage( const std::string& message );
   static Replay* getReplayLogger();
   bool replayLoggingEnabled();
+  uint64_t replayPid() { return m_replayPid; }
 
   static std::string printReplayAllocator( void ) {
     return std::string("");
@@ -56,6 +57,7 @@ private:
   ~Replay();
 
   bool replayEnabled;
+  uint64_t m_replayPid;
   static Replay* s_Replay;
 };
 
@@ -66,7 +68,11 @@ private:
 {                                                                            \
   if (umpire::replay::Replay::getReplayLogger()->replayLoggingEnabled()) {   \
     std::ostringstream local_msg;                                            \
-    local_msg  << "REPLAY," << msg << std::endl;                             \
+    local_msg                                                                \
+      << "REPLAY,"                                                           \
+      << umpire::replay::Replay::getReplayLogger()->replayPid() << ","       \
+      << msg                                                                 \
+      << std::endl;                                                          \
     umpire::replay::Replay::getReplayLogger()->logMessage(local_msg.str());  \
   }                                                                          \
 }

--- a/src/umpire/Replay.hpp
+++ b/src/umpire/Replay.hpp
@@ -36,7 +36,7 @@ public:
   void logMessage( const std::string& message );
   static Replay* getReplayLogger();
   bool replayLoggingEnabled();
-  uint64_t replayPid() { return m_replayPid; }
+  uint64_t replayUid() { return m_replayUid; }
 
   static std::string printReplayAllocator( void ) {
     return std::string("");
@@ -57,7 +57,7 @@ private:
   ~Replay();
 
   bool replayEnabled;
-  uint64_t m_replayPid;
+  uint64_t m_replayUid;
   static Replay* s_Replay;
 };
 
@@ -70,7 +70,7 @@ private:
     std::ostringstream local_msg;                                            \
     local_msg                                                                \
       << "REPLAY,"                                                           \
-      << umpire::replay::Replay::getReplayLogger()->replayPid() << ","       \
+      << umpire::replay::Replay::getReplayLogger()->replayUid() << ","       \
       << msg                                                                 \
       << std::endl;                                                          \
     umpire::replay::Replay::getReplayLogger()->logMessage(local_msg.str());  \

--- a/tools/replay.cpp
+++ b/tools/replay.cpp
@@ -80,7 +80,7 @@ class Replay {
   public:
     Replay( std::string in_file_name, std::string out_file_name ):
         m_sequence_id(0)
-      , m_replay_pid(0)
+      , m_replay_uid(0)
       , m_input_file(in_file_name)
       , m_rm(umpire::ResourceManager::getInstance())
     {
@@ -111,22 +111,22 @@ class Replay {
         if ( m_row[0] != "REPLAY" )
           continue;
 
-        uint64_t pid;
+        uint64_t uid;
 
-        get_from_string(m_row[1], pid);
+        get_from_string(m_row[1], uid);
 
-        if ( ! m_replay_pid ) {
-          m_replay_pid = pid;
-          m_pids[pid] = true;
+        if ( ! m_replay_uid ) {
+          m_replay_uid = uid;
+          m_uids[uid] = true;
         }
 
-        if ( m_replay_pid != pid ) {
-          if ( m_pids.find(pid) == m_pids.end()) {
+        if ( m_replay_uid != uid ) {
+          if ( m_uids.find(uid) == m_uids.end()) {
             //
-            // Only note a message once per pid
+            // Only note a message once per uid
             //
-            std::cerr << "Skipping Replay for PID " << pid << std::endl;
-            m_pids[pid] = true;
+            std::cerr << "Skipping Replay for PID " << uid << std::endl;
+            m_uids[uid] = true;
           }
           continue;
         }
@@ -178,11 +178,11 @@ class Replay {
 
   private:
     uint64_t m_sequence_id;
-    uint64_t m_replay_pid;
+    uint64_t m_replay_uid;
     std::ifstream m_input_file;
     umpire::ResourceManager& m_rm;
     std::ofstream m_replayout;
-    std::unordered_map<uint64_t, bool> m_pids;  // key(pid), val(always true)
+    std::unordered_map<uint64_t, bool> m_uids;  // key(uid), val(always true)
     std::unordered_map<void*, std::string> m_allocators;  // key(alloc_obj), val(alloc name)
     std::unordered_map<void*, void*> m_allocated_ptrs;    // key(alloc_ptr), val(replay_alloc_ptr)
     std::unordered_map<void*, uint64_t> m_allocation_seq;    // key(alloc_ptr), val(m_sequence_id)


### PR DESCRIPTION
With this change, UMPIRE_REPLAY will now include the PID of the calling process.

The replay tool has also been updated to only replay one of the PIDs.  By default, replay will replay the all of the operations from the first PID it finds.  If it finds other PIDs in the file, it will send a single error message per PID to std::cerr saying that it is skipping replays for that particular PID.