### PR TITLE
Fix build job for gcc 4_9_3 (default) and place it in standard pipeline

### DIFF
--- a/.gitlab/ci/build_lassen.yml
+++ b/.gitlab/ci/build_lassen.yml
@@ -27,6 +27,11 @@
 ####
 # Here are all lassen build jobs
 
+build_lassen_gcc_default:
+  variables:
+    COMPILER: "gcc_default"
+  extends: .build_lassen_advanced
+
 build_lassen_clang_3_9_1_advanced:
   variables:
     COMPILER: "clang_3_9_1"
@@ -41,11 +46,6 @@ build_lassen_clang_9_0_0:
   variables:
     COMPILER: "clang_9_0_0"
   extends: .build_lassen
-
-build_lassen_gcc_4_9_3_advanced:
-  variables:
-    COMPILER: "gcc_4_9_3"
-  extends: .build_lassen_advanced
 
 build_lassen_gcc_8_3_1:
   variables:


### PR DESCRIPTION
Simple fix for the failing job (gcc_default/gcc_4_9_3) in CI pipeline for master on lassen.
Also places this job in standard pipeline (rather than advanced).

Note: Clang_3_9_1 seems unstable for some reason.