### PR TITLE
Fix ENABLE_NUMA=On

### DIFF
--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -430,8 +430,8 @@ ResourceManager::reallocate(void* src_ptr, size_t size, Allocator allocator)
 }
 
 #if defined(UMPIRE_ENABLE_NUMA)
-static std::shared_ptr<strategy::NumaPolicy> cast_as_numa_policy(Allocator& allocator) {
-  std::shared_ptr<strategy::NumaPolicy> numa_alloc;
+static strategy::NumaPolicy* cast_as_numa_policy(Allocator& allocator) {
+  strategy::NumaPolicy* numa_alloc;
 
   numa_alloc = dynamic_cast<strategy::NumaPolicy*>(
     allocator.getAllocationStrategy());

--- a/src/umpire/op/NumaMoveOperation.cpp
+++ b/src/umpire/op/NumaMoveOperation.cpp
@@ -32,7 +32,7 @@ void NumaMoveOperation::transform(
     util::AllocationRecord* dst_allocation,
     size_t length)
 {
-  auto numa_allocator = std::static_pointer_cast<strategy::NumaPolicy>(dst_allocation->m_strategy);
+  auto numa_allocator = static_cast<strategy::NumaPolicy*>(dst_allocation->m_strategy);
 
   *dst_ptr = src_ptr;
   numa::move_to_node(*dst_ptr, length, numa_allocator->getNode());

--- a/tests/integration/strategy_tests.cpp
+++ b/tests/integration/strategy_tests.cpp
@@ -585,9 +585,9 @@ TEST(NumaPolicyTest, EdgeCases) {
                  "numa_alloc", -1, rm.getAllocator("HOST")),
                umpire::util::Exception);
 
+#if defined(UMPIRE_ENABLE_CUDA)
   const int numa_node = umpire::numa::preferred_node();
 
-#if defined(UMPIRE_ENABLE_CUDA)
   // Only works with HOST allocators
   EXPECT_THROW(rm.makeAllocator<umpire::strategy::NumaPolicy>(
                  "numa_alloc", numa_node, rm.getAllocator("DEVICE")),


### PR DESCRIPTION
Fixed mixing of raw pointer and `std::shared_ptr` by removing `std::shared_ptr`
Only call `umpire::numa::preferred_node` when CUDA is enabled, since `numa_node` is only used in a CUDA block