### PR TITLE
Allow pipeline to succeed when relaunched

### DIFF
--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -29,7 +29,8 @@ release_resources_build_quartz:
     - quartz
   stage: release_resources
   script:
-    - scancel $(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
+    - export JOBID=$(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
+    - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
   when: always
   except:
     - /_qnone/


### PR DESCRIPTION
Bugfix allowing cool stuff : the pipeline on quartz is allocation agnostic, if the pipeline failed and we want to manually relaunch it, the allocation does not exist any more but it won’t prevent the pipeline from succeeding.