### PR TITLE
CI Clean-up

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@
 # GIT_SUBMODULE_STRATEGY:
 # Tells Gitlab to recursively update the submodules when cloning umpire
 #
-# UMPIRE_ALLOC_NAME:
+# ALLOC_NAME:
 # On LLNL's quartz, this pipeline creates only one allocation shared among jobs
 # in order to save time and resources. This allocation has to be uniquely named
 # so that we are sure to retrieve it.
@@ -30,23 +30,14 @@
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
-  UMPIRE_ALLOC_NAME: umpire_ci_${CI_PIPELINE_ID}
-  BUILD_ROOT: ${CI_BUILDS_DIR}/umpire/${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
-
-# This defines the default behavior, may be overridden it.
-before_script:
-  - date
-
-after_script:
-  - date
+  ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
+  BUILD_ROOT: ${CI_BUILDS_DIR}/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
 
 # Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
 # can express dependencies between job that break the ordering of stages, in
 # favor of a DAG.
-# In practice q_*, l_* and b_* stages are independently run as soon as start is
-# complete.
+# In practice q_*, l_* and b_* stages are independently run and start immediately.
 stages:
-  - start
   - q_allocate_resources
   - q_build
   - q_test
@@ -54,40 +45,26 @@ stages:
   - l_build_and_test
   - b_build_and_test
 
-# The start job is actually a dumb one, which serves as a reference to start
-# q_allocate_resources, l_build_and_test and b_build_and_test simultaneously.
-# TODO: GitLab 12.8 will allow for empty "needs" to trigger the job asap,
-# this start job will no be necessary anymore.
-# Note: "GIT_STRATEGY: none" tells GitLab not to clone umpire for this job.
-start:
-  variables:
-    GIT_STRATEGY: none
-  stage: start
-  tags:
-    - shell
-  script:
-    - echo "Creating a reference job for dag execution (needs keyword)"
-
 # This is the rules that drives the activation of "advanced" jobs. All advanced
 # jobs will share this through a template mechanism.
 .advanced_pipeline:
   rules:
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $UMPIRE_ALL_TARGETS == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $ALL_TARGETS == "ON"' #run only if ...
 
 # These are also templates (.name) that define project specific build commands.
 # If an allocation exist with the name defined in this pipeline, the job will
 # use it (slurm specific).
 .build_toss_3_x86_64_ib_script:
   script:
-    - echo ${UMPIRE_ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${UMPIRE_ALLOC_NAME} --format=%A)
+    - echo ${ALLOC_NAME}
+    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
     - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 10 -N 1 -n 1 -c 4 scripts/gitlab/build_and_test.sh --build-only
 
 .test_toss_3_x86_64_ib_script:
   script:
-    - echo ${UMPIRE_ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${UMPIRE_ALLOC_NAME} --format=%A)
+    - echo ${ALLOC_NAME}
+    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
     - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 10 -N 1 -n 1 -c 4 scripts/gitlab/build_and_test.sh --test-only
 

--- a/.gitlab/butte.yml
+++ b/.gitlab/butte.yml
@@ -13,7 +13,7 @@
     - shell
     - butte
   rules:
-    - if: '$UMPIRE_CI_BUTTE != "ON"' #run except if ...
+    - if: '$ON_BUTTE != "ON"' #run except if ...
       when: never
     - when: on_success
   allow_failure: true
@@ -21,7 +21,7 @@
 .build_and_test_on_butte:
   stage: b_build_and_test
   extends: [.build_blueos_3_ppc64le_ib_script, .on_butte]
-  needs: ["start"]
+  needs: []
 
 # Note: .build_and_test_on_butte_advanced inherits from
 # .build_and_test_on_butte and .advanced_pileline.

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -13,14 +13,14 @@
     - shell
     - lassen
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $UMPIRE_CI_LASSEN == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"' #run except if ...
       when: never
     - when: on_success
 
 .build_and_test_on_lassen:
   stage: l_build_and_test
   extends: [.build_blueos_3_ppc64le_ib_p9_script, .on_lassen]
-  needs: ["start"]
+  needs: []
 
 # Note: .build_and_test_on_lassen_advanced inherits from
 # .build_and_test_on_lassen and .advanced_pileline.

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -15,7 +15,7 @@
     - shell
     - quartz
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $UMPIRE_CI_QUARTZ == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
       when: never
     - if: '$CI_JOB_NAME =~ /release_resources/'
       when: always
@@ -29,8 +29,8 @@ allocate_resources (on quartz):
   extends: .on_quartz
   stage: q_allocate_resources
   script:
-    - salloc -N 1 -c 36 -p pdebug -t 10 --no-shell --job-name=${UMPIRE_ALLOC_NAME}
-  needs: ["start"]
+    - salloc -N 1 -c 36 -p pdebug -t 10 --no-shell --job-name=${ALLOC_NAME}
+  needs: []
 
 ####
 # In post-build phase, deallocate resources
@@ -41,7 +41,7 @@ release_resources (on quartz):
   extends: .on_quartz
   stage: q_release_resources
   script:
-    - export JOBID=$(squeue -h --name=${UMPIRE_ALLOC_NAME} --format=%A)
+    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
 
 ####

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -33,7 +33,8 @@ fi
 conf=${CONFIGURATION:-""}
 if [[ -z ${conf} ]]
 then
-    echo "CONFIGURATION is undefined... aborting" exit 1
+    echo "CONFIGURATION is undefined... aborting"
+    exit 1
 fi
 
 project_dir="$(pwd)"


### PR DESCRIPTION
No functionality change in this PR.

- Removes mentions of UMPIRE in variable naming (makes the yaml file easier to use in another project).
- Removes the start job, not necessary in newer Gitlab. The `needs` key can now be given an empty list in which case the job will start immediately.