### PR TITLE
Remove MPI requirement from logging/replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and a dynamic pool for those that are larger.
 
 - Added a new IOManager that stores logging and replay output to files.
 
+- Added MPI-awareness to output for both logging and replay.
+
 - `DynamicPool` constructor has a new alignment argument.
 
 - Added HIP build to Travis CI.

--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -91,7 +91,6 @@ ResourceManager::ResourceManager() :
   const char* env_enable_log{getenv("UMPIRE_LOG_LEVEL")};
   bool enable_log{(env_enable_log != nullptr)};
 
-  util::MPI::initialize();
   util::IOManager::initialize(enable_log, enable_replay);
 
   resource::MemoryResourceRegistry& registry =

--- a/src/umpire/Umpire.hpp
+++ b/src/umpire/Umpire.hpp
@@ -22,6 +22,27 @@
 
 namespace umpire {
 
+inline void initialize(
+#if defined(UMPIRE_ENABLE_MPI)
+    MPI_Comm umpire_communicator
+#endif
+)
+{
+  static bool initialized = false;
+
+  if (!initialized) {
+#if defined(UMPIRE_ENABLE_MPI)
+    util::MPI::initialize(umpire_communicator);
+#else
+    util::MPI::initialize();
+#endif
+
+    initialized = true;
+  }
+}
+
+void finalize();
+
 /*!
  * \brief Allocate memory in the default space, with the default allocator.
  *

--- a/src/umpire/util/IOManager.cpp
+++ b/src/umpire/util/IOManager.cpp
@@ -164,6 +164,8 @@ IOManager::initialize(
     }
 
     s_initialized = true;
+
+    MPI::logMpiInfo();
   }
 }
 

--- a/src/umpire/util/MPI.cpp
+++ b/src/umpire/util/MPI.cpp
@@ -9,6 +9,7 @@
 #include "umpire/util/MPI.hpp" 
 
 #include "umpire/util/Macros.hpp"
+#include "umpire/Replay.hpp"
 
 #if defined(UMPIRE_ENABLE_MPI)
 #include "mpi.h"

--- a/src/umpire/util/MPI.cpp
+++ b/src/umpire/util/MPI.cpp
@@ -48,12 +48,6 @@ MPI::initialize(
       MPI_Comm_rank(s_communicator, &s_rank);
       MPI_Comm_size(s_communicator, &s_world_size);
       s_initialized = true;
-
-      UMPIRE_LOG(Info, "MPI rank: " << s_rank);
-      UMPIRE_LOG(Info, "MPI comm size: " << s_world_size);
-
-      UMPIRE_REPLAY("\"event\": \"mpi\", \"payload\": { \"rank\":" << s_rank
-          << ", \"size\":" << s_world_size << "}");
     }
 
 #endif
@@ -104,6 +98,20 @@ MPI::sync()
 #endif
   } else {
     UMPIRE_ERROR("Cannot call MPI::sync() before umpire::MPI is initialized");
+  }
+}
+
+void
+MPI::logMpiInfo()
+{
+  if (s_initialized) {
+#if defined(UMPIRE_ENABLE_MPI)
+    UMPIRE_LOG(Info, "MPI rank: " << s_rank);
+    UMPIRE_LOG(Info, "MPI comm size: " << s_world_size);
+
+    UMPIRE_REPLAY("\"event\": \"mpi\", \"payload\": { \"rank\":" << s_rank
+        << ", \"size\":" << s_world_size << "}");
+#endif
   }
 }
 

--- a/src/umpire/util/MPI.cpp
+++ b/src/umpire/util/MPI.cpp
@@ -6,10 +6,11 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "umpire/config.hpp"
 
-#include "umpire/util/MPI.hpp" 
-
 #include "umpire/util/Macros.hpp"
 #include "umpire/Replay.hpp"
+
+
+#include "umpire/util/MPI.hpp" 
 
 #if defined(UMPIRE_ENABLE_MPI)
 #include "mpi.h"
@@ -22,6 +23,9 @@ int MPI::s_rank = -1;
 int MPI::s_world_size = -1;
 bool MPI::s_initialized = false;
 int MPI::s_mpi_init_called = 0;
+#if defined(UMPIRE_ENABLE_MPI)
+MPI_Comm MPI::s_communicator = MPI_COMM_NULL;
+#endif
 
 void 
 MPI::initialize(

--- a/src/umpire/util/MPI.cpp
+++ b/src/umpire/util/MPI.cpp
@@ -20,20 +20,38 @@ namespace util {
 int MPI::s_rank = -1;
 int MPI::s_world_size = -1;
 bool MPI::s_initialized = false;
+int MPI::s_mpi_init_called = 0;
 
 void 
-MPI::initialize()
+MPI::initialize(
+#if defined(UMPIRE_ENABLE_MPI)
+    MPI_Comm comm
+#endif
+    )
 {
   if (!s_initialized) {
 #if !defined(UMPIRE_ENABLE_MPI)
     s_rank = 0;
     s_world_size = 1;
-#else
-    MPI_Comm_rank(MPI_COMM_WORLD, &s_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &s_world_size);
-#endif
-
+    s_mpi_init_called = 1;
     s_initialized = true;
+#else
+    MPI_Initialized(&s_mpi_init_called);
+
+    if (s_mpi_init_called) {
+      s_communicator = comm;
+      MPI_Comm_rank(s_communicator, &s_rank);
+      MPI_Comm_size(s_communicator, &s_world_size);
+      s_initialized = true;
+
+      UMPIRE_LOG(Info, "MPI rank: " << s_rank);
+      UMPIRE_LOG(Info, "MPI comm size: " << s_world_size);
+
+      UMPIRE_REPLAY("\"event\": \"mpi\", \"payload\": { \"rank\":" << s_rank
+          << ", \"size\":" << s_world_size << "}");
+    }
+
+#endif
   } else {
     UMPIRE_ERROR("umpire::MPI already initialized, cannot call initialize() again!");
   }
@@ -55,13 +73,39 @@ MPI::finalize()
 int
 MPI::getRank()
 {
+  if (!s_initialized) {
+    UMPIRE_LOG(Warning, "umpire::MPI not initialized, returning rank=" << s_rank);
+  }
+
   return s_rank;
 }
 
 int
 MPI::getSize()
 {
+  if (!s_initialized) {
+    UMPIRE_LOG(Warning, "umpire::MPI not initialized, returning size=" << s_world_size);
+  }
+
   return s_world_size;
+}
+
+void
+MPI::sync()
+{
+  if (s_initialized) {
+#if defined(UMPIRE_ENABLE_MPI)
+    MPI_Barrier(s_communicator);
+#endif
+  } else {
+    UMPIRE_ERROR("Cannot call MPI::sync() before umpire::MPI is initialized");
+  }
+}
+
+bool 
+MPI::isInitialized()
+{
+  return s_initialized;
 }
 
 } // end of namespace util

--- a/src/umpire/util/MPI.hpp
+++ b/src/umpire/util/MPI.hpp
@@ -29,6 +29,8 @@ public:
 
   static void sync();
 
+  static void logMpiInfo();
+
   static bool isInitialized();
 private:
   static int s_rank;

--- a/src/umpire/util/MPI.hpp
+++ b/src/umpire/util/MPI.hpp
@@ -16,16 +16,31 @@ namespace util {
 
 class MPI {
 public:
-  static void initialize();
+  static void initialize(
+#if defined(UMPIRE_ENABLE_MPI)
+      MPI_Comm umpire_communicator
+#endif
+  );
+
   static void finalize();
 
   static int getRank();
   static int getSize();
+
+  static void sync();
+
+  static bool isInitialized();
 private:
   static int s_rank;
   static int s_world_size;
 
   static bool s_initialized;
+
+  static int s_mpi_init_called;
+
+#if defined(UMPIRE_ENABLE_MPI)
+  static MPI_Comm s_communicator;
+#endif
 };
 
 } // end of namespace util

--- a/tests/integration/io/iomanager_tests.cpp
+++ b/tests/integration/io/iomanager_tests.cpp
@@ -6,6 +6,8 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "umpire/config.hpp"
 
+#include "umpire/Umpire.hpp"
+
 #include "umpire/util/MPI.hpp"
 #include "umpire/util/IOManager.hpp"
 
@@ -18,12 +20,14 @@
 int main(int argc, char** argv) {
 #if defined(UMPIRE_ENABLE_MPI)
   MPI_Init(&argc, &argv);
+  umpire::initialize(MPI_COMM_WORLD);
 #else
   (void) argc;
   (void) argv;
+  umpire::initialize();
 #endif
 
-  cxxopts::Options options(argv[0], "Replay an umpire session from a file");
+  cxxopts::Options options(argv[0], "IO tests");
 
   options
     .add_options()
@@ -47,7 +51,6 @@ int main(int argc, char** argv) {
     enable_replay = true;
   }
 
-  umpire::util::MPI::initialize();
   umpire::util::IOManager::initialize(enable_logging, enable_replay);
 
   umpire::log << "testing log stream" << std::endl;

--- a/tests/integration/io/iomanager_tests_runner.py
+++ b/tests/integration/io/iomanager_tests_runner.py
@@ -19,8 +19,14 @@ def check_output(name, file_object, expected):
 
     print("{BLUE}[RUN     ]{END} Checking for \"{expected}\" in {name}".format(name=name, expected=expected, **formatters))
 
-    contents = file_object.readline().rstrip()
-    if (contents != expected):
+
+    found = False
+
+    for line in file_object:
+        if (expected in line.rstrip()):
+            found = True
+
+    if (not found):
         print("{RED}[   ERROR]{END} Got {contents}".format(contents=contents, expected=expected, **formatters))
         errors = errors + 1
     else:

--- a/tests/integration/io/iomanager_tests_runner.py
+++ b/tests/integration/io/iomanager_tests_runner.py
@@ -80,12 +80,12 @@ def run_io_test(test_env, file_uid, expect_logging, expect_replay):
 
     check_output('stderr', error, 'testing error stream')
 
-    output_filename = 'umpire_io_tests.0.{pid}.{uid}.log'.format(uid=file_uid, pid=pid)
-    replay_filename = 'umpire_io_tests.0.{pid}.{uid}.replay'.format(uid=file_uid, pid=pid)
+    output_filename = 'umpire_io_tests.{pid}.{uid}.log'.format(uid=file_uid, pid=pid)
+    replay_filename = 'umpire_io_tests.{pid}.{uid}.replay'.format(uid=file_uid, pid=pid)
 
     if 'UMPIRE_OUTPUT_DIR' in test_env.keys():
-        output_filename = '{dir}/umpire_io_tests.0.{pid}.{uid}.log'.format(dir=test_env['UMPIRE_OUTPUT_DIR'], uid=file_uid, pid=pid)
-        replay_filename = '{dir}/umpire_io_tests.0.{pid}.{uid}.replay'.format(dir=test_env['UMPIRE_OUTPUT_DIR'], uid=file_uid, pid=pid)
+        output_filename = '{dir}/umpire_io_tests.{pid}.{uid}.log'.format(dir=test_env['UMPIRE_OUTPUT_DIR'], uid=file_uid, pid=pid)
+        replay_filename = '{dir}/umpire_io_tests.{pid}.{uid}.replay'.format(dir=test_env['UMPIRE_OUTPUT_DIR'], uid=file_uid, pid=pid)
 
     if expect_logging:
         check_file_exists(output_filename)

--- a/tests/integration/replay/replay_tests.bash
+++ b/tests/integration/replay/replay_tests.bash
@@ -23,7 +23,7 @@ fi
 #
 # Now replay from the activity captured in the replay_test1.csv file
 #
-$replayprogram -i umpire.0.*.0.replay -t replay.out
+$replayprogram -i umpire.*.0.replay -t replay.out
 if [ $? -ne 0 ]; then
     echo "Failed: Unable to run $replayprogram"
     exit 1

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -39,7 +39,7 @@ blt_add_test(
 blt_add_executable(
   NAME memory_map_tests
   SOURCES memory_map_tests.cpp
-  DEPENDS_ON umpire_util umpire_tpl_judy gtest
+  DEPENDS_ON umpire gtest
   OUTPUT_DIR ${util_dir})
 
 blt_add_test(


### PR DESCRIPTION
MPI is now initialized by the user calling `umpire::initialize(MPI_Comm comm)` - once it's initialized, MPI information is added to the logging and replay output.

MPI rank is no longer included in filenames.

MPI must be initialized _before_ using any other Umpire resources if using a custom directory for log/replay output.