### PR TITLE
Unique names for job allocations in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
-  BUILD_QUARTZ_ALLOC_NAME: "umpire_ci_build_on_quartz"
+  BUILD_QUARTZ_ALLOC_NAME: umpire_ci_$CI_COMMIT_SHORT_SHA
 
 before_script:
   - date
@@ -26,7 +26,9 @@ stages:
 # If an allocation exist with the name defined in this pipeline, the job will use it
 .build_quartz_script:
   script:
+    - echo ${BUILD_QUARTZ_ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
+    - echo ${JOBID}
     - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 10 -N 1 -n 1 -c 4 scripts/gitlab/build.sh
 
 # Butte uses a very different job allocation system, building on login nodes is recommended


### PR DESCRIPTION
Since I am naming allocations for jobs on quartz, it is necessary to use unique names so that GitLab can generate multiple pipelines at the same time.