### PR TITLE
Feature/um 716 improve destruction resilliance of primary pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Fixed
 
+- Improved resilliance of primary pool destructors so that giving back
+  previously allocated blocks to a device that has already been cleaned up
+  will no longer throw an error, but instead will now be logged and ignored.
+
 - Fixed Allocator overrun problem in replay tool
 
 ## [v4.0.1] - 2020-09-03

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -51,6 +51,7 @@ void DynamicPoolList::deallocate(void* ptr)
 
 void DynamicPoolList::release()
 {
+  UMPIRE_LOG(Debug, "()");
   dpa.release();
 }
 
@@ -94,6 +95,7 @@ MemoryResourceTraits DynamicPoolList::getTraits() const noexcept
 
 void DynamicPoolList::coalesce() noexcept
 {
+  UMPIRE_LOG(Debug, "()");
   UMPIRE_REPLAY("\"event\": \"coalesce\", \"payload\": { \"allocator_name\": \""
                 << getName() << "\" }");
   dpa.coalesce();

--- a/src/umpire/strategy/DynamicPoolMap.cpp
+++ b/src/umpire/strategy/DynamicPoolMap.cpp
@@ -31,18 +31,20 @@ DynamicPoolMap::DynamicPoolMap(
       mixins::AlignedAllocation{alignment, allocator.getAllocationStrategy()},
       m_should_coalesce{should_coalesce},
       m_first_minimum_pool_allocation_size{
-          aligned_round_up(first_minimum_pool_allocation_size)},
+            first_minimum_pool_allocation_size},
       m_next_minimum_pool_allocation_size{
-          aligned_round_up(next_minimum_pool_allocation_size)}
+            next_minimum_pool_allocation_size}
 {
-  UMPIRE_LOG(Debug, " { "
-    << "Name(\"" << name << "\")"
-    << ", Id(" << id << ")"
-    << ", For(\"" << allocator.getName() << "\")"
-    << " 1st_alloc(" << m_first_minimum_pool_allocation_size << ")"
-    << ", next_alloc(" << m_next_minimum_pool_allocation_size << ")"
-    << ", align(" << alignment << ")"
-    << " }");
+  UMPIRE_LOG(Debug, " ( "
+    << "name=\"" << name << "\""
+    << ", id=" << id
+    << ", allocator=\"" << allocator.getName() << "\""
+    << ", first_minimum_pool_allocation_size="
+        << m_first_minimum_pool_allocation_size
+    << ", next_minimum_pool_allocation_size="
+        << m_next_minimum_pool_allocation_size
+    << ", alignment=" << alignment
+    << " )");
 }
 
 DynamicPoolMap::~DynamicPoolMap()
@@ -346,8 +348,8 @@ void DynamicPoolMap::deallocateBlock(void* ptr, std::size_t size)
   catch (...) {
     if (m_is_destructing) {
       //
-      // Ignore the error if we are destructing as the resource to which we
-      // are releasing to may have gone away
+      // Ignore error in case the underlying vendor API has already
+      // shutdown
       //
       UMPIRE_LOG(Error, "Pool is destructing, Exception Ignored");
     }

--- a/src/umpire/strategy/DynamicPoolMap.hpp
+++ b/src/umpire/strategy/DynamicPoolMap.hpp
@@ -178,6 +178,7 @@ class DynamicPoolMap : public AllocationStrategy,
   const std::size_t m_next_minimum_pool_allocation_size;
 
   std::size_t m_actual_bytes{0};
+  bool m_is_destructing{false};
 };
 
 } // end of namespace strategy

--- a/src/umpire/strategy/DynamicSizePool.hpp
+++ b/src/umpire/strategy/DynamicSizePool.hpp
@@ -228,8 +228,8 @@ class DynamicSizePool : private umpire::strategy::mixins::AlignedAllocation {
         catch (...) {
           if (m_is_destructing) {
             //
-            // Ignore the error if we are destructing as the resource to which we
-            // are releasing to may have gone away
+            // Ignore error in case the underlying vendor API has already
+            // shutdown
             //
             UMPIRE_LOG(Error, "Pool is destructing, Exception Ignored");
           }
@@ -285,16 +285,18 @@ class DynamicSizePool : private umpire::strategy::mixins::AlignedAllocation {
         freeBlocks{nullptr},
         m_actual_bytes{0},
         m_first_minimum_pool_allocation_size{
-            aligned_round_up(first_minimum_pool_allocation_size)},
+              first_minimum_pool_allocation_size},
         m_next_minimum_pool_allocation_size{
-            aligned_round_up(next_minimum_pool_allocation_size)}
+              next_minimum_pool_allocation_size}
   {
-    UMPIRE_LOG(Debug, " { "
-      << "Pool For(\"" << strat->getName() << "\")"
-      << " 1st_alloc(" << m_first_minimum_pool_allocation_size << ")"
-      << ", next_alloc(" << m_next_minimum_pool_allocation_size << ")"
-      << ", align(" << alignment << ")"
-      << " }");
+    UMPIRE_LOG(Debug, " ( "
+      << ", allocator=\"" << strat->getName() << "\""
+      << ", first_minimum_pool_allocation_size="
+          << m_first_minimum_pool_allocation_size
+      << ", next_minimum_pool_allocation_size="
+          << m_next_minimum_pool_allocation_size
+      << ", alignment=" << alignment
+      << " )");
   }
 
   DynamicSizePool(const DynamicSizePool &) = delete;

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -23,18 +23,20 @@ QuickPool::QuickPool(const std::string& name, int id, Allocator allocator,
       mixins::AlignedAllocation{alignment, allocator.getAllocationStrategy()},
       m_should_coalesce{should_coalesce},
       m_first_minimum_pool_allocation_size{
-          aligned_round_up(first_minimum_pool_allocation_size)},
+            first_minimum_pool_allocation_size},
       m_next_minimum_pool_allocation_size{
-          aligned_round_up(next_minimum_pool_allocation_size)}
+            next_minimum_pool_allocation_size}
 {
-  UMPIRE_LOG(Debug, " { "
-    << "Name(\"" << name << "\")"
-    << ", Id(" << id << ")"
-    << ", For(\"" << allocator.getName() << "\")"
-    << " 1st_alloc(" << m_first_minimum_pool_allocation_size << ")"
-    << ", next_alloc(" << m_next_minimum_pool_allocation_size << ")"
-    << ", align(" << alignment << ")"
-    << " }");
+  UMPIRE_LOG(Debug, " ( "
+    << "name=\"" << name << "\""
+    << ", id=" << id
+    << ", allocator=\"" << allocator.getName() << "\""
+    << ", first_minimum_pool_allocation_size="
+        << m_first_minimum_pool_allocation_size
+    << ", next_minimum_pool_allocation_size="
+        << m_next_minimum_pool_allocation_size
+    << ", alignment=" << alignment
+    << " )");
 }
 
 QuickPool::~QuickPool()
@@ -223,8 +225,7 @@ void QuickPool::release()
       catch (...) {
         if (m_is_destructing) {
           //
-          // Ignore the error if we are destructing as the resource to which we
-          // are releasing to may have gone away
+          // Ignore error in case the underlying vendor API has already shutdown
           //
           UMPIRE_LOG(Error, "Pool is destructing, Exception Ignored");
         }

--- a/src/umpire/strategy/QuickPool.hpp
+++ b/src/umpire/strategy/QuickPool.hpp
@@ -151,6 +151,7 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
 
   std::size_t m_actual_bytes{0};
   std::size_t m_releasable_bytes{0};
+  bool m_is_destructing{false};
 };
 
 } // end of namespace strategy

--- a/src/umpire/strategy/QuickPool.hpp
+++ b/src/umpire/strategy/QuickPool.hpp
@@ -84,6 +84,7 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
   std::size_t getLargestAvailableBlock() noexcept;
 
   void coalesce() noexcept;
+  void do_coalesce() noexcept;
 
  private:
   struct Chunk;


### PR DESCRIPTION
1. Added logging to primary pools to better reflect pool life cycle
2. Added (missing) REPLAY of coalesce operation to `QuickPool`
3. Modified destructors of primary pools to try/catch/log/ignore deallocation failures from the device which may happen if destruction occurrs after the device's runtime has already shut down.
