### PR TITLE
Updated script to skip non-existant configurations

### DIFF
--- a/scripts/bamboo/run_build_and_test.sh
+++ b/scripts/bamboo/run_build_and_test.sh
@@ -17,14 +17,18 @@ function trycmd
   fi
 }
 
-echo "Configuring..."
-trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
+if [ -f ${UMPIRE_SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${UMPIRE_COMPILER}.cmake ]; then
+  echo "Configuring..."
+  trycmd "cmake -DENABLE_DEVELOPER_DEFAULTS=On \
     -C ${UMPIRE_SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${UMPIRE_COMPILER}.cmake \
     -C ${UMPIRE_SOURCE_DIR}/host-configs/${SYS_TYPE}/${UMPIRE_COMPILER}.cmake \
     -DCMAKE_BUILD_TYPE=${UMPIRE_BUILD_TYPE} ${BUILD_OPTIONS} ${UMPIRE_SOURCE_DIR}"
 
-echo "Building..."
-trycmd "make VERBOSE=1 -j"
+  echo "Building..."
+  trycmd "make VERBOSE=1 -j"
 
-echo "Testing..."
-trycmd "ctest --output-on-failure -T Test"
+  echo "Testing..."
+  trycmd "ctest --output-on-failure -T Test"
+else
+  echo "${UMPIRE_SOURCE_DIR}/.gitlab/conf/host-configs/${SYS_TYPE}/${UMPIRE_COMPILER}.cmake does not yet exist, skipping configuration"
+fi


### PR DESCRIPTION
This is needed in order to enable smooth development for adding new compiler support.