### PR TITLE
Fix bamboo rmdir failures

### DIFF
--- a/scripts/bamboo/build_and_benchmark.sh
+++ b/scripts/bamboo/build_and_benchmark.sh
@@ -10,8 +10,12 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 . ${SCRIPTPATH}/build_and_test.sh
 
+#
+# The remainder of this script assumes that build_and_test.sh places us in the
+# build directory (this assumption is not new, I am just documenting it now).
+#
 echo "Benchmarking..."
-COMMIT=`git rev-parse --short HEAD`
+COMMIT="$( cd "$(dirname "$0")" ; git rev-parse --short HEAD )"
 DATE=`date +%Y-%m-%d`
 BENCHMARK_OUTPUT_NAME="${COMMIT}_${COMPILER}_${SYS_TYPE}_${DATE}"
 

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -6,27 +6,28 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-COMPILER=${1:-gcc_4_9_3}
-BUILD_TYPE=${2:-Release}
-BUILD_DIR="build-${SYS_TYPE}"
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
-
 echo "Cleaning out previous build..."
+BUILD_DIR="build-${SYS_TYPE}"
 rm -rf ${BUILD_DIR} 2> /dev/null
 mkdir -p ${BUILD_DIR} 2> /dev/null
 cd ${BUILD_DIR}
 
+export UMPIRE_COMPILER=${1:-gcc_4_9_3}
+export UMPIRE_BUILD_TYPE=${2:-Release}
+export UMPIRE_SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
+
+UMPIRE_SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
 if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
-  echo "lalloc 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}"
-  lalloc 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}
+  echo "lalloc 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"
+  lalloc 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh
   if [ $? -ne 0 ]; then
     echo "Error: lalloc job failed"
     exit -1
   fi
 else
-  echo "srun -ppdebug -t 5 -N 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}"
-  srun -ppdebug -t 5 -N 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}
+  echo "srun -ppdebug -t 5 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"
+  srun -ppdebug -t 5 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh
   if [ $? -ne 0 ]; then
     echo "Error: srun job failed"
     exit -1

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -22,17 +22,10 @@ function runjob
   echo $1
   
   $1 << EOF
-    BUILD_DIR="build-${SYS_TYPE}"
-    SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
-
     echo "Cleaning out previous build..."
-
     rm -rf ${BUILD_DIR} 2> /dev/null
     mkdir -p ${BUILD_DIR} 2> /dev/null
     cd ${BUILD_DIR}
-
-    export COMPILER=${1:-gcc_4_9_3}
-    export BUILD_TYPE=${2:-Release}
 
     echo "Configuring..."
     trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
@@ -47,6 +40,11 @@ function runjob
     trycmd "ctest --output-on-failure -T Test"
 EOF
 }
+
+export COMPILER=${1:-gcc_4_9_3}
+export BUILD_TYPE=${2:-Release}
+BUILD_DIR="build-${SYS_TYPE}"
+SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
 
 if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
   runjob "lalloc 1 "

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -14,8 +14,12 @@ cd ${BUILD_DIR}
 
 export UMPIRE_COMPILER=${1:-gcc_4_9_3}
 export UMPIRE_BUILD_TYPE=${2:-Release}
+dirname $0
 UMPIRE_SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+echo "UMPIRE_SCRIPT_PATH = ${UMPIRE_SCRIPT_PATH}"
+dirname ${UMPIRE_SCRIPT_PATH}
 export UMPIRE_SOURCE_DIR="$( cd "$(dirname "${UMPIRE_SCRIPT_PATH}")" ; git rev-parse --show-toplevel )"
+echo "UMPIRE_SOURCE_DIR = ${UMPIRE_SOURCE_DIR}"
 
 if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
   echo "lalloc 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -6,62 +6,29 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-function runjob
-{
-  echo $1
-  
-  $1 << EOF
-    echo "Cleaning out previous build..."
-    rm -rf ${BUILD_DIR} 2> /dev/null
-    mkdir -p ${BUILD_DIR} 2> /dev/null
-    cd ${BUILD_DIR}
-
-    echo "Configuring..."
-
-    cmake -DENABLE_DEVELOPER_DEFAULTS=On \
-        -C ${SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-        -C ${SOURCE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ${SOURCE_DIR}
-
-    if [ $? -ne 0 ]; then
-      echo "Error"
-      exit -1
-    fi
-
-    echo "Building..."
-    make VERBOSE=1 -j
-
-    if [ $? -ne 0 ]; then
-      echo "Error"
-      exit -1
-    fi
-
-    echo "Testing..."
-    ctest --output-on-failure -T Test
-    if [ $? -ne 0 ]; then
-      echo "Error"
-      exit -1
-    fi
-EOF
-}
-
-export COMPILER=${1:-gcc_4_9_3}
-export BUILD_TYPE=${2:-Release}
+COMPILER=${1:-gcc_4_9_3}
+BUILD_TYPE=${2:-Release}
 BUILD_DIR="build-${SYS_TYPE}"
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
 
+echo "Cleaning out previous build..."
+rm -rf ${BUILD_DIR} 2> /dev/null
+mkdir -p ${BUILD_DIR} 2> /dev/null
+cd ${BUILD_DIR}
+
 if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
-  runjob "lalloc 1 "
+  echo "lalloc 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}"
+  lalloc 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}
   if [ $? -ne 0 ]; then
-    echo "Error"
+    echo "Error: lalloc job failed"
     exit -1
   fi
 else
-  runjob "srun -ppdebug -t 5 -N 1 "
+  echo "srun -ppdebug -t 5 -N 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}"
+  srun -ppdebug -t 5 -N 1 ${SCRIPTPATH}/run_build_and_test.sh ${BUILD_DIR} ${SOURCE_DIR} ${COMPILER} ${BUILD_TYPE}
   if [ $? -ne 0 ]; then
-    echo "Error"
+    echo "Error: srun job failed"
     exit -1
   fi
 fi
-
-sleep 60

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -14,9 +14,8 @@ cd ${BUILD_DIR}
 
 export UMPIRE_COMPILER=${1:-gcc_4_9_3}
 export UMPIRE_BUILD_TYPE=${2:-Release}
-export UMPIRE_SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
-
 UMPIRE_SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+export UMPIRE_SOURCE_DIR="$( cd "$(dirname "${UMPIRE_SCRIPT_PATH}")" ; git rev-parse --show-toplevel )"
 
 if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
   echo "lalloc 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -21,7 +21,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 export UMPIRE_DIR=$(git rev-parse --show-toplevel)
 export UMPIRE_DIR_BASE=$(basename $UMPIRE_DIR)
-export BUILD_DIR=../$UMPIRE_DIR_BASE.build-${SYS_TYPE}
+export BUILD_DIR=$UMPIRE_DIR_BASE.build-${SYS_TYPE}
 
 rm -rf ${BUILD_DIR} 2> /dev/null
 mkdir -p ${BUILD_DIR} 2> /dev/null
@@ -35,7 +35,7 @@ echo "Configuring..."
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
 	  -C ${UMPIRE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
 	  -C ${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../$UMPIRE_DIR_BASE"
+	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} src/$UMPIRE_DIR_BASE"
 
 echo "Building..."
 trycmd "make VERBOSE=1 -j"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -8,12 +8,8 @@
 
 export UMPIRE_COMPILER=${1:-gcc_4_9_3}
 export UMPIRE_BUILD_TYPE=${2:-Release}
-dirname $0
 UMPIRE_SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
-echo "UMPIRE_SCRIPT_PATH = ${UMPIRE_SCRIPT_PATH}"
-dirname ${UMPIRE_SCRIPT_PATH}
 export UMPIRE_SOURCE_DIR="$( cd "$(dirname "${UMPIRE_SCRIPT_PATH}")" ; git rev-parse --show-toplevel )"
-echo "UMPIRE_SOURCE_DIR = ${UMPIRE_SOURCE_DIR}"
 
 echo "Cleaning out previous build..."
 BUILD_DIR="build-${SYS_TYPE}"
@@ -29,8 +25,8 @@ if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
     exit -1
   fi
 else
-  echo "srun -ppdebug -t 5 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"
-  srun -ppdebug -t 5 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh
+  echo "srun -ppdebug -t 15 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"
+  srun -ppdebug -t 15 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh
   if [ $? -ne 0 ]; then
     echo "Error: srun job failed"
     exit -1

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -6,12 +6,6 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-echo "Cleaning out previous build..."
-BUILD_DIR="build-${SYS_TYPE}"
-rm -rf ${BUILD_DIR} 2> /dev/null
-mkdir -p ${BUILD_DIR} 2> /dev/null
-cd ${BUILD_DIR}
-
 export UMPIRE_COMPILER=${1:-gcc_4_9_3}
 export UMPIRE_BUILD_TYPE=${2:-Release}
 dirname $0
@@ -20,6 +14,12 @@ echo "UMPIRE_SCRIPT_PATH = ${UMPIRE_SCRIPT_PATH}"
 dirname ${UMPIRE_SCRIPT_PATH}
 export UMPIRE_SOURCE_DIR="$( cd "$(dirname "${UMPIRE_SCRIPT_PATH}")" ; git rev-parse --show-toplevel )"
 echo "UMPIRE_SOURCE_DIR = ${UMPIRE_SOURCE_DIR}"
+
+echo "Cleaning out previous build..."
+BUILD_DIR="build-${SYS_TYPE}"
+rm -rf ${BUILD_DIR} 2> /dev/null
+mkdir -p ${BUILD_DIR} 2> /dev/null
+cd ${BUILD_DIR}
 
 if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
   echo "lalloc 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -63,3 +63,5 @@ else
     exit -1
   fi
 fi
+
+sleep 60

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -17,7 +17,10 @@ function trycmd
   fi
 }
 
-export BUILD_DIR=build-${SYS_TYPE}
+BUILD_DIR="build-${SYS_TYPE}"
+SOURCE_DIR="$( cd "$(dirname "$0")" ; git rev-parse --show-toplevel )"
+
+echo "Cleaning out previous build..."
 
 rm -rf ${BUILD_DIR} 2> /dev/null
 mkdir -p ${BUILD_DIR} 2> /dev/null
@@ -29,8 +32,8 @@ export BUILD_TYPE=${2:-Release}
 echo "Configuring..."
 
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
-	  -C ../src/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -C ../src/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -C ${SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -C ${SOURCE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
 	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../src"
 
 echo "Building..."

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -25,8 +25,8 @@ if [[ $HOSTNAME == *manta* ]] || [[ $HOSTNAME == *ansel* ]]; then
     exit -1
   fi
 else
-  echo "srun -ppdebug -t 15 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"
-  srun -ppdebug -t 15 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh
+  echo "srun -ppdebug -t 60 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh"
+  srun -ppdebug -t 60 -N 1 ${UMPIRE_SCRIPT_PATH}/run_build_and_test.sh
   if [ $? -ne 0 ]; then
     echo "Error: srun job failed"
     exit -1

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -34,7 +34,7 @@ echo "Configuring..."
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
 	  -C ${SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
 	  -C ${SOURCE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../src"
+	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ${SOURCE_DIR}"
 
 echo "Building..."
 trycmd "make VERBOSE=1 -j"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -17,11 +17,10 @@ function trycmd
   fi
 }
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+SCRIPTPATH="$( cd src/"$(dirname "$0")" ; pwd -P )"
 
-export UMPIRE_DIR=$(git rev-parse --show-toplevel)
-export UMPIRE_DIR_BASE=$(basename $UMPIRE_DIR)
-export BUILD_DIR=$UMPIRE_DIR_BASE.build-${SYS_TYPE}
+export UMPIRE_DIR="src"
+export BUILD_DIR=build-${SYS_TYPE}
 
 rm -rf ${BUILD_DIR} 2> /dev/null
 mkdir -p ${BUILD_DIR} 2> /dev/null
@@ -33,9 +32,9 @@ export BUILD_TYPE=${2:-Release}
 echo "Configuring..."
 
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
-	  -C ${UMPIRE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -C ${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} src/$UMPIRE_DIR_BASE"
+	  -C ../${UMPIRE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -C ../${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../src"
 
 echo "Building..."
 trycmd "make VERBOSE=1 -j"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -20,12 +20,15 @@ function trycmd
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 export UMPIRE_DIR=$(git rev-parse --show-toplevel)
-export BUILD_DIR=build-${SYS_TYPE}
+export UMPIRE_DIR_BASE=$(basename $UMPIRE_DIR)
+export BUILD_DIR=../$UMPIRE_DIR_BASE.build-${SYS_TYPE}
 
 export COMPILER=${1:-gcc_4_9_3}
 export BUILD_TYPE=${2:-Release}
 
-mkdir ${BUILD_DIR} 2> /dev/null
+echo "rm -rf ${BUILD_DIR} 2> /dev/null"
+# rm -rf ${BUILD_DIR} 2> /dev/null
+mkdir -p ${BUILD_DIR} 2> /dev/null
 cd ${BUILD_DIR}
 
 echo "Configuring..."
@@ -33,7 +36,7 @@ echo "Configuring..."
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
 	  -C ${UMPIRE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
 	  -C ${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../"
+	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../$UMPIRE_DIR_BASE"
 
 echo "Building..."
 trycmd "make VERBOSE=1 -j"

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -23,13 +23,12 @@ export UMPIRE_DIR=$(git rev-parse --show-toplevel)
 export UMPIRE_DIR_BASE=$(basename $UMPIRE_DIR)
 export BUILD_DIR=../$UMPIRE_DIR_BASE.build-${SYS_TYPE}
 
-export COMPILER=${1:-gcc_4_9_3}
-export BUILD_TYPE=${2:-Release}
-
-echo "rm -rf ${BUILD_DIR} 2> /dev/null"
-# rm -rf ${BUILD_DIR} 2> /dev/null
+rm -rf ${BUILD_DIR} 2> /dev/null
 mkdir -p ${BUILD_DIR} 2> /dev/null
 cd ${BUILD_DIR}
+
+export COMPILER=${1:-gcc_4_9_3}
+export BUILD_TYPE=${2:-Release}
 
 echo "Configuring..."
 

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -17,9 +17,6 @@ function trycmd
   fi
 }
 
-SCRIPTPATH="$( cd src/"$(dirname "$0")" ; pwd -P )"
-
-export UMPIRE_DIR="src"
 export BUILD_DIR=build-${SYS_TYPE}
 
 rm -rf ${BUILD_DIR} 2> /dev/null
@@ -32,8 +29,8 @@ export BUILD_TYPE=${2:-Release}
 echo "Configuring..."
 
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
-	  -C ../${UMPIRE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-	  -C ../${UMPIRE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -C ../src/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+	  -C ../src/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
 	  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ../src"
 
 echo "Building..."

--- a/scripts/bamboo/run_build_and_test.sh
+++ b/scripts/bamboo/run_build_and_test.sh
@@ -17,16 +17,11 @@ function trycmd
   fi
 }
 
-BUILD_DIR=$1
-SOURCE_DIR=$2
-COMPILER=$3
-BUILD_TYPE=$4
-
 echo "Configuring..."
 trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
-    -C ${SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-    -C ${SOURCE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ${SOURCE_DIR}"
+    -C ${UMPIRE_SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${UMPIRE_COMPILER}.cmake \
+    -C ${UMPIRE_SOURCE_DIR}/host-configs/${SYS_TYPE}/${UMPIRE_COMPILER}.cmake \
+    -DCMAKE_BUILD_TYPE=${UMPIRE_BUILD_TYPE} ${BUILD_OPTIONS} ${UMPIRE_SOURCE_DIR}"
 
 echo "Building..."
 trycmd "make VERBOSE=1 -j"

--- a/scripts/bamboo/run_build_and_test.sh
+++ b/scripts/bamboo/run_build_and_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+
+function trycmd
+{
+  echo $1
+  $1
+
+  if [ $? -ne 0 ]; then
+    echo "Error: Command Failed"
+    exit -1
+  fi
+}
+
+BUILD_DIR=$1
+SOURCE_DIR=$2
+COMPILER=$3
+BUILD_TYPE=$4
+
+echo "Configuring..."
+trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
+    -C ${SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+    -C ${SOURCE_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${BUILD_OPTIONS} ${SOURCE_DIR}"
+
+echo "Building..."
+trycmd "make VERBOSE=1 -j"
+
+echo "Testing..."
+trycmd "ctest --output-on-failure -T Test"

--- a/tests/integration/replay/test_output.cuda.good
+++ b/tests/integration/replay/test_output.cuda.good
@@ -3,7 +3,6 @@
 { "kind":"replay", "uid":124865, "timestamp":1568313296697146405, "event": "makeMemoryResource", "payload": { "name": "DEVICE" }, "result": "0x102ea120" }
 { "kind":"replay", "uid":124865, "timestamp":1568313296697177296, "event": "makeMemoryResource", "payload": { "name": "PINNED" }, "result": "0x102ea2a0" }
 { "kind":"replay", "uid":124865, "timestamp":1568313296697798230, "event": "makeMemoryResource", "payload": { "name": "UM" }, "result": "0x102ea450" }
-{ "kind":"replay", "uid":124865, "timestamp":1568313296697810977, "event": "makeMemoryResource", "payload": { "name": "DEVICE_CONST" }, "result": "0x102ea650" }
 { "kind":"replay", "uid":124865, "timestamp":1568313296697842159, "event": "makeAllocator", "payload": { "type":"umpire::strategy::MixedPool", "with_introspection":true, "allocator_name":"host_mixedpool_default", "args": [ "HOST" ] } }
 { "kind":"replay", "uid":124865, "timestamp":1568313296697895993, "event": "allocation_map_insert", "payload": { "ptr": "0x100020000010", "record_ptr": "0x100020000010", "record_size": "536870912", "record_strategy": "0x10263c10" } }
 { "kind":"replay", "uid":124865, "timestamp":1568313296697920708, "event": "allocation_map_insert", "payload": { "ptr": "0x10000d270010", "record_ptr": "0x10000d270010", "record_size": "524288", "record_strategy": "0x10263c10" } }

--- a/tests/integration/replay/test_output.hip.good
+++ b/tests/integration/replay/test_output.hip.good
@@ -2,7 +2,6 @@
 { "kind":"replay", "uid":15596, "timestamp":1568324852515722121, "event": "makeMemoryResource", "payload": { "name": "HOST" }, "result": "0x6f9e30" }
 { "kind":"replay", "uid":15596, "timestamp":1568324852745352753, "event": "makeMemoryResource", "payload": { "name": "DEVICE" }, "result": "0x8a4830" }
 { "kind":"replay", "uid":15596, "timestamp":1568324852745367664, "event": "makeMemoryResource", "payload": { "name": "PINNED" }, "result": "0x8a49f0" }
-{ "kind":"replay", "uid":15596, "timestamp":1568324852745373584, "event": "makeMemoryResource", "payload": { "name": "DEVICE_CONST" }, "result": "0x8a4be0" }
 { "kind":"replay", "uid":15596, "timestamp":1568324852745413934, "event": "makeAllocator", "payload": { "type":"umpire::strategy::MixedPool", "with_introspection":true, "allocator_name":"host_mixedpool_default", "args": [ "HOST" ] } }
 { "kind":"replay", "uid":15596, "timestamp":1568324852745480194, "event": "allocation_map_insert", "payload": { "ptr": "0x2aaec5801010", "record_ptr": "0x2aaec5801010", "record_size": "536870912", "record_strategy": "0x6f9e30" } }
 { "kind":"replay", "uid":15596, "timestamp":1568324852745497924, "event": "allocation_map_insert", "payload": { "ptr": "0x1237f20", "record_ptr": "0x1237f20", "record_size": "524288", "record_strategy": "0x6f9e30" } }


### PR DESCRIPTION
This is an attempt to stop lingering nfs files from breaking CI on bamboo.

- Moved build directory to be peer of source directory instead of sub-directory of source
- (note: Bamboo plan also modified to place source in a `src` directory or working dir)
- Updated script to manually remove (rm -rf) the build directory and ignore/supress errors about lingering nfs files.
- Both the build and test are now being performed on the compute node