### PR TITLE
Fix CHANGELOG organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,7 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.4] - 2019-06-06
-
-### Fixed
-
-- Bug AllocationRecord::AllocationMap::findRecord causing it to miss finding
-allocations that were zero bytes in length.
+## Unreleased
 
 ### Added
 
@@ -84,6 +79,13 @@ and a dynamic pool for those that are larger.
 
 - Fix CodeCov reporting by explicitly downloading older version of upload
   script.
+
+## [0.3.4] - 2019-06-06
+
+### Fixed
+
+- Bug AllocationRecord::AllocationMap::findRecord causing it to miss finding
+allocations that were zero bytes in length.
 
 ## [0.3.3] - 2019-04-11
 


### PR DESCRIPTION
"Unreleased" header disappeared when merging 0.3.4 to develop.