### PR TITLE
Feature/umpire ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
+  BUILD_QUARTZ_ALLOC_NAME: "umpire_ci_build_on_quartz"
+
+before_script:
+  - date
+
+after_script:
+  - date
+
+# There are no tests for now
+stages:
+  - allocate_resources
+  - build
+  - test
+  - release_resources
+
+# This is not a job, but contains project specific build commands
+# If an allocation exist with the name defined in this pipeline, the job will use it
+.build_quartz_script:
+  script:
+    - export JOBID=$(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 10 -N 1 -n 1 -c 4 scripts/gitlab/build.sh
+
+# Butte uses a very different job allocation system, building on login nodes is recommended
+.build_butte_script:
+  script:
+    - lalloc 1 scripts/gitlab/build.sh
+
+
+# This is where jobs are included
+include:
+  - local: .gitlab/ci/build_quartz.yml
+  - local: .gitlab/ci/build_butte.yml
+
+

--- a/.gitlab/ci/build_butte.yml
+++ b/.gitlab/ci/build_butte.yml
@@ -1,0 +1,89 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+####
+# This is the share configuration of jobs for butte
+
+.build_butte:
+  variables:
+  tags:
+    - shell
+    - butte
+  stage: build
+  extends: .build_butte_script
+  except:
+    - /_bnone/
+  allow_failure: true
+
+####
+# Here are all butte build jobs
+
+build_butte_clang_3_9_1:
+  variables:
+    COMPILER: "clang_3_9_1"
+  extends: .build_butte
+
+build_butte_gcc_4_9_3:
+  variables:
+    COMPILER: "gcc_4_9_3"
+  extends: .build_butte
+
+build_butte_clang_4_0_0:
+  variables:
+    COMPILER: "clang_4_0_0"
+  extends: .build_butte
+
+build_butte_clang_coral_2017_06_29:
+  variables:
+    COMPILER: "clang_coral_2017_06_29"
+  extends: .build_butte
+
+build_butte_clang_coral_2017_08_31:
+  variables:
+    COMPILER: "clang_coral_2017_08_31"
+  extends: .build_butte
+
+build_butte_clang_coral_2017_09_06:
+  variables:
+    COMPILER: "clang_coral_2017_09_06"
+  extends: .build_butte
+
+build_butte_clang_coral_2017_09_18:
+  variables:
+    COMPILER: "clang_coral_2017_09_18"
+  extends: .build_butte
+
+build_butte_nvcc_gcc_4_9_3:
+  variables:
+    COMPILER: "nvcc_gcc_4_9_3"
+  extends: .build_butte
+
+build_butte_nvcc_clang_coral_2017_06_29:
+  variables:
+    COMPILER: "nvcc_clang_coral_2017_06_29"
+  extends: .build_butte
+
+build_butte_nvcc_clang_coral_2017_08_31:
+  variables:
+    COMPILER: "nvcc_clang_coral_2017_08_31"
+  extends: .build_butte
+
+build_butte_nvcc_clang_coral_2017_09_06:
+  variables:
+    COMPILER: "nvcc_clang_coral_2017_09_06"
+  extends: .build_butte
+
+build_butte_nvcc_clang_coral_2017_09_18:
+  variables:
+    COMPILER: "nvcc_clang_coral_2017_09_18"
+  extends: .build_butte
+
+build_butte_nvcc_xl-beta-2017.09.13:
+  variables:
+    COMPILER: "nvcc_xl-beta-2017.09.13"
+  extends: .build_butte
+

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -1,0 +1,109 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+####
+# This is the share configuration of jobs for quartz
+
+####
+# In pre-build phase, allocate a node for builds
+allocate_resources_build_quartz:
+  tags:
+    - shell
+    - quartz
+  stage: allocate_resources
+  script:
+    - salloc -N 1 -c 36 -p pdebug -t 10 --no-shell --job-name=${BUILD_QUARTZ_ALLOC_NAME}
+  except:
+    - /_qnone/
+
+####
+# In post-build phase, deallocate resources
+# Note : make sure this is run even on build phase failure
+release_resources_build_quartz:
+  tags:
+    - shell
+    - quartz
+  stage: release_resources
+  script:
+    - scancel $(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
+  when: always
+  except:
+    - /_qnone/
+
+####
+# Generic qwartz job, extending build script
+.build_quartz:
+  variables:
+  tags:
+    - shell
+    - quartz
+  stage: build
+  extends: .build_quartz_script
+  except:
+    - /_qnone/
+
+
+####
+# Here are all quartz build jobs
+
+build_quartz_clang_3_9_1:
+  variables:
+    COMPILER: "clang_3_9_1"
+  extends: .build_quartz
+
+build_quartz_gcc_4_9_3:
+  variables:
+    COMPILER: "gcc_4_9_3"
+  extends: .build_quartz
+
+build_quartz_clang_4_0_0:
+  variables:
+    COMPILER: "clang_4_0_0"
+  extends: .build_quartz
+
+build_quartz_cudatoolkit_9_1:
+  variables:
+    COMPILER: "cudatoolkit_9_1"
+  extends: .build_quartz
+
+build_quartz_gcc_6_1_0:
+  variables:
+    COMPILER: "gcc_6_1_0"
+  extends: .build_quartz
+
+build_quartz_gcc_7_1_0:
+  variables:
+    COMPILER: "gcc_7_1_0"
+  extends: .build_quartz
+
+build_quartz_icpc_16_0_4:
+  variables:
+    COMPILER: "icpc_16_0_4"
+  extends: .build_quartz
+  allow_failure: true
+
+build_quartz_icpc_17_0_2:
+  variables:
+    COMPILER: "icpc_17_0_2"
+  extends: .build_quartz
+
+build_quartz_icpc_18_0_0:
+  variables:
+    COMPILER: "icpc_18_0_0"
+  extends: .build_quartz
+
+build_quartz_pgi_17_10:
+  variables:
+    COMPILER: "pgi_17_10"
+  extends: .build_quartz
+  allow_failure: true
+
+build_quartz_pgi_18_5:
+  variables:
+    COMPILER: "pgi_18_5"
+  extends: .build_quartz
+  allow_failure: true

--- a/.gitlab/conf/host-configs/bgqos_0/clang_4_0_0.cmake
+++ b/.gitlab/conf/host-configs/bgqos_0/clang_4_0_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/apps/gnu/clang/r284961-stable/bin/bgclang++11" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/apps/gnu/clang/r284961-stable/bin/bgclang" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_3_9_1.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_3_9_1.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tcetmp/packages/clang/clang-3.9.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tcetmp/packages/clang/clang-3.9.1/bin/clang" CACHE PATH "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_4_0_0.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_4_0_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tcetmp/packages/clang/clang-4.0.0/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tcetmp/packages/clang/clang-4.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_06_29.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_06_29.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_08_31.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_08_31.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_06.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_06.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_18.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_18.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_4_9_3.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_4_9_3.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
+

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_06_29.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_06_29.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_08_31.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_08_31.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_06.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_06.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_18.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_18.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_xl-beta-2017.09.13.cmake
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_xl-beta-2017.09.13.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlC_r" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlc_r" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/.gitlab/conf/host-configs/blueos_3_ppc64le_ib_p9
+++ b/.gitlab/conf/host-configs/blueos_3_ppc64le_ib_p9
@@ -1,0 +1,1 @@
+blueos_3_ppc64le_ib

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_8_1.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_8_1.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.8.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.8.1/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_9_1.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_9_1.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.9.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.9.1/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_4_0_0.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_4_0_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-4.0.0/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-4.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/cudatoolkit_8_0.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/cudatoolkit_8_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+set (CUDA_TOOLKIT_ROOT_DIR "/opt/cudatoolkit-8.0" CACHE PATH "")
+set (CMAKE_CUDA_COMPILER "/opt/cudatoolkit-8.0/bin/nvcc" CACHE PATH "")

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/gcc_4_9_3.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/gcc_4_9_3.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/apps/gnu/4.9.3/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/apps/gnu/4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_16_0_258.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_16_0_258.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc-16.0.258" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/local/bin/icc-16.0.258" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/local/bin/ifort-16.0.258" CACHE PATH "")

--- a/.gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_17_0_174.cmake
+++ b/.gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_17_0_174.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc-17.0.174" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/local/bin/icc-17.0.174" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/local/bin/ifort-17.0.174" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/clang_3_9_1.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/clang_3_9_1.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-3.9.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-3.9.1/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/clang_4_0_0.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/clang_4_0_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-4.0.0/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-4.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/cudatoolkit_9_1.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/cudatoolkit_9_1.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+set (CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-9.1.85" CACHE PATH "")
+
+set (CMAKE_CUDA_COMPILER "/usr/tce/packages/cuda/cuda-9.1.85/bin/nvcc" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_4_9_3.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_4_9_3.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_6_1_0.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_6_1_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_7_1_0.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_7_1_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_16_0_4.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_16_0_4.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/icpc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/icc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/ifort" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_17_0_2.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_17_0_2.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/icpc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/icc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/ifort" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_18_0_0.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_18_0_0.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/icpc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/icc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/ifort" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_17_10.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_17_10.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_C_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgc++" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgfortran" CACHE PATH "")

--- a/.gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_18_5.cmake
+++ b/.gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_18_5.cmake
@@ -1,0 +1,9 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_C_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgc++" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgfortran" CACHE PATH "")

--- a/host-configs/bgqos_0/clang_4_0_0.cmake
+++ b/host-configs/bgqos_0/clang_4_0_0.cmake
@@ -4,9 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/apps/gnu/clang/r284961-stable/bin/bgclang++11" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/apps/gnu/clang/r284961-stable/bin/bgclang" CACHE PATH "")
-
 set(CMAKE_CXX_FLAGS "-stdlib=libc++" CACHE STRING "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")

--- a/host-configs/blueos_3_ppc64le_ib/clang_3_9_1.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/clang_3_9_1.cmake
@@ -4,9 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/packages/clang/clang-3.9.1/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/packages/clang/clang-3.9.1/bin/clang" CACHE PATH "")
-
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")
-
 set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-beta-2017.09.13/lib" CACHE STRING "")

--- a/host-configs/blueos_3_ppc64le_ib/clang_4_0_0.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/clang_4_0_0.cmake
@@ -4,7 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/packages/clang/clang-4.0.0/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/packages/clang/clang-4.0.0/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")
 set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-beta-2017.09.13/lib" CACHE STRING "")

--- a/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_06_29.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_06_29.cmake
@@ -4,7 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")
 set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-beta-2017.09.13/lib" CACHE STRING "")

--- a/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_08_31.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_08_31.cmake
@@ -4,7 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")
 set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-beta-2017.09.13/lib" CACHE STRING "")

--- a/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_06.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_06.cmake
@@ -4,7 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")
 set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-beta-2017.09.13/lib" CACHE STRING "")

--- a/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_18.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_18.cmake
@@ -4,7 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")
 set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-beta-2017.09.13/lib" CACHE STRING "")

--- a/host-configs/blueos_3_ppc64le_ib/gcc_4_9_3.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/gcc_4_9_3.cmake
@@ -4,7 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
 

--- a/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_06_29.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_06_29.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_08_31.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_08_31.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_06.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_06.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_18.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_18.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
@@ -4,7 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")

--- a/host-configs/blueos_3_ppc64le_ib/nvcc_xl-beta-2017.09.13.cmake
+++ b/host-configs/blueos_3_ppc64le_ib/nvcc_xl-beta-2017.09.13.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlC_r" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlc_r" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/host-configs/chaos_5_x86_64_ib/clang_3_8_1.cmake
+++ b/host-configs/chaos_5_x86_64_ib/clang_3_8_1.cmake
@@ -4,8 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.8.1/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.8.1/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_8_0.cmake)

--- a/host-configs/chaos_5_x86_64_ib/clang_3_9_1.cmake
+++ b/host-configs/chaos_5_x86_64_ib/clang_3_9_1.cmake
@@ -4,8 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.9.1/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.9.1/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_8_0.cmake)

--- a/host-configs/chaos_5_x86_64_ib/clang_4_0_0.cmake
+++ b/host-configs/chaos_5_x86_64_ib/clang_4_0_0.cmake
@@ -4,8 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-4.0.0/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-4.0.0/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_8_0.cmake)

--- a/host-configs/chaos_5_x86_64_ib/cudatoolkit_8_0.cmake
+++ b/host-configs/chaos_5_x86_64_ib/cudatoolkit_8_0.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-
-set (CUDA_TOOLKIT_ROOT_DIR "/opt/cudatoolkit-8.0" CACHE PATH "")
-set (CMAKE_CUDA_COMPILER "/opt/cudatoolkit-8.0/bin/nvcc" CACHE PATH "")

--- a/host-configs/chaos_5_x86_64_ib/gcc_4_9_3.cmake
+++ b/host-configs/chaos_5_x86_64_ib/gcc_4_9_3.cmake
@@ -4,8 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/apps/gnu/4.9.3/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/apps/gnu/4.9.3/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_8_0.cmake)

--- a/host-configs/chaos_5_x86_64_ib/icpc_16_0_258.cmake
+++ b/host-configs/chaos_5_x86_64_ib/icpc_16_0_258.cmake
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc-16.0.258" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/local/bin/icc-16.0.258" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/local/bin/ifort-16.0.258" CACHE PATH "")
-
 set(COMMON_FLAGS "-gnu-prefix=/usr/apps/gnu/4.9.3/bin/ -Wl,-rpath,/usr/apps/gnu/4.9.3/lib64 -std=c++17")
 set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_FLAGS} -O3 -march=native -ansi-alias" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${COMMON_FLAGS} -O3 -g -march=native -ansi-alias" CACHE STRING "")

--- a/host-configs/chaos_5_x86_64_ib/icpc_17_0_174.cmake
+++ b/host-configs/chaos_5_x86_64_ib/icpc_17_0_174.cmake
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc-17.0.174" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/local/bin/icc-17.0.174" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/local/bin/ifort-17.0.174" CACHE PATH "")
-
 set(COMMON_FLAGS "-gnu-prefix=/usr/apps/gnu/4.9.3/bin/ -Wl,-rpath,/usr/apps/gnu/4.9.3/lib64 -std=c++17")
 set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_FLAGS} -O3 -march=native -ansi-alias" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${COMMON_FLAGS} -O3 -g -march=native -ansi-alias" CACHE STRING "")

--- a/host-configs/toss_3_x86_64_ib/clang_3_9_1.cmake
+++ b/host-configs/toss_3_x86_64_ib/clang_3_9_1.cmake
@@ -5,8 +5,4 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-3.9.1/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-3.9.1/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_9_1.cmake)

--- a/host-configs/toss_3_x86_64_ib/clang_4_0_0.cmake
+++ b/host-configs/toss_3_x86_64_ib/clang_4_0_0.cmake
@@ -4,8 +4,5 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-4.0.0/bin/clang++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-4.0.0/bin/clang" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_9_1.cmake)

--- a/host-configs/toss_3_x86_64_ib/cudatoolkit_9_1.cmake
+++ b/host-configs/toss_3_x86_64_ib/cudatoolkit_9_1.cmake
@@ -5,6 +5,3 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-set (CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-9.1.85" CACHE PATH "")
-
-set (CMAKE_CUDA_COMPILER "/usr/tce/packages/cuda/cuda-9.1.85/bin/nvcc" CACHE PATH "")

--- a/host-configs/toss_3_x86_64_ib/gcc_4_9_3.cmake
+++ b/host-configs/toss_3_x86_64_ib/gcc_4_9_3.cmake
@@ -4,8 +4,5 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_9_1.cmake)

--- a/host-configs/toss_3_x86_64_ib/gcc_6_1_0.cmake
+++ b/host-configs/toss_3_x86_64_ib/gcc_6_1_0.cmake
@@ -4,8 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_9_1.cmake)

--- a/host-configs/toss_3_x86_64_ib/gcc_7_1_0.cmake
+++ b/host-configs/toss_3_x86_64_ib/gcc_7_1_0.cmake
@@ -4,8 +4,4 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran" CACHE PATH "")
-
 include(${CMAKE_CURRENT_LIST_DIR}/cudatoolkit_9_1.cmake)

--- a/host-configs/toss_3_x86_64_ib/icpc_16_0_4.cmake
+++ b/host-configs/toss_3_x86_64_ib/icpc_16_0_4.cmake
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/icpc" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/icc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/ifort" CACHE PATH "")
-
 set(COMMON_FLAGS "-gxx-name=/usr/tce/packages/gcc/gcc-4.9.3/bin/g++ -std=c++17")
 set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_FLAGS} -O3 -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${COMMON_FLAGS} -O3 -g -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch" CACHE STRING "")

--- a/host-configs/toss_3_x86_64_ib/icpc_17_0_2.cmake
+++ b/host-configs/toss_3_x86_64_ib/icpc_17_0_2.cmake
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/icpc" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/icc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/ifort" CACHE PATH "")
-
 set(COMMON_FLAGS "-gxx-name=/usr/tce/packages/gcc/gcc-4.9.3/bin/g++ -std=c++17")
 set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_FLAGS} -O3 -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${COMMON_FLAGS} -O3 -g -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch" CACHE STRING "")

--- a/host-configs/toss_3_x86_64_ib/icpc_18_0_0.cmake
+++ b/host-configs/toss_3_x86_64_ib/icpc_18_0_0.cmake
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/icpc" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/icc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/ifort" CACHE PATH "")
-
 set(COMMON_FLAGS "-gxx-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++ -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_FLAGS} -O3 -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${COMMON_FLAGS} -O3 -g -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch" CACHE STRING "")

--- a/host-configs/toss_3_x86_64_ib/pgi_17_10.cmake
+++ b/host-configs/toss_3_x86_64_ib/pgi_17_10.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_C_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgcc" CACHE PATH "")
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgc++" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgfortran" CACHE PATH "")

--- a/host-configs/toss_3_x86_64_ib/pgi_18_5.cmake
+++ b/host-configs/toss_3_x86_64_ib/pgi_18_5.cmake
@@ -4,6 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_C_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgcc" CACHE PATH "")
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgc++" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgfortran" CACHE PATH "")

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -30,7 +30,10 @@ cd ${BUILD_DIR}
 
 echo "Configuring..."
 
-trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On -C ${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../"
+trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
+	  -C ${UMPIRE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -C ${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../"
 
 echo "Building..."
 trycmd "make VERBOSE=1 -j"

--- a/scripts/gitlab/build.sh
+++ b/scripts/gitlab/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+BUILD_DIRECTORY="build_${SYS_TYPE}_${COMPILER}"
+CCONF="host-configs/${SYS_TYPE}/${COMPILER}.cmake" 
+
+rm -rf ${BUILD_DIRECTORY} 2>/dev/null
+mkdir ${BUILD_DIRECTORY} && cd ${BUILD_DIRECTORY}
+
+cmake \
+  -C ../.gitlab/conf/${CCONF} \
+  -C ../${CCONF} \
+  ..
+cmake --build . -j 4
+make test


### PR DESCRIPTION
This feature aims at introducing a first GitLab CI pipeline designed for the LC GitLab instance.
The additional constraint was to design this pipeline so that we could share as much configuration as possible with other projects.

**First action**
The idea is to separate project specific and shareable configuration.

As for now, shareable information mainly consist in toolchain configuration, such as compiler paths, and is placed in the `.gitlab/conf` directory. More generally, the aim is to have .gitlab containing non-project specific gitlab configuration so that it can be easily moved elsewhere later on (submodule ?).

Project specific configuration, such as compiling flags and target release identification, remains at the same place.

Shareable and project configuration are linked by the directory layout which remains the same : system_type/toolchain

**Second action**
The `.gitlab-ci.yml` file is used by GitLab CI as the main configuration file. Using inclusion of files (`include:`) and job properties extensions (`extends:`) the pipeline configuration is split in several places in a modular manner.

`.gitlab-ci.yml` containins project specific configuration of the pipeline.

`scripts/gitlab` contains projects specific scripts for gitlab.

`.gitlab/ci` contains shareable configuration, such as configuration of jobs for different clusters.

In addition, an allocation mechanism is introduced so that on quartz only one resource allocation is required. Note that this allocation is currently using the pdebug queue.

**Discussion**
This is a first step toward a more complex CI process. 

Features included : 
- modular conception
- unique build script
- build and test on quartz and butte
- share a single resource allocation on quartz
- butte and/or quartz jobs can be deactivate using keywords in branch name (_qnone _bnone)

Feature not included : 
- split builds and tests (under development)
- leveling of test (extensive tests for release)
- optimizations using cache ?

**Known limits**
- Some builds or tests are ending in errors both for known or unknown issues. This jobs have been tagged as "allowed to fail" but should be fixed asap.
- We may want to limit the number of builds depending on the context. The Gitlab repo is currently configured mirror the main GitHub repo and trigger the CI for any change in the latter.
