### PR TITLE
revert -Xcudafe option to ignore nvcc warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Fixed
 
-- Fixed warnings from nvcc about potential early returns from non-void
-  functions.
-
 ## [v4.1.2] - 2020-10-06
 
 ### Fixed

--- a/src/umpire/CMakeLists.txt
+++ b/src/umpire/CMakeLists.txt
@@ -105,13 +105,6 @@ blt_add_library(
   DEPENDS_ON ${umpire_depends}
   DEFINES ${umpire_defines})
 
-if (NOT WIN32 AND CMAKE_VERSION VERSION_GREATER 3.11)
-  target_compile_options(
-    umpire PUBLIC
-    $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe "--diag_suppress=implicit_return_from_non_void_function">
-  )
-endif()
-
 if (NOT WIN32 AND CMAKE_VERSION VERSION_GREATER 3.17)
   target_link_options(
     umpire INTERFACE

--- a/src/umpire/resource/CMakeLists.txt
+++ b/src/umpire/resource/CMakeLists.txt
@@ -146,13 +146,6 @@ blt_add_library(
   DEPENDS_ON ${umpire_resource_depends}
   OBJECT TRUE)
 
-if (NOT WIN32 AND CMAKE_VERSION VERSION_GREATER 3.11)
-  target_compile_options(
-    umpire_resource PUBLIC
-    $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe "--diag_suppress=implicit_return_from_non_void_function">
-  )
-endif()
-
 target_include_directories(
   umpire_resource
   PUBLIC


### PR DESCRIPTION
Instead of turning off this option entirely, we now specifically implement the workaround in the offending header file.