### PR TITLE
Um 345 re enable replay tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ and a dynamic pool for those that are larger.
 
 - Switched template parameters to runtime constructor arguments in `FixedPool`.
 
-- Replay CI tests temporarily disabled.  This line to be removed once we
-  enable the tests again after replay works with Azure pipelines and MixedPool
-
 - Updated README to better describe Umpire capability
 
 - Update BLT to fix CMake 3.13 warnings and MSVC compatibility

--- a/tests/integration/replay/replay_tests.bash
+++ b/tests/integration/replay/replay_tests.bash
@@ -19,14 +19,6 @@ testprogram=$replay_tests_dir/replay_tests
 replayprogram=$tools_dir/replay
 
 #
-# Temporarily disable replay tests until after flurry of new functionality
-# (MixedPool) and platform support (Azure) has been merged into branch.  Once
-# that is done, Marty will update replay and its tests to work with those new
-# items.
-echo "Replay tests have (temporarily) been disabled (UM-343)"
-exit 0
-
-#
 # The following program will generate a CSV file of Umpire activity that
 # may be replayed.
 #
@@ -55,5 +47,5 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-/bin/rm -f replay.out replay_test1.csv
+# /bin/rm -f replay.out replay_test1.csv
 exit 0

--- a/tests/integration/replay/replay_tests.bash
+++ b/tests/integration/replay/replay_tests.bash
@@ -47,5 +47,5 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# /bin/rm -f replay.out replay_test1.csv
+/bin/rm -f replay.out replay_test1.csv
 exit 0


### PR DESCRIPTION
These tests were temporarily disabled while we awaited the JSON formatted piece to be complete.  It's complete now and the tests have been updated.