### PR TITLE
ResourceManager Instance Changed to Automatic Variable

### DIFF
--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -51,17 +51,13 @@
 
 namespace umpire {
 
-ResourceManager* ResourceManager::s_resource_manager_instance = nullptr;
-
 ResourceManager&
 ResourceManager::getInstance()
 {
-  if (!s_resource_manager_instance) {
-    s_resource_manager_instance = new ResourceManager();
-  }
+  static ResourceManager s_resource_manager_instance;
 
-  UMPIRE_LOG(Debug, "() returning " << s_resource_manager_instance);
-  return *s_resource_manager_instance;
+  UMPIRE_LOG(Debug, "() returning " << &s_resource_manager_instance);
+  return s_resource_manager_instance;
 }
 
 ResourceManager::ResourceManager() :

--- a/src/umpire/ResourceManager.hpp
+++ b/src/umpire/ResourceManager.hpp
@@ -250,8 +250,6 @@ class ResourceManager {
 
     std::string getAllocatorInformation() const noexcept;
 
-    static ResourceManager* s_resource_manager_instance;
-
     std::unordered_map<std::string, strategy::AllocationStrategy* > m_allocators_by_name;
     std::unordered_map<int, strategy::AllocationStrategy* > m_allocators_by_id;
 


### PR DESCRIPTION
Changed ResourceManager::getInstance to return reference to static variable instead of pointer to remove memory leak