### PR TITLE
Using cache to optimize virtual env management

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
-  PYTHON_ENVIRONMENT_PATH: ${CI_BUILDS_DIR}/python-umpire
+  PYTHON_ENVIRONMENT_PATH: .venv
 
 # Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
 # can express dependencies between job that break the ordering of stages, in
@@ -56,9 +56,13 @@ configure_python:
     - quartz
   stage: environment
   script:
-    - virtualenv -p /usr/tce/packages/python/python-3.8.2/bin/python $PYTHON_ENVIRONMENT_PATH
+    - virtualenv -p /usr/tce/packages/python/python-3.8.2/bin/python ${PYTHON_ENVIRONMENT_PATH}
     - . ${PYTHON_ENVIRONMENT_PATH}/bin/activate
     - pip install lxml
+  cache:
+    key: venv
+    paths:
+      - ${PYTHON_ENVIRONMENT_PATH}
 
 # This is the rules that drives the activation of "advanced" jobs. All advanced
 # jobs will share this through a template mechanism.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
-  PYTHON_ENVIRONMENT_PATH: .venv
+  PYTHON_ENVIRONMENT_PATH: ${CI_PROJECT_DIR}/.venv
 
 # Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
 # can express dependencies between job that break the ordering of stages, in

--- a/.gitlab/quartz-templates.yml
+++ b/.gitlab/quartz-templates.yml
@@ -48,6 +48,11 @@ release_resources (on quartz):
 .build_and_test_on_quartz:
   extends: [.build_toss_3_x86_64_ib_script, .on_quartz]
   stage: q_build_and_test
+  cache:
+    key: venv
+    paths:
+      - ${PYTHON_ENVIRONMENT_PATH}
+    policy: pull
 
 .build_and_test_on_quartz_advanced:
   extends: [.build_and_test_on_quartz, .advanced_pipeline]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - GitLab test script now converts CTest output to JUnit so that test results
   are visible in the native GitLab UI.
 
+- Gitlab test scripts now caches python virtual environment.
+
 ### Removed
 
 - Peer access is no longer automatically enabled for CUDA and HIP.

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -136,7 +136,7 @@ then
     # Convert CTest xml to JUnit (on toss3 only)
     if [[ ${sys_type} == *toss_3* ]]; then
         if [[ -n ${py_env_path} ]]; then
-            . ./${py_env_path}/bin/activate
+            . ${py_env_path}/bin/activate
 
             python3 ${project_dir}/scripts/gitlab/convert_to_junit.py \
             ${project_dir}/Test.xml \

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -136,7 +136,7 @@ then
     # Convert CTest xml to JUnit (on toss3 only)
     if [[ ${sys_type} == *toss_3* ]]; then
         if [[ -n ${py_env_path} ]]; then
-            . ${py_env_path}/bin/activate
+            . ./${py_env_path}/bin/activate
 
             python3 ${project_dir}/scripts/gitlab/convert_to_junit.py \
             ${project_dir}/Test.xml \


### PR DESCRIPTION
I’ve been willing to use cache correctly for a while, and seized the opportunity.

Relevant points:
- cache prevents from creating "out of clone" directories, like "PYTHON_ENVIRONMENT_PATH" was before this PR.
- cache prevents from reinstalling stuff multiple times.
- cache involves some data movements, which should be optimized not to burden the pipeline: see use of `policy:pull` for an example.
- a cache are shared will all pipelines, and all jobs, unless keys are use to restrict that. See documentation for more.