### PR TITLE
Add missing Caliper dependency in various subdirectories

### DIFF
--- a/src/umpire/op/CMakeLists.txt
+++ b/src/umpire/op/CMakeLists.txt
@@ -129,6 +129,12 @@ if (ENABLE_OPENMP_TARGET)
     openmp)
 endif ()
 
+if (ENABLE_CALIPER)
+  set( umpire_op_depends
+    ${umpire_op_depends}
+    cali)
+endif ()
+
 blt_add_library(
   NAME umpire_op
   HEADERS ${umpire_op_headers}

--- a/src/umpire/resource/CMakeLists.txt
+++ b/src/umpire/resource/CMakeLists.txt
@@ -139,6 +139,12 @@ if (ENABLE_OPENMP_TARGET)
     openmp)
 endif ()
 
+if (ENABLE_CALIPER)
+  set( umpire_resource_depends
+    ${umpire_resource_depends}
+    cali)
+endif ()
+
 blt_add_library(
   NAME umpire_resource
   HEADERS ${umpire_resource_headers}

--- a/src/umpire/strategy/CMakeLists.txt
+++ b/src/umpire/strategy/CMakeLists.txt
@@ -76,6 +76,12 @@ if (ENABLE_OPENMP_TARGET)
     openmp)
 endif ()
 
+if (ENABLE_CALIPER)
+  set( umpire_strategy_depends
+    ${umpire_strategy_depends}
+    cali)
+endif ()
+
 blt_add_library(
   NAME umpire_strategy
   HEADERS ${umpire_strategy_headers} ${umpire_strategy_mixin_headers}


### PR DESCRIPTION
Compiler complained about missing Caliper includes as the Caliper dependency was missing in some subdirectories' CMake scripts.