### PR TITLE
Fix exit with error if ctest failed

### DIFF
--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -135,4 +135,9 @@ then
     echo "Copying Testing xml reports for export"
     tree Testing
     cp Testing/*/Test.xml ${project_dir}
+
+    if grep -q "Errors while running CTest" ./tests_output.txt
+    then
+        echo "ERROR: failure(s) while running CTest" && exit 1
+    fi
 fi


### PR DESCRIPTION
I noticed that a unit test for intel 16.0.4 on quartz was failing but this wasn’t caught by CI.

This is due to a mistake in exit status management in build_and_test.sh script.

This PR fixes that.