### PR TITLE
Allow compilation without git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,12 @@ if (NOT BLT_LOADED)
   include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 endif()
 
-blt_git_hashcode (HASHCODE umpire_sha1
-                  RETURN_CODE rc
-                  SOURCE_DIR ${PROJECT_SOURCE_DIR})
-set (UMPIRE_VERSION_RC ${umpire_sha1})
+if (Git_FOUND)
+  blt_git_hashcode (HASHCODE umpire_sha1
+                    RETURN_CODE rc
+                    SOURCE_DIR ${PROJECT_SOURCE_DIR})
+  set (UMPIRE_VERSION_RC ${umpire_sha1})
+endif ()
 
 include(cmake/SetupCMakeBasics.cmake)
 include(cmake/SetupCompilerFlags.cmake)


### PR DESCRIPTION
Umpire loads the BLT cmake functions.
But BLT does not load its git related functions if git is not found.
And Umpire was using blt_git_hashcode
without checking that it was actually loaded.

See issue https://github.com/LLNL/Umpire/issues/282