### PR TITLE
Adding fixes to solve warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Fixed Allocator overrun problem in replay tool
 
+- Removed warnings from MemoryResourceTypes header file
+
 ## [v4.0.1] - 2020-09-03
 
 ### Fixed

--- a/src/umpire/resource/MemoryResourceTypes.hpp
+++ b/src/umpire/resource/MemoryResourceTypes.hpp
@@ -23,7 +23,7 @@ struct MemoryResourceTypeHash {
   }
 };
 
-enum MemoryResourceType { Host, Device, Unified, Pinned, Constant, File };
+enum MemoryResourceType { Host, Device, Unified, Pinned, Constant, File, Unknown };
 
 inline std::string resource_to_string(MemoryResourceType type)
 {
@@ -42,6 +42,7 @@ inline std::string resource_to_string(MemoryResourceType type)
       return "FILE";
     default: 
       UMPIRE_ERROR("Unkown resource type: " << type);
+      return "UNKNOWN"; 
   }
 }
 
@@ -53,7 +54,10 @@ inline MemoryResourceType string_to_resource(const std::string& resource)
   else if (resource == "PINNED") return MemoryResourceType::Pinned;
   else if (resource == "DEVICE_CONST") return MemoryResourceType::Constant;
   else if (resource == "FILE") return MemoryResourceType::File;
-  else UMPIRE_ERROR("Unkown resource name: " << resource);
+  else {
+    UMPIRE_ERROR("Unkown resource name: " << resource);
+    return MemoryResourceType::Unknown;
+  }
 }
 
 inline int resource_to_device_id(const std::string& resource) {


### PR DESCRIPTION
After recompiling on Lassen, I didn't get the same warning messages as before. However, I still kept the same fixes and things will compile with no warnings/errors. For the record, the error we got before was:
`/g/g0/belcher6/Umpire/src/umpire/resource/MemoryResourceTypes.hpp(46): warning: missing return statement at end of non-void function "umpire::resource::resource_to_string"

/g/g0/belcher6/Umpire/src/umpire/resource/MemoryResourceTypes.hpp(57): warning: missing return statement at end of non-void function "umpire::resource::string_to_resource"`
So we added an "Unknown" Resource Type to return if the end of the function was reached. This should solve the problem that came up before.