### PR TITLE
Fix ordering

### DIFF
--- a/src/umpire/resource/CudaConstantMemoryResource.cu
+++ b/src/umpire/resource/CudaConstantMemoryResource.cu
@@ -23,8 +23,8 @@ CudaConstantMemoryResource::CudaConstantMemoryResource(const std::string& name, 
   m_highwatermark{0},
   m_platform{Platform::cuda},
   m_offset{0},
-  m_initialized{false},
-  m_ptr{nullptr}
+  m_ptr{nullptr},
+  m_initialized{false}
 {
 }
 


### PR DESCRIPTION
This small PR fixes an error (initializer list order) when compiling umpire with `-Werror reorder` :

```
error: the initialization of member "umpire::resource::CudaConstantMemoryResource::m_ptr" will be done before that of member "umpire::resource::CudaConstantMemoryResource::m_initialized"
 
1 error detected in the compilation of "/tmpxft_00016b14_00000000-6_CudaConstantMemoryResource.cpp1.ii".
make[2]: *** [src/umpire/resource/CMakeFiles/umpire_resource.dir/build.make:128: src/umpire/resource/CMakeFiles/umpire_resource.dir/CudaConstantMemoryResource.cu.o] Error 1
```

Can recreate the error with the following cmake host-config options on `blueos` :

```
set(CMAKE_CXX_COMPILER /usr/tce/packages/gcc/gcc-8.3.1/bin/g++ CACHE PATH "")
set(CMAKE_C_COMPILER /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc CACHE PATH "")

# Cuda options
set(ENABLE_CUDA ON CACHE BOOL "")
set(CUDA_TOOLKIT_ROOT_DIR /usr/tce/packages/cuda/cuda-10.1.243 CACHE STRING "")
set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc CACHE STRING "")
set(CUDA_ARCH sm_70 CACHE STRING "")
set(CMAKE_CUDA_FLAGS "-restrict -arch ${CUDA_ARCH} -Werror reorder" CACHE STRING "")
```



