### PR TITLE
Fixes for the newly merge feature/uberenv

### DIFF
--- a/host-configs/blueos_3_ppc64le_ib_p9
+++ b/host-configs/blueos_3_ppc64le_ib_p9
@@ -1,0 +1,1 @@
+blueos_3_ppc64le_ib

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -80,7 +80,6 @@ class Umpire(CMakePackage, CudaPackage):
     variant('fortran', default=False, description='Build C/Fortran API')
     variant('c', default=True, description='Build C API')
     variant('numa', default=False, description='Enable NUMA support')
-    variant('cuda', default=False, description='Enable CUDA support')
     variant('openmp', default=False, description='Build with OpenMP support')
     variant('deviceconst', default=False,
             description='Enables support for constant device memory')


### PR DESCRIPTION
2 fixes:
- In a moment of weakness I added "cuda" variant to umpire spack package... again. Umpire package inherits from CudaPackage.
- Restore symlink to blueos hostconfig files, deleted by mistake.
 