### PR TITLE
Add a build-only type of job for variant 'tests=none'

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,13 @@ configure_python:
     - echo ${ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 scripts/gitlab/build_and_test.sh --build-only
+
+.build_and_test_toss_3_x86_64_ib_script:
+  script:
+    - echo ${ALLOC_NAME}
+    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
+    - echo ${JOBID}
     - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 scripts/gitlab/build_and_test.sh
   artifacts:
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,6 +63,13 @@ configure_python:
     paths:
       - ${PYTHON_ENVIRONMENT_PATH}
 
+.venv:
+  cache:
+    key: venv
+    paths:
+      - ${PYTHON_ENVIRONMENT_PATH}
+    policy: pull
+
 # This is the rules that drives the activation of "advanced" jobs. All advanced
 # jobs will share this through a template mechanism.
 .advanced_pipeline:
@@ -72,13 +79,6 @@ configure_python:
 # These are also templates (.name) that define project specific build commands.
 # If an allocation exist with the name defined in this pipeline, the job will
 # use it (slurm specific).
-.build_toss_3_x86_64_ib_script:
-  script:
-    - echo ${ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
-    - echo ${JOBID}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 scripts/gitlab/build_and_test.sh --build-only
-
 .build_and_test_toss_3_x86_64_ib_script:
   script:
     - echo ${ALLOC_NAME}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ configure_python:
 # These are also templates (.name) that define project specific build commands.
 # If an allocation exist with the name defined in this pipeline, the job will
 # use it (slurm specific).
-.build_and_test_toss_3_x86_64_ib_script:
+.build_toss_3_x86_64_ib_script:
   script:
     - echo ${ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)

--- a/.gitlab/quartz-jobs.yml
+++ b/.gitlab/quartz-jobs.yml
@@ -24,10 +24,12 @@ icpc_17_0_2:
     SPEC: "+fortran %intel@17.0.2"
   extends: .build_and_test_on_quartz
 
+# Warning: "tests=none" variant requires "build_on_quartz"
+# instead of "build_and_tests_on_quartz"
 icpc_18_0_2:
   variables:
-    SPEC: "+fortran %intel@18.0.2"
-  extends: .build_and_test_on_quartz
+    SPEC: "+fortran tests=none %intel@18.0.2"
+  extends: .build_on_quartz
 
 icpc_19_1_0:
   variables:

--- a/.gitlab/quartz-jobs.yml
+++ b/.gitlab/quartz-jobs.yml
@@ -24,12 +24,10 @@ icpc_17_0_2:
     SPEC: "+fortran %intel@17.0.2"
   extends: .build_and_test_on_quartz
 
-# Warning: "tests=none" variant requires "build_on_quartz"
-# instead of "build_and_tests_on_quartz"
 icpc_18_0_2:
   variables:
     SPEC: "+fortran tests=none %intel@18.0.2"
-  extends: .build_on_quartz
+  extends: .build_and_test_on_quartz
 
 icpc_19_1_0:
   variables:

--- a/.gitlab/quartz-templates.yml
+++ b/.gitlab/quartz-templates.yml
@@ -21,13 +21,6 @@
       when: always
     - when: on_success
 
-.venv:
-  cache:
-    key: venv
-    paths:
-      - ${PYTHON_ENVIRONMENT_PATH}
-    policy: pull
-
 ####
 # In pre-build phase, allocate a node for builds
 allocate_resources (on quartz):
@@ -52,13 +45,6 @@ release_resources (on quartz):
 
 ####
 # Generic quartz build job, extending build script
-.build_on_quartz:
-  extends: [.build_toss_3_x86_64_ib_script, .on_quartz, .venv]
-  stage: q_build_and_test
-
-.build_on_quartz_advanced:
-  extends: [.build_on_quartz, .advanced_pipeline]
-
 .build_and_test_on_quartz:
   extends: [.build_and_test_toss_3_x86_64_ib_script, .on_quartz, .venv]
   stage: q_build_and_test

--- a/.gitlab/quartz-templates.yml
+++ b/.gitlab/quartz-templates.yml
@@ -46,7 +46,7 @@ release_resources (on quartz):
 ####
 # Generic quartz build job, extending build script
 .build_and_test_on_quartz:
-  extends: [.build_and_test_toss_3_x86_64_ib_script, .on_quartz, .venv]
+  extends: [.build_toss_3_x86_64_ib_script, .on_quartz, .venv]
   stage: q_build_and_test
 
 .build_and_test_on_quartz_advanced:

--- a/.gitlab/quartz-templates.yml
+++ b/.gitlab/quartz-templates.yml
@@ -21,6 +21,13 @@
       when: always
     - when: on_success
 
+.venv:
+  cache:
+    key: venv
+    paths:
+      - ${PYTHON_ENVIRONMENT_PATH}
+    policy: pull
+
 ####
 # In pre-build phase, allocate a node for builds
 allocate_resources (on quartz):
@@ -45,14 +52,16 @@ release_resources (on quartz):
 
 ####
 # Generic quartz build job, extending build script
-.build_and_test_on_quartz:
-  extends: [.build_toss_3_x86_64_ib_script, .on_quartz]
+.build_on_quartz:
+  extends: [.build_toss_3_x86_64_ib_script, .on_quartz, .venv]
   stage: q_build_and_test
-  cache:
-    key: venv
-    paths:
-      - ${PYTHON_ENVIRONMENT_PATH}
-    policy: pull
+
+.build_on_quartz_advanced:
+  extends: [.build_on_quartz, .advanced_pipeline]
+
+.build_and_test_on_quartz:
+  extends: [.build_and_test_toss_3_x86_64_ib_script, .on_quartz, .venv]
+  stage: q_build_and_test
 
 .build_and_test_on_quartz_advanced:
   extends: [.build_and_test_on_quartz, .advanced_pipeline]

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -108,7 +108,7 @@ then
 fi
 
 # Test
-if [[ "${option}" != "--build-only" ]]
+if [[ "${option}" != "--build-only" && $(grep -q “ENABLE_TESTS ON” ${hostconfig_path}) ]]
 then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "~~~~~ Testing Umpire"


### PR DESCRIPTION
Here is the suggested patch:

- Parse the host-config in build_and_test.sh script to check if tests are enabled in the build.
- The job succeeds, with an error message to mention no files were found to upload as artifact.
