### PR TITLE
only initialize rank and world size if MPI has been inited.

### DIFF
--- a/src/umpire/util/MPI.cpp
+++ b/src/umpire/util/MPI.cpp
@@ -19,24 +19,22 @@ namespace util {
 
 int MPI::s_rank = -1;
 int MPI::s_world_size = -1;
-bool MPI::s_initialized = false;
+int MPI::s_initialized = 0;
 
 void 
 MPI::initialize()
 {
-  if (!s_initialized) {
 #if !defined(UMPIRE_ENABLE_MPI)
     s_rank = 0;
     s_world_size = 1;
+    s_initialized = 1;
 #else
-    MPI_Comm_rank(MPI_COMM_WORLD, &s_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &s_world_size);
-#endif
-
-    s_initialized = true;
-  } else {
-    UMPIRE_ERROR("umpire::MPI already initialized, cannot call initialize() again!");
+  MPI_Initialized(&s_initialized);
+  if (s_initialized) {
+     MPI_Comm_rank(MPI_COMM_WORLD, &s_rank);
+     MPI_Comm_size(MPI_COMM_WORLD, &s_world_size);
   }
+#endif
 }
 
 void

--- a/src/umpire/util/MPI.hpp
+++ b/src/umpire/util/MPI.hpp
@@ -25,7 +25,7 @@ private:
   static int s_rank;
   static int s_world_size;
 
-  static bool s_initialized;
+  static int s_initialized;
 };
 
 } // end of namespace util


### PR DESCRIPTION
Generating PR on @robinson96's behalf.  @davidbeckingsale, this is related to Jira ticket: [UM-399](https://rzlc.llnl.gov/jira/browse/UM-399) and is for reference for you when investigating the bug and determining the fix.