### PR TITLE
CI: Define two categories of targets for testing [feature/split_compilers]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,10 @@ start:
   script:
     - echo "Creating a reference job for dag execution (needs keyword)"
 
+.advanced_pipeline:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $UMPIRE_ALL_TARGETS == "ON"' #run only if ...
+
 # This is not a job, but contains project specific build commands
 # If an allocation exist with the name defined in this pipeline, the job will use it
 .build_toss_3_x86_64_ib_script:
@@ -59,7 +63,6 @@ start:
 
 .build_blueos_3_ppc64le_ib_p9_script:
   extends: .build_blueos_3_ppc64le_ib_script
-
 
 # This is where jobs are included
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,10 +18,22 @@ after_script:
 
 # There are no tests for now
 stages:
-  - allocate_resources
-  - build
-  - test
-  - release_resources
+  - start
+  - q_allocate_resources
+  - q_build
+  - q_test
+  - q_release_resources
+  - l_build_and_test
+  - b_build_and_test
+
+start:
+  variables:
+    GIT_STRATEGY: none
+  stage: start
+  tags:
+    - shell
+  script:
+    - echo "Creating a reference job for dag execution (needs keyword)"
 
 # This is not a job, but contains project specific build commands
 # If an allocation exist with the name defined in this pipeline, the job will use it
@@ -52,7 +64,7 @@ stages:
 # This is where jobs are included
 include:
   - local: .gitlab/ci/build_quartz.yml
-  - local: .gitlab/ci/build_butte.yml
   - local: .gitlab/ci/build_lassen.yml
+  - local: .gitlab/ci/build_butte.yml
 
 

--- a/.gitlab/ci/build_butte.yml
+++ b/.gitlab/ci/build_butte.yml
@@ -15,19 +15,24 @@
     - butte
   stage: b_build_and_test
   extends: .build_blueos_3_ppc64le_ib_script
-  only:
-    variables:
-      - $UMPIRE_CI_BUTTE == "ON"
+  rules:
+    - if: '$UMPIRE_CI_BUTTE != "ON"' #run except if ...
+      when: never
+    - when: on_success
   allow_failure: true
   needs: ["start"]
+
+.build_butte_advanced:
+  extends: [.build_butte, .advanced_pipeline]
+  allow_failure: true
 
 ####
 # Here are all butte build jobs
 
-build_butte_clang_3_9_1:
+build_butte_clang_3_9_1_advanced:
   variables:
     COMPILER: "clang_3_9_1"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
 build_butte_gcc_4_9_3:
   variables:
@@ -39,20 +44,20 @@ build_butte_clang_4_0_0:
     COMPILER: "clang_4_0_0"
   extends: .build_butte
 
-build_butte_clang_coral_2017_06_29:
+build_butte_clang_coral_2017_06_29_advanced:
   variables:
     COMPILER: "clang_coral_2017_06_29"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
-build_butte_clang_coral_2017_08_31:
+build_butte_clang_coral_2017_08_31_advanced:
   variables:
     COMPILER: "clang_coral_2017_08_31"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
-build_butte_clang_coral_2017_09_06:
+build_butte_clang_coral_2017_09_06_advanced:
   variables:
     COMPILER: "clang_coral_2017_09_06"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
 build_butte_clang_coral_2017_09_18:
   variables:
@@ -64,20 +69,20 @@ build_butte_nvcc_gcc_4_9_3:
     COMPILER: "nvcc_gcc_4_9_3"
   extends: .build_butte
 
-build_butte_nvcc_clang_coral_2017_06_29:
+build_butte_nvcc_clang_coral_2017_06_29_advanced:
   variables:
     COMPILER: "nvcc_clang_coral_2017_06_29"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
-build_butte_nvcc_clang_coral_2017_08_31:
+build_butte_nvcc_clang_coral_2017_08_31_advanced:
   variables:
     COMPILER: "nvcc_clang_coral_2017_08_31"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
-build_butte_nvcc_clang_coral_2017_09_06:
+build_butte_nvcc_clang_coral_2017_09_06_advanced:
   variables:
     COMPILER: "nvcc_clang_coral_2017_09_06"
-  extends: .build_butte
+  extends: .build_butte_advanced
 
 build_butte_nvcc_clang_coral_2017_09_18:
   variables:

--- a/.gitlab/ci/build_butte.yml
+++ b/.gitlab/ci/build_butte.yml
@@ -13,12 +13,13 @@
   tags:
     - shell
     - butte
-  stage: build
+  stage: b_build_and_test
   extends: .build_blueos_3_ppc64le_ib_script
   only:
     variables:
       - $UMPIRE_CI_BUTTE == "ON"
   allow_failure: true
+  needs: ["start"]
 
 ####
 # Here are all butte build jobs

--- a/.gitlab/ci/build_lassen.yml
+++ b/.gitlab/ci/build_lassen.yml
@@ -13,13 +13,14 @@
   tags:
     - shell
     - lassen
-  stage: build
+  stage: l_build_and_test
   extends: .build_blueos_3_ppc64le_ib_p9_script
   except:
     refs:
       - /_lnone/
     variables:
       - $UMPIRE_CI_LASSEN == "OFF"
+  needs: ["start"]
 
 ####
 # Here are all lassen build jobs

--- a/.gitlab/ci/build_lassen.yml
+++ b/.gitlab/ci/build_lassen.yml
@@ -15,57 +15,59 @@
     - lassen
   stage: l_build_and_test
   extends: .build_blueos_3_ppc64le_ib_p9_script
-  except:
-    refs:
-      - /_lnone/
-    variables:
-      - $UMPIRE_CI_LASSEN == "OFF"
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $UMPIRE_CI_LASSEN == "OFF"' #run except if ...
+      when: never
+    - when: on_success
   needs: ["start"]
+
+.build_lassen_advanced:
+  extends: [.build_lassen, .advanced_pipeline]
 
 ####
 # Here are all lassen build jobs
 
-build_lassen_clang_3_9_1:
+build_lassen_clang_3_9_1_advanced:
   variables:
     COMPILER: "clang_3_9_1"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
 
-build_lassen_gcc_4_9_3:
-  variables:
-    COMPILER: "gcc_4_9_3"
-  extends: .build_lassen
-
-build_lassen_gcc_8_3_1:
-  variables:
-    COMPILER: "gcc_8_3_1"
-  extends: .build_lassen
-
-build_lassen_clang_4_0_0:
+build_lassen_clang_4_0_0_advanced:
   variables:
     COMPILER: "clang_4_0_0"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
 
 build_lassen_clang_9_0_0:
   variables:
     COMPILER: "clang_9_0_0"
   extends: .build_lassen
 
-build_lassen_clang_coral_2017_06_29:
+build_lassen_gcc_4_9_3_advanced:
+  variables:
+    COMPILER: "gcc_4_9_3"
+  extends: .build_lassen_advanced
+
+build_lassen_gcc_8_3_1:
+  variables:
+    COMPILER: "gcc_8_3_1"
+  extends: .build_lassen
+
+build_lassen_clang_coral_2017_06_29_advanced:
   variables:
     COMPILER: "clang_coral_2017_06_29"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
-build_lassen_clang_coral_2017_08_31:
+build_lassen_clang_coral_2017_08_31_advanced:
   variables:
     COMPILER: "clang_coral_2017_08_31"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
-build_lassen_clang_coral_2017_09_06:
+build_lassen_clang_coral_2017_09_06_advanced:
   variables:
     COMPILER: "clang_coral_2017_09_06"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
 build_lassen_clang_coral_2017_09_18:
@@ -79,22 +81,22 @@ build_lassen_nvcc_gcc_4_9_3:
     COMPILER: "nvcc_gcc_4_9_3"
   extends: .build_lassen
 
-build_lassen_nvcc_clang_coral_2017_06_29:
+build_lassen_nvcc_clang_coral_2017_06_29_advanced:
   variables:
     COMPILER: "nvcc_clang_coral_2017_06_29"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
-build_lassen_nvcc_clang_coral_2017_08_31:
+build_lassen_nvcc_clang_coral_2017_08_31_advanced:
   variables:
     COMPILER: "nvcc_clang_coral_2017_08_31"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
-build_lassen_nvcc_clang_coral_2017_09_06:
+build_lassen_nvcc_clang_coral_2017_09_06_advanced:
   variables:
     COMPILER: "nvcc_clang_coral_2017_09_06"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
 build_lassen_nvcc_clang_coral_2017_09_18:
@@ -103,10 +105,10 @@ build_lassen_nvcc_clang_coral_2017_09_18:
   extends: .build_lassen
   allow_failure: true
 
-build_lassen_nvcc_xl-beta-2017.09.13:
+build_lassen_nvcc_xl-beta-2017.09.13_advanced:
   variables:
     COMPILER: "nvcc_xl-beta-2017.09.13"
-  extends: .build_lassen
+  extends: .build_lassen_advanced
   allow_failure: true
 
 build_lassen_nvcc_xl-beta-2019.08.20:

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -14,11 +14,12 @@
   tags:
     - shell
     - quartz
-  except:
-    refs:
-      - /_qnone/
-    variables:
-      - $UMPIRE_CI_QUARTZ == "OFF"
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $UMPIRE_CI_QUARTZ == "OFF"' #run except if ...
+      when: never
+    - if: '$CI_JOB_NAME =~ /release_resources/'
+      when: always
+    - when: on_success
 
 ####
 # In pre-build phase, allocate a node for builds
@@ -42,7 +43,6 @@ release_resources_build_quartz:
   script:
     - export JOBID=$(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
-  when: always
 
 ####
 # Generic qwartz job, extending build script
@@ -50,28 +50,44 @@ release_resources_build_quartz:
   stage: q_build
   extends: [.quartz_common, .build_toss_3_x86_64_ib_script]
 
+.build_quartz_advanced:
+  extends: [.build_quartz, .advanced_pipeline]
+
 ####
 # Generic qwartz job, extending test script
 .test_quartz:
   stage: q_test
   extends: [.quartz_common, .test_toss_3_x86_64_ib_script]
 
+.test_quartz_advanced:
+  extends: [.test_quartz, .advanced_pipeline]
+
 ####
 # Here are all quartz build jobs
 
-build_quartz_clang_3_9_1:
+build_quartz_clang_3_9_1_advanced:
   variables:
     COMPILER: "clang_3_9_1"
-  extends: .build_quartz
-
-build_quartz_gcc_4_9_3:
-  variables:
-    COMPILER: "gcc_4_9_3"
-  extends: .build_quartz
+  extends: .build_quartz_advanced
 
 build_quartz_clang_4_0_0:
   variables:
     COMPILER: "clang_4_0_0"
+  extends: .build_quartz
+
+build_quartz_gcc_4_9_3_advanced:
+  variables:
+    COMPILER: "gcc_4_9_3"
+  extends: .build_quartz_advanced
+
+build_quartz_gcc_6_1_0_advanced:
+  variables:
+    COMPILER: "gcc_6_1_0"
+  extends: .build_quartz_advanced
+
+build_quartz_gcc_7_1_0:
+  variables:
+    COMPILER: "gcc_7_1_0"
   extends: .build_quartz
 
 build_quartz_cudatoolkit_9_1:
@@ -79,36 +95,26 @@ build_quartz_cudatoolkit_9_1:
     COMPILER: "cudatoolkit_9_1"
   extends: .build_quartz
 
-build_quartz_gcc_6_1_0:
-  variables:
-    COMPILER: "gcc_6_1_0"
-  extends: .build_quartz
-
-build_quartz_gcc_7_1_0:
-  variables:
-    COMPILER: "gcc_7_1_0"
-  extends: .build_quartz
-
-build_quartz_icpc_16_0_4:
+build_quartz_icpc_16_0_4_advanced:
   variables:
     COMPILER: "icpc_16_0_4"
-  extends: .build_quartz
+  extends: .build_quartz_advanced
   allow_failure: true
 
-build_quartz_icpc_17_0_2:
+build_quartz_icpc_17_0_2_advanced:
   variables:
     COMPILER: "icpc_17_0_2"
-  extends: .build_quartz
+  extends: .build_quartz_advanced
 
 build_quartz_icpc_18_0_0:
   variables:
     COMPILER: "icpc_18_0_0"
   extends: .build_quartz
 
-build_quartz_pgi_17_10:
+build_quartz_pgi_17_10_advanced:
   variables:
     COMPILER: "pgi_17_10"
-  extends: .build_quartz
+  extends: .build_quartz_advanced
   allow_failure: true
 
 build_quartz_pgi_18_5:
@@ -123,17 +129,11 @@ build_quartz_pgi_18_5:
 ####
 # Here are all quartz tests jobs
 
-test_quartz_clang_3_9_1:
+test_quartz_clang_3_9_1_advanced:
   variables:
     COMPILER: "clang_3_9_1"
-  extends: .test_quartz
-  needs: ["build_quartz_clang_3_9_1"]
-
-test_quartz_gcc_4_9_3:
-  variables:
-    COMPILER: "gcc_4_9_3"
-  extends: .test_quartz
-  needs: ["build_quartz_gcc_4_9_3"]
+  extends: .test_quartz_advanced
+  needs: ["build_quartz_clang_3_9_1_advanced"]
 
 test_quartz_clang_4_0_0:
   variables:
@@ -141,17 +141,17 @@ test_quartz_clang_4_0_0:
   extends: .test_quartz
   needs: ["build_quartz_clang_4_0_0"]
 
-test_quartz_cudatoolkit_9_1:
+test_quartz_gcc_4_9_3_advanced:
   variables:
-    COMPILER: "cudatoolkit_9_1"
-  extends: .test_quartz
-  needs: ["build_quartz_cudatoolkit_9_1"]
+    COMPILER: "gcc_4_9_3"
+  extends: .test_quartz_advanced
+  needs: ["build_quartz_gcc_4_9_3_advanced"]
 
-test_quartz_gcc_6_1_0:
+test_quartz_gcc_6_1_0_advanced:
   variables:
     COMPILER: "gcc_6_1_0"
-  extends: .test_quartz
-  needs: ["build_quartz_gcc_6_1_0"]
+  extends: .test_quartz_advanced
+  needs: ["build_quartz_gcc_6_1_0_advanced"]
 
 test_quartz_gcc_7_1_0:
   variables:
@@ -159,18 +159,24 @@ test_quartz_gcc_7_1_0:
   extends: .test_quartz
   needs: ["build_quartz_gcc_7_1_0"]
 
-test_quartz_icpc_16_0_4:
+test_quartz_cudatoolkit_9_1:
+  variables:
+    COMPILER: "cudatoolkit_9_1"
+  extends: .test_quartz
+  needs: ["build_quartz_cudatoolkit_9_1"]
+
+test_quartz_icpc_16_0_4_advanced:
   variables:
     COMPILER: "icpc_16_0_4"
-  extends: .test_quartz
-  needs: ["build_quartz_icpc_16_0_4"]
+  extends: .test_quartz_advanced
+  needs: ["build_quartz_icpc_16_0_4_advanced"]
   allow_failure: true
 
-test_quartz_icpc_17_0_2:
+test_quartz_icpc_17_0_2_advanced:
   variables:
     COMPILER: "icpc_17_0_2"
-  extends: .test_quartz
-  needs: ["build_quartz_icpc_17_0_2"]
+  extends: .test_quartz_advanced
+  needs: ["build_quartz_icpc_17_0_2_advanced"]
 
 test_quartz_icpc_18_0_0:
   variables:
@@ -178,11 +184,11 @@ test_quartz_icpc_18_0_0:
   extends: .test_quartz
   needs: ["build_quartz_icpc_18_0_0"]
 
-test_quartz_pgi_17_10:
+test_quartz_pgi_17_10_advanced:
   variables:
     COMPILER: "pgi_17_10"
-  extends: .test_quartz
-  needs: ["build_quartz_pgi_17_10"]
+  extends: .test_quartz_advanced
+  needs: ["build_quartz_pgi_17_10_advanced"]
   allow_failure: true
 
 test_quartz_pgi_18_5:

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -26,9 +26,10 @@ allocate_resources_build_quartz:
   variables:
     GIT_STRATEGY: none
   extends: .quartz_common
-  stage: allocate_resources
+  stage: q_allocate_resources
   script:
     - salloc -N 1 -c 36 -p pdebug -t 10 --no-shell --job-name=${BUILD_QUARTZ_ALLOC_NAME}
+  needs: ["start"]
 
 ####
 # In post-build phase, deallocate resources
@@ -37,49 +38,23 @@ release_resources_build_quartz:
   variables:
     GIT_STRATEGY: none
   extends: .quartz_common
-  stage: release_resources
+  stage: q_release_resources
   script:
     - export JOBID=$(squeue -h --name=${BUILD_QUARTZ_ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
   when: always
-  except:
-    - /_qnone/
-  needs: ["test_quartz_clang_3_9_1",
-          "test_quartz_gcc_4_9_3",
-          "test_quartz_clang_4_0_0",
-          "test_quartz_cudatoolkit_9_1",
-          "test_quartz_gcc_6_1_0",
-          "test_quartz_gcc_7_1_0",
-          "test_quartz_icpc_16_0_4",
-          "test_quartz_icpc_17_0_2",
-          "test_quartz_icpc_18_0_0",
-          "test_quartz_pgi_17_10",
-          "test_quartz_pgi_18_5"]
 
 ####
 # Generic qwartz job, extending build script
 .build_quartz:
-  variables:
-  tags:
-    - shell
-    - quartz
-  stage: build
-  extends: .build_toss_3_x86_64_ib_script
-  except:
-    - /_qnone/
+  stage: q_build
+  extends: [.quartz_common, .build_toss_3_x86_64_ib_script]
 
 ####
 # Generic qwartz job, extending test script
 .test_quartz:
-  variables:
-    CLUSTER: "toss_3_x86_64_ib"
-  tags:
-    - shell
-    - quartz
-  stage: test
-  extends: .test_toss_3_x86_64_ib_script
-  except:
-    - /_qnone/
+  stage: q_test
+  extends: [.quartz_common, .test_toss_3_x86_64_ib_script]
 
 ####
 # Here are all quartz build jobs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Changed
 
+- LC Gitlab CI runs only a subset of targets on PRs, and all of them on master
+  and develop branch.
+
 ### Removed
 
 ### Fixed


### PR DESCRIPTION
Affects exclusively Gitlab CI.

In this PR, I split the targets (or toolchains, or compilers) in two categories:
- By default, the tests on Pull Request will run on a subset on targets, considered preferred or mandatory.
- The "advanced" categories gathers the other targets, and will be built and tested only on "master" or "develop" branches, or if a the "UMPIRE_ALL_TARGETS" variable is set in the pipeline.

Jobs have be re-organized so that it is easier to identify the machines they run on. All the build are still triggered simultaneously for efficiency, relying on the `needs` mechanism in gitlab ci.

Also, `only` and `except` keywords (which are candidates for deprecation in Gitlab) have been replaced with `rules` making the filtering mechanism slightly more readable and easier to maintain.

Fixes #287 