### PR TITLE
DynamicPoolList memory leak fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - When installing, camp target was not exported.
 
+- DynamicPoolList no longer uses a pointer for DynamicSizePool, fixing
+  memory leak.
+
 ## [3.0.0] - 2020-06-30
 
 ### Added

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -24,11 +24,10 @@ DynamicPoolList::DynamicPoolList(
     CoalesceHeuristic coalesce_heuristic) noexcept
   :
   AllocationStrategy(name, id),
-  dpa(nullptr),
   m_allocator(allocator.getAllocationStrategy()),
+  dpa(DynamicSizePool<>(m_allocator, min_initial_alloc_size, min_alloc_size)),
   do_coalesce{coalesce_heuristic}
 {
-  dpa = new DynamicSizePool<>(m_allocator, min_initial_alloc_size, min_alloc_size);
 }
 
 void*
@@ -36,7 +35,7 @@ DynamicPoolList::allocate(size_t bytes)
 {
   UMPIRE_LOG(Debug, "(bytes=" << bytes << ")");
 
-  void* ptr = dpa->allocate(bytes);
+  void* ptr = dpa.allocate(bytes);
   return ptr;
 }
 
@@ -44,25 +43,25 @@ void
 DynamicPoolList::deallocate(void* ptr)
 {
   UMPIRE_LOG(Debug, "(ptr=" << ptr << ")");
-  dpa->deallocate(ptr);
+  dpa.deallocate(ptr);
 
   if ( do_coalesce(*this) ) {
     UMPIRE_LOG(Debug, "Heuristic returned true, "
         "performing coalesce operation for " << this << "\n");
-    dpa->coalesce();
+    dpa.coalesce();
   }
 }
 
 void
 DynamicPoolList::release()
 {
-  dpa->release();
+  dpa.release();
 }
 
 std::size_t
 DynamicPoolList::getActualSize() const noexcept
 {
-  std::size_t ActualSize = dpa->getActualSize();
+  std::size_t ActualSize = dpa.getActualSize();
   UMPIRE_LOG(Debug, "() returning " << ActualSize);
   return ActualSize;
 }
@@ -70,7 +69,7 @@ DynamicPoolList::getActualSize() const noexcept
 std::size_t
 DynamicPoolList::getReleasableSize() const noexcept
 {
-  std::size_t SparseBlockSize = dpa->getReleasableSize();
+  std::size_t SparseBlockSize = dpa.getReleasableSize();
   UMPIRE_LOG(Debug, "() returning " << SparseBlockSize);
   return SparseBlockSize;
 }
@@ -78,7 +77,7 @@ DynamicPoolList::getReleasableSize() const noexcept
 std::size_t
 DynamicPoolList::getBlocksInPool() const noexcept
 {
-  std::size_t BlocksInPool = dpa->getBlocksInPool();
+  std::size_t BlocksInPool = dpa.getBlocksInPool();
   UMPIRE_LOG(Debug, "() returning " << BlocksInPool);
   return BlocksInPool;
 }
@@ -86,7 +85,7 @@ DynamicPoolList::getBlocksInPool() const noexcept
 std::size_t
 DynamicPoolList::getLargestAvailableBlock() const noexcept
 {
-  std::size_t LargestAvailableBlock = dpa->getLargestAvailableBlock();
+  std::size_t LargestAvailableBlock = dpa.getLargestAvailableBlock();
   UMPIRE_LOG(Debug, "() returning " << LargestAvailableBlock);
   return LargestAvailableBlock;
 }
@@ -107,7 +106,7 @@ void
 DynamicPoolList::coalesce() noexcept
 {
   UMPIRE_REPLAY("\"event\": \"coalesce\", \"payload\": { \"allocator_name\": \"" << getName() << "\" }");
-  dpa->coalesce();
+  dpa.coalesce();
 }
 
 } // end of namespace strategy

--- a/src/umpire/strategy/DynamicPoolList.hpp
+++ b/src/umpire/strategy/DynamicPoolList.hpp
@@ -105,9 +105,9 @@ class DynamicPoolList :
     MemoryResourceTraits getTraits() const noexcept final override;
 
   private:
-    DynamicSizePool<>* dpa;
-
     strategy::AllocationStrategy* m_allocator;
+    DynamicSizePool<> dpa;
+    
     CoalesceHeuristic do_coalesce;
 };
 


### PR DESCRIPTION
DynamicSizePool instance variable, dpa, is no longer a pointer. Now, dpa is left on the stack and is automatically cleaned up by default destructor. Some variable rearrangement was necessary so that compiler did not complain about how variables were constructed. Note that this class still does not have a custom destructor.