### PR TITLE
Build System Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Both user and code documentation is available [here](http://umpire.readthedocs.i
 
 The Umpire [tutorial](https://umpire.readthedocs.io/en/develop/tutorial.html) provides a step by step introduction to Umpire features.
 
-If you have build problems, we have comprehensive [build sytem documentation](https://umpire.readthedocs.io/en/develop/advanced_configuration.html) too!
+If you have build problems, we have comprehensive [build system documentation](https://umpire.readthedocs.io/en/develop/advanced_configuration.html) too!
 
 # Getting Involved
 

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -27,8 +27,8 @@ Here is a summary of the configuration options, their default value, and meaning
       ``ENABLE_SLIC``              Off      Enable SLIC logging
       ``ENABLE_TOOLS``             On       Enable tools like replay
       ``ENABLE_DOCS``              Off      Build documentation (requires Sphinx and/or Doxygen)
-      ``ENABLE_C``             Off      Build the C API
-      ``ENABLE_FORTRAN``       Off      Build the Fortran API
+      ``ENABLE_C``                 Off      Build the C API
+      ``ENABLE_FORTRAN``           Off      Build the Fortran API
       ===========================  ======== ===============================================================================
 
 These arguments are explained in more detail below:


### PR DESCRIPTION
Middle column of the cmake options table was not aligned, causing the table to not show up in the documentation
README fix