### PR TITLE
Ignore .vscode project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 CMakeFiles
 *.tar.gz
+.vscode


### PR DESCRIPTION
For now, I'd like to ignore the workspace settings control directory the vscode places in the open workspace.  We may wish to revisit this later if we decide to put project-specific settings in there that we would like other (vscode) developers to see.  But for now it is just an annoyance.