### PR TITLE
Added documentation anchors for tutorial and cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   avoid name collisions.  (Note: this changes may be user visible so need to be
   release noted).
 
+- Fixed up broken source links in tutorial documentation.
+
 ### Removed
 
 ### Fixed

--- a/docs/sphinx/cookbook/advice_device_id.rst
+++ b/docs/sphinx/cookbook/advice_device_id.rst
@@ -17,7 +17,9 @@ By passing a specific device id when constructing an
 will be applied with respect to that device
 
 .. literalinclude:: ../../../examples/cookbook/recipe_advice_device_id.cpp
-                    :lines: 30-32
+   :start-after: _umpire_tut_device_advice_start
+   :end-before: _umpire_tut_device_advice_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/advice_device_id.rst
+++ b/docs/sphinx/cookbook/advice_device_id.rst
@@ -17,8 +17,8 @@ By passing a specific device id when constructing an
 will be applied with respect to that device
 
 .. literalinclude:: ../../../examples/cookbook/recipe_advice_device_id.cpp
-   :start-after: _umpire_tut_device_advice_start
-   :end-before: _umpire_tut_device_advice_end
+   :start-after: _sphinx_tag_tut_device_advice_start
+   :end-before: _sphinx_tag_tut_device_advice_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/coalesce_pool.rst
+++ b/docs/sphinx/cookbook/coalesce_pool.rst
@@ -13,16 +13,16 @@ function, you must get the pointer to the
 :class:`umpire::Allocator`:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_coalesce_pool.cpp
-   :start-after: _umpire_tut_unwrap_strategy_start
-   :end-before: _umpire_tut_unwrap_strategy_end
+   :start-after: _sphinx_tag_tut_unwrap_strategy_start
+   :end-before: _sphinx_tag_tut_unwrap_strategy_end
    :language: C++
 
 Once you have the pointer to the appropriate strategy, you can call the
 function:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_coalesce_pool.cpp
-   :start-after: _umpire_tut_call_coalesce_start
-   :end-before: _umpire_tut_call_coalesce_end
+   :start-after: _sphinx_tag_tut_call_coalesce_start
+   :end-before: _sphinx_tag_tut_call_coalesce_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/coalesce_pool.rst
+++ b/docs/sphinx/cookbook/coalesce_pool.rst
@@ -13,13 +13,17 @@ function, you must get the pointer to the
 :class:`umpire::Allocator`:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_coalesce_pool.cpp
-                    :lines: 24-25
+   :start-after: _umpire_tut_unwrap_strategy_start
+   :end-before: _umpire_tut_unwrap_strategy_end
+   :language: C++
 
 Once you have the pointer to the appropriate strategy, you can call the
 function:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_coalesce_pool.cpp
-                    :lines: 28
+   :start-after: _umpire_tut_call_coalesce_start
+   :end-before: _umpire_tut_call_coalesce_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/dynamic_pool_heuristics.rst
+++ b/docs/sphinx/cookbook/dynamic_pool_heuristics.rst
@@ -44,13 +44,17 @@ A heuristic of 0 will cause the DynamicPool to never automatically coalesce.
 Creation of the heuristic function is accomplished by:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_dynamic_pool_heuristic.cpp
-                    :lines: 25
+   :start-after: _umpire_tut_creat_heuristic_fun_start
+   :end-before: _umpire_tut_creat_heuristic_fun_end
+   :language: C++
 
 The heuristic function is then provided as a parameter when the object is
 instantiated:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_dynamic_pool_heuristic.cpp
-                    :lines: 33-38
+   :start-after: _umpire_tut_use_heuristic_fun_start
+   :end-before: _umpire_tut_use_heuristic_fun_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/dynamic_pool_heuristics.rst
+++ b/docs/sphinx/cookbook/dynamic_pool_heuristics.rst
@@ -44,16 +44,16 @@ A heuristic of 0 will cause the DynamicPool to never automatically coalesce.
 Creation of the heuristic function is accomplished by:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_dynamic_pool_heuristic.cpp
-   :start-after: _umpire_tut_creat_heuristic_fun_start
-   :end-before: _umpire_tut_creat_heuristic_fun_end
+   :start-after: _sphinx_tag_tut_creat_heuristic_fun_start
+   :end-before: _sphinx_tag_tut_creat_heuristic_fun_end
    :language: C++
 
 The heuristic function is then provided as a parameter when the object is
 instantiated:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_dynamic_pool_heuristic.cpp
-   :start-after: _umpire_tut_use_heuristic_fun_start
-   :end-before: _umpire_tut_use_heuristic_fun_end
+   :start-after: _sphinx_tag_tut_use_heuristic_fun_start
+   :end-before: _sphinx_tag_tut_use_heuristic_fun_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/file_allocation.rst
+++ b/docs/sphinx/cookbook/file_allocation.rst
@@ -18,12 +18,16 @@ Requesting the allocation takes two steps: 1) getting a "FILE" allocator,
 2) requesting the amount of memory to allocate.
 
 .. literalinclude:: ../../../examples/cookbook/recipe_filesystem_memory_allocation.cpp
-                    :lines: 12-15
+   :start-after: _umpire_tut_file_allocate_start
+   :end-before: _umpire_tut_file_allocate_end
+   :language: C++
 
 To deallocate:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_filesystem_memory_allocation.cpp
-                    :lines: 17
+   :start-after: _umpire_tut_file_deallocate_start
+   :end-before: _umpire_tut_file_deallocate_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/file_allocation.rst
+++ b/docs/sphinx/cookbook/file_allocation.rst
@@ -18,15 +18,15 @@ Requesting the allocation takes two steps: 1) getting a "FILE" allocator,
 2) requesting the amount of memory to allocate.
 
 .. literalinclude:: ../../../examples/cookbook/recipe_filesystem_memory_allocation.cpp
-   :start-after: _umpire_tut_file_allocate_start
-   :end-before: _umpire_tut_file_allocate_end
+   :start-after: _sphinx_tag_tut_file_allocate_start
+   :end-before: _sphinx_tag_tut_file_allocate_end
    :language: C++
 
 To deallocate:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_filesystem_memory_allocation.cpp
-   :start-after: _umpire_tut_file_deallocate_start
-   :end-before: _umpire_tut_file_deallocate_end
+   :start-after: _sphinx_tag_tut_file_deallocate_start
+   :end-before: _sphinx_tag_tut_file_deallocate_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/get_largest_available_block_in_pool.rst
+++ b/docs/sphinx/cookbook/get_largest_available_block_in_pool.rst
@@ -14,13 +14,17 @@ function, you must get the pointer to the
 :class:`umpire::Allocator`:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
-                    :lines: 18-24
+   :start-after: _umpire_tut_unwrap_start
+   :end-before: _umpire_tut_unwrap_end
+   :language: C++
 
 Once you have the pointer to the appropriate strategy, you can call the
 function:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
-                    :lines: 32-35
+   :start-after: _umpire_tut_get_info_start
+   :end-before: _umpire_tut_get_info_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/get_largest_available_block_in_pool.rst
+++ b/docs/sphinx/cookbook/get_largest_available_block_in_pool.rst
@@ -14,16 +14,16 @@ function, you must get the pointer to the
 :class:`umpire::Allocator`:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
-   :start-after: _umpire_tut_unwrap_start
-   :end-before: _umpire_tut_unwrap_end
+   :start-after: _sphinx_tag_tut_unwrap_start
+   :end-before: _sphinx_tag_tut_unwrap_end
    :language: C++
 
 Once you have the pointer to the appropriate strategy, you can call the
 function:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
-   :start-after: _umpire_tut_get_info_start
-   :end-before: _umpire_tut_get_info_end
+   :start-after: _sphinx_tag_tut_get_info_start
+   :end-before: _sphinx_tag_tut_get_info_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/move_to_managed.rst
+++ b/docs/sphinx/cookbook/move_to_managed.rst
@@ -9,8 +9,8 @@ should be moved to unified memory in order to make it accessible by the GPU.
 You can do this with the :func:`umpire::ResourceManager::move` operation:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_move_to_managed.cpp
-   :start-after: _umpire_tut_move_host_to_managed_start
-   :end-before: _umpire_tut_move_host_to_managed_end
+   :start-after: _sphinx_tag_tut_move_host_to_managed_start
+   :end-before: _sphinx_tag_tut_move_host_to_managed_end
    :language: C++
 
 The move operation will copy the data from host memory to unified memory,

--- a/docs/sphinx/cookbook/move_to_managed.rst
+++ b/docs/sphinx/cookbook/move_to_managed.rst
@@ -9,7 +9,9 @@ should be moved to unified memory in order to make it accessible by the GPU.
 You can do this with the :func:`umpire::ResourceManager::move` operation:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_move_to_managed.cpp
-                    :lines: 26
+   :start-after: _umpire_tut_move_host_to_managed_start
+   :end-before: _umpire_tut_move_host_to_managed_end
+   :language: C++
 
 The move operation will copy the data from host memory to unified memory,
 allocated using the provided ``um_allocator``. The original allocation in host

--- a/docs/sphinx/cookbook/no_introspection.rst
+++ b/docs/sphinx/cookbook/no_introspection.rst
@@ -18,8 +18,8 @@ introspection, you pass a boolean as the second template parameter to the
 :func:`umpire::ResourceManager::makeAllocator` method:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_no_introspection.cpp
-   :start-after: _umpire_tut_nointro_start
-   :end-before: _umpire_tut_nointro_end
+   :start-after: _sphinx_tag_tut_nointro_start
+   :end-before: _sphinx_tag_tut_nointro_end
    :language: C++
 
 Remember that disabling introspection will stop tracking the size of
@@ -27,8 +27,8 @@ allocations made from the pool, so the
 :func:`umpire::Allocator::getCurrentSize` method will return 0:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_no_introspection.cpp
-   :start-after: _umpire_tut_getsize_start
-   :end-before: _umpire_tut_getsize_end
+   :start-after: _sphinx_tag_tut_getsize_start
+   :end-before: _sphinx_tag_tut_getsize_end
    :language: C++
 
 

--- a/docs/sphinx/cookbook/no_introspection.rst
+++ b/docs/sphinx/cookbook/no_introspection.rst
@@ -18,14 +18,18 @@ introspection, you pass a boolean as the second template parameter to the
 :func:`umpire::ResourceManager::makeAllocator` method:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_no_introspection.cpp
-                    :lines: 24-26
+   :start-after: _umpire_tut_nointro_start
+   :end-before: _umpire_tut_nointro_end
+   :language: C++
 
 Remember that disabling introspection will stop tracking the size of
 allocations made from the pool, so the
 :func:`umpire::Allocator::getCurrentSize` method will return 0:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_no_introspection.cpp
-                    :lines: 31
+   :start-after: _umpire_tut_getsize_start
+   :end-before: _umpire_tut_getsize_end
+   :language: C++
 
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/pinned_pool.rst
+++ b/docs/sphinx/cookbook/pinned_pool.rst
@@ -12,7 +12,9 @@ Building the pool takes two steps: 1) getting a base "PINNED" allocator, and 2)
 creating the pool:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_pinned_pool.F
-                    :lines: 19-24
+   :start-after: _umpire_tut_pinned_fortran_start
+   :end-before: _umpire_tut_pinned_fortran_end
+   :language: FORTRAN
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/pinned_pool.rst
+++ b/docs/sphinx/cookbook/pinned_pool.rst
@@ -12,8 +12,8 @@ Building the pool takes two steps: 1) getting a base "PINNED" allocator, and 2)
 creating the pool:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_pinned_pool.F
-   :start-after: _umpire_tut_pinned_fortran_start
-   :end-before: _umpire_tut_pinned_fortran_end
+   :start-after: _sphinx_tag_tut_pinned_fortran_start
+   :end-before: _sphinx_tag_tut_pinned_fortran_end
    :language: FORTRAN
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/pool_advice.rst
+++ b/docs/sphinx/cookbook/pool_advice.rst
@@ -15,7 +15,9 @@ By creating a pool on top of an :class:`umpire::strategy::AllocationAdvisor`,
 you can amortize the cost of applying memory advice:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_pool_advice.cpp
-                    :lines: 26-36
+   :start-after: _umpire_tut_pool_advice_start
+   :end-before: _umpire_tut_pool_advice_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/pool_advice.rst
+++ b/docs/sphinx/cookbook/pool_advice.rst
@@ -15,8 +15,8 @@ By creating a pool on top of an :class:`umpire::strategy::AllocationAdvisor`,
 you can amortize the cost of applying memory advice:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_pool_advice.cpp
-   :start-after: _umpire_tut_pool_advice_start
-   :end-before: _umpire_tut_pool_advice_end
+   :start-after: _sphinx_tag_tut_pool_advice_start
+   :end-before: _sphinx_tag_tut_pool_advice_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/shrinking_pools.rst
+++ b/docs/sphinx/cookbook/shrinking_pools.rst
@@ -14,21 +14,27 @@ and then allocate a single word from this pool to ensure the initial block is
 never freed:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_shrink.cpp
-                    :lines: 24-29
+   :start-after: _umpire_tut_create_pool_start
+   :end-before: _umpire_tut_create_pool_end
+   :language: C++
 
 To increase the pool size you can preallocate a large chunk and then
 immediately free it. The pool will retain this memory for use by later
 allocations:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_shrink.cpp
-                    :lines: 40-41
+   :start-after: _umpire_tut_grow_pool_start
+   :end-before: _umpire_tut_grow_pool_end
+   :language: C++
 
 Assuming that there are no allocations left in the larger "chunk" of the pool,
 you can shrink the pool back down to the initial size by calling
 :func:`umpire::Allocator::release`:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_shrink.cpp
-                    :lines: 50
+   :start-after: _umpire_tut_shrink_pool_back_start
+   :end-before: _umpire_tut_shrink_pool_back_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/cookbook/shrinking_pools.rst
+++ b/docs/sphinx/cookbook/shrinking_pools.rst
@@ -14,8 +14,8 @@ and then allocate a single word from this pool to ensure the initial block is
 never freed:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_shrink.cpp
-   :start-after: _umpire_tut_create_pool_start
-   :end-before: _umpire_tut_create_pool_end
+   :start-after: _sphinx_tag_tut_create_pool_start
+   :end-before: _sphinx_tag_tut_create_pool_end
    :language: C++
 
 To increase the pool size you can preallocate a large chunk and then
@@ -23,8 +23,8 @@ immediately free it. The pool will retain this memory for use by later
 allocations:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_shrink.cpp
-   :start-after: _umpire_tut_grow_pool_start
-   :end-before: _umpire_tut_grow_pool_end
+   :start-after: _sphinx_tag_tut_grow_pool_start
+   :end-before: _sphinx_tag_tut_grow_pool_end
    :language: C++
 
 Assuming that there are no allocations left in the larger "chunk" of the pool,
@@ -32,8 +32,8 @@ you can shrink the pool back down to the initial size by calling
 :func:`umpire::Allocator::release`:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_shrink.cpp
-   :start-after: _umpire_tut_shrink_pool_back_start
-   :end-before: _umpire_tut_shrink_pool_back_end
+   :start-after: _sphinx_tag_tut_shrink_pool_back_start
+   :end-before: _sphinx_tag_tut_shrink_pool_back_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/thread_safe.rst
+++ b/docs/sphinx/cookbook/thread_safe.rst
@@ -13,8 +13,8 @@ In this recipe, we look at creating a `umpire::strategy::ThreadSafeAllocator`
 for an `umpire::strategy::DynamicPool` object:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_thread_safe.cpp
-   :start-after: _umpire_tut_thread_safe_start
-   :end-before: _umpire_tut_thread_safe_end
+   :start-after: _sphinx_tag_tut_thread_safe_start
+   :end-before: _sphinx_tag_tut_thread_safe_end
    :language: C++
 
 The complete example is included below:

--- a/docs/sphinx/cookbook/thread_safe.rst
+++ b/docs/sphinx/cookbook/thread_safe.rst
@@ -13,7 +13,9 @@ In this recipe, we look at creating a `umpire::strategy::ThreadSafeAllocator`
 for an `umpire::strategy::DynamicPool` object:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_thread_safe.cpp
-                    :lines: 14-21
+   :start-after: _umpire_tut_thread_safe_start
+   :end-before: _umpire_tut_thread_safe_end
+   :language: C++
 
 The complete example is included below:
 

--- a/docs/sphinx/features/logging_and_replay.rst
+++ b/docs/sphinx/features/logging_and_replay.rst
@@ -52,8 +52,9 @@ The first event captured is the **version** event which shows the version
 information as follows:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-                    :lines: 15
-                    :language: json
+   :start-after: _umpire_doc_version_start
+   :end-before: _umpire_doc_version_end
+   :language: json
 
 Each line contains the following set of common elements:
 
@@ -86,8 +87,9 @@ Next you will see events for the creation of the default memory resources
 provided by Umpire with the **makeMemoryResource** event:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-                    :lines: 16-20
-                    :language: json
+   :start-after: _umpire_doc_makememoryresource_start
+   :end-before: _umpire_doc_makememoryresource_end
+   :language: json
 
 The *payload* shows that a memory resource was created for *HOST*, *DEVICE*,
 *PINNED*, *UM*, and *DEVICE_CONST* respectively. Note that this could also
@@ -106,8 +108,9 @@ later.
 :class:`umpire::Allocator`:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-                    :lines: 21-22
-                    :language: json
+   :start-after: _umpire_doc_makeallocator_start
+   :end-before: _umpire_doc_makeallocator_end
+   :language: json
 
 The *payload* shows how the allocator was constructed.  The *result* shows the
 reference to the allocated object.
@@ -119,8 +122,9 @@ intention/result pair so that an error may be replayed in the event that
 there is an allocation failure.
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-                    :lines: 23-24
-                    :language: json
+   :start-after: _umpire_doc_allocate_start
+   :end-before: _umpire_doc_allocate_end
+   :language: json
 
 The *payload* shows the object reference of the allocator and the size of the
 allocation request.  The *result* shows the pointer to the memory allocated.
@@ -128,8 +132,9 @@ allocation request.  The *result* shows the pointer to the memory allocated.
 deallocate Event
 ----------------
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-                    :lines: 151
-                    :language: json
+   :start-after: _umpire_doc_deallocate_start
+   :end-before: _umpire_doc_deallocate_end
+   :language: json
 
 The *payload* shows the reference to the allocator object and the pointer
 to the allocated memory that is to be freed.

--- a/docs/sphinx/features/logging_and_replay.rst
+++ b/docs/sphinx/features/logging_and_replay.rst
@@ -52,8 +52,8 @@ The first event captured is the **version** event which shows the version
 information as follows:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-   :start-after: _umpire_doc_version_start
-   :end-before: _umpire_doc_version_end
+   :start-after: _sphinx_tag_doc_version_start
+   :end-before: _sphinx_tag_doc_version_end
    :language: json
 
 Each line contains the following set of common elements:
@@ -87,8 +87,8 @@ Next you will see events for the creation of the default memory resources
 provided by Umpire with the **makeMemoryResource** event:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-   :start-after: _umpire_doc_makememoryresource_start
-   :end-before: _umpire_doc_makememoryresource_end
+   :start-after: _sphinx_tag_doc_makememoryresource_start
+   :end-before: _sphinx_tag_doc_makememoryresource_end
    :language: json
 
 The *payload* shows that a memory resource was created for *HOST*, *DEVICE*,
@@ -108,8 +108,8 @@ later.
 :class:`umpire::Allocator`:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-   :start-after: _umpire_doc_makeallocator_start
-   :end-before: _umpire_doc_makeallocator_end
+   :start-after: _sphinx_tag_doc_makeallocator_start
+   :end-before: _sphinx_tag_doc_makeallocator_end
    :language: json
 
 The *payload* shows how the allocator was constructed.  The *result* shows the
@@ -122,8 +122,8 @@ intention/result pair so that an error may be replayed in the event that
 there is an allocation failure.
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-   :start-after: _umpire_doc_allocate_start
-   :end-before: _umpire_doc_allocate_end
+   :start-after: _sphinx_tag_doc_allocate_start
+   :end-before: _sphinx_tag_doc_allocate_end
    :language: json
 
 The *payload* shows the object reference of the allocator and the size of the
@@ -132,8 +132,8 @@ allocation request.  The *result* shows the pointer to the memory allocated.
 deallocate Event
 ----------------
 .. literalinclude:: ../../../examples/tutorial/tut_replay_log.json
-   :start-after: _umpire_doc_deallocate_start
-   :end-before: _umpire_doc_deallocate_end
+   :start-after: _sphinx_tag_doc_deallocate_start
+   :end-before: _sphinx_tag_doc_deallocate_end
    :language: json
 
 The *payload* shows the reference to the allocator object and the pointer

--- a/docs/sphinx/tutorial/allocators.rst
+++ b/docs/sphinx/tutorial/allocators.rst
@@ -13,15 +13,15 @@ All :class:`umpire::Allocator` s are created and managed by Umpire's
 :class:`umpire::ResourceManager`. To get an Allocator, you need to ask for one: 
 
 .. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
-   :start-after: _umpire_tut_get_allocator_start
-   :end-before: _umpire_tut_get_allocator_end
+   :start-after: _sphinx_tag_tut_get_allocator_start
+   :end-before: _sphinx_tag_tut_get_allocator_end
    :language: C++
 
 Once you have an :class:`umpire::Allocator` you can use it to allocate and deallocate memory:
 
 .. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
-   :start-after: _umpire_tut_de_allocate_start
-   :end-before: _umpire_tut_de_allocate_end
+   :start-after: _sphinx_tag_tut_de_allocate_start
+   :end-before: _sphinx_tag_tut_de_allocate_end
    :language: C++
 
 In the next section, we will see how to allocate memory using different

--- a/docs/sphinx/tutorial/allocators.rst
+++ b/docs/sphinx/tutorial/allocators.rst
@@ -13,14 +13,19 @@ All :class:`umpire::Allocator` s are created and managed by Umpire's
 :class:`umpire::ResourceManager`. To get an Allocator, you need to ask for one: 
 
 .. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
-                    :lines: 14-16
+   :start-after: _umpire_tut_get_allocator_start
+   :end-before: _umpire_tut_get_allocator_end
+   :language: C++
 
 Once you have an :class:`umpire::Allocator` you can use it to allocate and deallocate memory:
 
 .. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
-                    :lines: 18-24
+   :start-after: _umpire_tut_de_allocate_start
+   :end-before: _umpire_tut_de_allocate_end
+   :language: C++
 
 In the next section, we will see how to allocate memory using different
 resources.
 
 .. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
+   :language: C++

--- a/docs/sphinx/tutorial/allocators.rst
+++ b/docs/sphinx/tutorial/allocators.rst
@@ -20,8 +20,13 @@ All :class:`umpire::Allocator` s are created and managed by Umpire's
 Once you have an :class:`umpire::Allocator` you can use it to allocate and deallocate memory:
 
 .. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
-   :start-after: _sphinx_tag_tut_de_allocate_start
-   :end-before: _sphinx_tag_tut_de_allocate_end
+   :start-after: _sphinx_tag_tut_allocate_start
+   :end-before: _sphinx_tag_tut_allocate_end
+   :language: C++
+
+.. literalinclude:: ../../../examples/tutorial/tut_allocator.cpp
+   :start-after: _sphinx_tag_tut_deallocate_start
+   :end-before: _sphinx_tag_tut_deallocate_end
    :language: C++
 
 In the next section, we will see how to allocate memory using different

--- a/docs/sphinx/tutorial/c/allocators.rst
+++ b/docs/sphinx/tutorial/c/allocators.rst
@@ -14,16 +14,16 @@ As with the native C++ interface, all allocators are accessed via the
 ``umpire_resourcemanager`` type. To get an ``umpire_allocator``:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_allocator.c
-   :start-after: _umpire_tut_c_get_allocator_start
-   :end-before: _umpire_tut_c_get_allocator_end
+   :start-after: _sphinx_tag_tut_c_get_allocator_start
+   :end-before: _sphinx_tag_tut_c_get_allocator_end
    :language: C
 
 Once you have an ``umpire_allocator``, you can use it to allocate and
 deallocate memory:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_allocator.c
-   :start-after: _umpire_tut_c_allocate_start
-   :end-before: _umpire_tut_c_allocate_end
+   :start-after: _sphinx_tag_tut_c_allocate_start
+   :end-before: _sphinx_tag_tut_c_allocate_end
    :language: C
 
 In the next section, we will see how to allocate memory in different places.

--- a/docs/sphinx/tutorial/c/allocators.rst
+++ b/docs/sphinx/tutorial/c/allocators.rst
@@ -14,12 +14,16 @@ As with the native C++ interface, all allocators are accessed via the
 ``umpire_resourcemanager`` type. To get an ``umpire_allocator``:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_allocator.c
-                    :lines: 14-18
+   :start-after: _umpire_tut_c_get_allocator_start
+   :end-before: _umpire_tut_c_get_allocator_end
+   :language: C
 
 Once you have an ``umpire_allocator``, you can use it to allocate and
 deallocate memory:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_allocator.c
-                    :lines: 20-24
+   :start-after: _umpire_tut_c_allocate_start
+   :end-before: _umpire_tut_c_allocate_end
+   :language: C
 
 In the next section, we will see how to allocate memory in different places.

--- a/docs/sphinx/tutorial/c/pools.rst
+++ b/docs/sphinx/tutorial/c/pools.rst
@@ -14,8 +14,8 @@ allocations of any size. To create a new ``umpire_allocator`` using the pooling
 algorithm:
 
 .. literalinclude:: ../../../examples/tutorial/c/tut_pool.c
-   :start-after: _umpire_tut_pool_create_start
-   :end-before: _umpire_tut_pool_create_end
+   :start-after: _sphinx_tag_tut_pool_create_start
+   :end-before: _sphinx_tag_tut_pool_create_end
    :language: C
 
 The two arguments are the size of the initial block that is allocated, and the
@@ -28,8 +28,8 @@ before, without needing to worry about the underlying algorithm used for the
 allocations:
 
 .. literalinclude:: ../../../examples/tutorial/c/tut_pool.c
-   :start-after: _umpire_tut_allocate_start
-   :end-before: _umpire_tut_allocate_end
+   :start-after: _sphinx_tag_tut_allocate_start
+   :end-before: _sphinx_tag_tut_allocate_end
    :language: C
 
 

--- a/docs/sphinx/tutorial/c/pools.rst
+++ b/docs/sphinx/tutorial/c/pools.rst
@@ -13,8 +13,10 @@ In this example, we will look at creating a pool that can fulfill requests for
 allocations of any size. To create a new ``umpire_allocator`` using the pooling
 algorithm:
 
-.. literalinclude:: ../../../examples/tutorial/tut_pool.c
-                    :lines: 21-22
+.. literalinclude:: ../../../examples/tutorial/c/tut_pool.c
+   :start-after: _umpire_tut_pool_create_start
+   :end-before: _umpire_tut_pool_create_end
+   :language: C
 
 The two arguments are the size of the initial block that is allocated, and the
 minimum size of any future blocks. We have to provide a new name for the
@@ -26,7 +28,9 @@ before, without needing to worry about the underlying algorithm used for the
 allocations:
 
 .. literalinclude:: ../../../examples/tutorial/c/tut_pool.c
-                    :lines: 24-29
+   :start-after: _umpire_tut_allocate_start
+   :end-before: _umpire_tut_allocate_end
+   :language: C
 
 
 This pool can be created with any valid underlying ``umpire_allocator``.

--- a/docs/sphinx/tutorial/c/resources.rst
+++ b/docs/sphinx/tutorial/c/resources.rst
@@ -27,8 +27,8 @@ can get them using the same ``umpire_resourcemanager_get_allocator_by_name``
 call you saw in the previous example:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_resources.cpp
-   :start-after: _umpire_tut_create_allocator_start
-   :end-before: _umpire_tut_create_allocator_end
+   :start-after: _sphinx_tag_tut_create_allocator_start
+   :end-before: _sphinx_tag_tut_create_allocator_end
    :language: C
 
 Note that every allocator supports the same calls, no matter which resource it
@@ -36,15 +36,15 @@ is for, this means we can run the same code for all the resources available in
 the system:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_resources.cpp 
-   :start-after: _umpire_tut_allocate_start
-   :end-before: _umpire_tut_allocate_end
+   :start-after: _sphinx_tag_tut_allocate_start
+   :end-before: _sphinx_tag_tut_allocate_end
    :language: C
 
 As you can see, we can call this function with any valid resource name:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_resources.cpp 
-   :start-after: _umpire_tut_resource_types_start
-   :end-before: _umpire_tut_resource_types_end
+   :start-after: _sphinx_tag_tut_resource_types_start
+   :end-before: _sphinx_tag_tut_resource_types_end
    :language: C
 
 In the next example, we will learn how to move data between resources using

--- a/docs/sphinx/tutorial/c/resources.rst
+++ b/docs/sphinx/tutorial/c/resources.rst
@@ -27,19 +27,25 @@ can get them using the same ``umpire_resourcemanager_get_allocator_by_name``
 call you saw in the previous example:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_resources.cpp
-                    :lines: 15-19
+   :start-after: _umpire_tut_create_allocator_start
+   :end-before: _umpire_tut_create_allocator_end
+   :language: C
 
 Note that every allocator supports the same calls, no matter which resource it
 is for, this means we can run the same code for all the resources available in
 the system:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_resources.cpp 
-                    :lines: 21-27
+   :start-after: _umpire_tut_allocate_start
+   :end-before: _umpire_tut_allocate_end
+   :language: C
 
 As you can see, we can call this function with any valid resource name:
 
 .. literalinclude:: ../../../../examples/tutorial/c/tut_resources.cpp 
-                    :lines: 34-44
+   :start-after: _umpire_tut_resource_types_start
+   :end-before: _umpire_tut_resource_types_end
+   :language: C
 
 In the next example, we will learn how to move data between resources using
 operations.

--- a/docs/sphinx/tutorial/dynamic_pool.rst
+++ b/docs/sphinx/tutorial/dynamic_pool.rst
@@ -15,7 +15,9 @@ allocations of any size. To create a new ``Allocator`` using the
 :class:`umpire::strategy::DynamicPool` strategy:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
-                    :lines: 18-22
+   :start-after: _umpire_tut_makepool_start
+   :end-before: _umpire_tut_makepool_end
+   :language: C++
 
 We have to provide a new name for the Allocator, as well as the underlying
 Allocator we wish to use to grab memory.
@@ -25,12 +27,16 @@ before, without needing to worry about the underlying algorithm used for the
 allocations:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
-                    :lines: 24-30
+   :start-after: _umpire_tut_allocate_start
+   :end-before: _umpire_tut_allocate_end
+   :language: C++
 
 Don't forget, these strategies can be created on top of any valid Allocator:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
-                    :lines: 36-46
+   :start-after: _umpire_tut_anyallocator_start
+   :end-before: _umpire_tut_anyallocator_end
+   :language: C++
 
 Most Umpire users will make allocations that use the GPU via the
 :class:`umpire::strategy::DynamicPool`, to help mitigate the cost of allocating
@@ -44,13 +50,17 @@ any future underlying allocations. These two parameters can be passed when
 constructing a pool:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_2.cpp
-                    :lines: 21-27
+   :start-after: _umpire_tut_allocator_tuning_start
+   :end-before: _umpire_tut_allocator_tuning_end
+   :language: C++
 
 Depending on where you are allocating data, you might want to use different
 sizes. It's easy to construct multiple pools with different configurations:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_2.cpp
-                    :lines: 41-50
+   :start-after: _umpire_tut_device_sized_pool_start
+   :end-before: _umpire_tut_device_sized_pool_end
+   :language: C++
 
 There are lots of different strategies that you can use, we will look at some
 of them in this tutorial. A complete list of strategies can be found `here

--- a/docs/sphinx/tutorial/dynamic_pool.rst
+++ b/docs/sphinx/tutorial/dynamic_pool.rst
@@ -15,8 +15,8 @@ allocations of any size. To create a new ``Allocator`` using the
 :class:`umpire::strategy::DynamicPool` strategy:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
-   :start-after: _umpire_tut_makepool_start
-   :end-before: _umpire_tut_makepool_end
+   :start-after: _sphinx_tag_tut_makepool_start
+   :end-before: _sphinx_tag_tut_makepool_end
    :language: C++
 
 We have to provide a new name for the Allocator, as well as the underlying
@@ -27,15 +27,15 @@ before, without needing to worry about the underlying algorithm used for the
 allocations:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
-   :start-after: _umpire_tut_allocate_start
-   :end-before: _umpire_tut_allocate_end
+   :start-after: _sphinx_tag_tut_allocate_start
+   :end-before: _sphinx_tag_tut_allocate_end
    :language: C++
 
 Don't forget, these strategies can be created on top of any valid Allocator:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
-   :start-after: _umpire_tut_anyallocator_start
-   :end-before: _umpire_tut_anyallocator_end
+   :start-after: _sphinx_tag_tut_anyallocator_start
+   :end-before: _sphinx_tag_tut_anyallocator_end
    :language: C++
 
 Most Umpire users will make allocations that use the GPU via the
@@ -50,16 +50,16 @@ any future underlying allocations. These two parameters can be passed when
 constructing a pool:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_2.cpp
-   :start-after: _umpire_tut_allocator_tuning_start
-   :end-before: _umpire_tut_allocator_tuning_end
+   :start-after: _sphinx_tag_tut_allocator_tuning_start
+   :end-before: _sphinx_tag_tut_allocator_tuning_end
    :language: C++
 
 Depending on where you are allocating data, you might want to use different
 sizes. It's easy to construct multiple pools with different configurations:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_2.cpp
-   :start-after: _umpire_tut_device_sized_pool_start
-   :end-before: _umpire_tut_device_sized_pool_end
+   :start-after: _sphinx_tag_tut_device_sized_pool_start
+   :end-before: _sphinx_tag_tut_device_sized_pool_end
    :language: C++
 
 There are lots of different strategies that you can use, we will look at some

--- a/docs/sphinx/tutorial/dynamic_pool.rst
+++ b/docs/sphinx/tutorial/dynamic_pool.rst
@@ -31,6 +31,11 @@ allocations:
    :end-before: _sphinx_tag_tut_allocate_end
    :language: C++
 
+.. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp
+   :start-after: _sphinx_tag_tut_deallocate_start
+   :end-before: _sphinx_tag_tut_deallocate_end
+   :language: C++
+
 Don't forget, these strategies can be created on top of any valid Allocator:
 
 .. literalinclude:: ../../../examples/tutorial/tut_dynamic_pool_1.cpp

--- a/docs/sphinx/tutorial/fortran/allocators.rst
+++ b/docs/sphinx/tutorial/fortran/allocators.rst
@@ -16,14 +16,18 @@ As with the native C++ interface, all allocators are accessed via the
 ``UmpireResourceManager`` type. To get an ``UmpireAllocator``:
 
 .. literalinclude:: ../../../../examples/tutorial/fortran/tut_allocator.f
-                    :lines: 17-18
+   :start-after: _umpire_tut_get_allocator_start
+   :end-before: _umpire_tut_get_allocator_end
+   :language: FORTRAN
 
 In this example we fetch the allocator by id, using 0 means you will always get
 a host allocator. Once you have an ``UmpireAllocator``, you can use it to allocate and
 deallocate memory:
 
 .. literalinclude:: ../../../../examples/tutorial/fortran/tut_allocator.f
-                    :lines: 20-24
+   :start-after: _umpire_tut_allocate_start
+   :end-before: _umpire_tut_allocate_end
+   :language: FORTRAN
 
 In this case, we allocate a one-dimensional array using the generic
 ``allocate`` function.

--- a/docs/sphinx/tutorial/fortran/allocators.rst
+++ b/docs/sphinx/tutorial/fortran/allocators.rst
@@ -16,8 +16,8 @@ As with the native C++ interface, all allocators are accessed via the
 ``UmpireResourceManager`` type. To get an ``UmpireAllocator``:
 
 .. literalinclude:: ../../../../examples/tutorial/fortran/tut_allocator.f
-   :start-after: _umpire_tut_get_allocator_start
-   :end-before: _umpire_tut_get_allocator_end
+   :start-after: _sphinx_tag_tut_get_allocator_start
+   :end-before: _sphinx_tag_tut_get_allocator_end
    :language: FORTRAN
 
 In this example we fetch the allocator by id, using 0 means you will always get
@@ -25,8 +25,8 @@ a host allocator. Once you have an ``UmpireAllocator``, you can use it to alloca
 deallocate memory:
 
 .. literalinclude:: ../../../../examples/tutorial/fortran/tut_allocator.f
-   :start-after: _umpire_tut_allocate_start
-   :end-before: _umpire_tut_allocate_end
+   :start-after: _sphinx_tag_tut_allocate_start
+   :end-before: _sphinx_tag_tut_allocate_end
    :language: FORTRAN
 
 In this case, we allocate a one-dimensional array using the generic

--- a/docs/sphinx/tutorial/introspection.rst
+++ b/docs/sphinx/tutorial/introspection.rst
@@ -13,23 +13,25 @@ The :class:`umpire::ResourceManager` can be used to find the allocator
 associated with an address: 
 
 .. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-                    :lines: 36
+   :start-after: _umpire_tut_getallocator_start
+   :end-before: _umpire_tut_getallocator_end
+   :language: C++
 
-Once you have this, it's easy to query things like the name of the Allocator:
-
-.. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-                    :lines: 39
-
-You can also find out the associated :class:`umpire::Platform`, which can help
+Once you have this, it's easy to query things like the name of the Allocator or
+find out the associated :class:`umpire::Platform`, which can help
 you decide where to operate on this data:
 
 .. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-                    :lines: 41
+   :start-after: _umpire_tut_getinfo_start
+   :end-before: _umpire_tut_getinfo_end
+   :language: C++
 
 You can also find out how big the allocation is, in case you forgot:
 
 .. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-                    :lines: 44
+   :start-after: _umpire_tut_getsize_start
+   :end-before: _umpire_tut_getsize_end
+   :language: C++
 
 Remember that these functions will work on any allocation made using an
 Allocator or :class:`umpire::TypedAllocator`.

--- a/docs/sphinx/tutorial/introspection.rst
+++ b/docs/sphinx/tutorial/introspection.rst
@@ -13,8 +13,8 @@ The :class:`umpire::ResourceManager` can be used to find the allocator
 associated with an address: 
 
 .. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-   :start-after: _umpire_tut_getallocator_start
-   :end-before: _umpire_tut_getallocator_end
+   :start-after: _sphinx_tag_tut_getallocator_start
+   :end-before: _sphinx_tag_tut_getallocator_end
    :language: C++
 
 Once you have this, it's easy to query things like the name of the Allocator or
@@ -22,15 +22,15 @@ find out the associated :class:`umpire::Platform`, which can help
 you decide where to operate on this data:
 
 .. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-   :start-after: _umpire_tut_getinfo_start
-   :end-before: _umpire_tut_getinfo_end
+   :start-after: _sphinx_tag_tut_getinfo_start
+   :end-before: _sphinx_tag_tut_getinfo_end
    :language: C++
 
 You can also find out how big the allocation is, in case you forgot:
 
 .. literalinclude:: ../../../examples/tutorial/tut_introspection.cpp
-   :start-after: _umpire_tut_getsize_start
-   :end-before: _umpire_tut_getsize_end
+   :start-after: _sphinx_tag_tut_getsize_start
+   :end-before: _sphinx_tag_tut_getsize_end
    :language: C++
 
 Remember that these functions will work on any allocation made using an

--- a/docs/sphinx/tutorial/operations.rst
+++ b/docs/sphinx/tutorial/operations.rst
@@ -21,7 +21,9 @@ figuring out where the source and destination pointers were allocated, and
 selects the correct implementation to copy the data:
 
 .. literalinclude:: ../../../examples/tutorial/tut_copy.cpp
-                    :lines: 18
+   :start-after: _umpire_tut_copy_start
+   :end-before: _umpire_tut_copy_end
+   :language: C++
 
 This example allocates the destination data using any valid Allocator. 
 
@@ -34,7 +36,9 @@ If you want to move data to a new Allocator and deallocate the old copy, Umpire
 provides a :func:`umpire::ResourceManager::move` operation.
 
 .. literalinclude:: ../../../examples/tutorial/tut_move.cpp
-                    :lines: 17-18
+   :start-after: _umpire_tut_move_start
+   :end-before: _umpire_tut_move_end
+   :language: C++
 
 The move operation combines an allocation, a copy, and a deallocate into one
 function call, allowing you to move data without having to have the destination
@@ -51,7 +55,9 @@ most people know as a memset. Umpire provides a
 any allocation, regardless of where it came from:
 
 .. literalinclude:: ../../../examples/tutorial/tut_memset.cpp
-                    :lines: 36
+   :start-after: _umpire_tut_memset_start
+   :end-before: _umpire_tut_memset_end
+   :language: C++
 
 ----------
 Reallocate
@@ -63,7 +69,9 @@ however, you can be out of luck. Umpire provides a
 :func:`umpire::ResourceManager::reallocate` operation:
 
 .. literalinclude:: ../../../examples/tutorial/tut_reallocate.cpp
-                    :lines: 40
+   :start-after: _umpire_tut_realloc_start
+   :end-before: _umpire_tut_realloc_end
+   :language: C++
 
 This method returns a pointer to the reallocated data. Like all operations,
 this can be used regardless of the Allocator used for the source data.

--- a/docs/sphinx/tutorial/operations.rst
+++ b/docs/sphinx/tutorial/operations.rst
@@ -21,8 +21,8 @@ figuring out where the source and destination pointers were allocated, and
 selects the correct implementation to copy the data:
 
 .. literalinclude:: ../../../examples/tutorial/tut_copy.cpp
-   :start-after: _umpire_tut_copy_start
-   :end-before: _umpire_tut_copy_end
+   :start-after: _sphinx_tag_tut_copy_start
+   :end-before: _sphinx_tag_tut_copy_end
    :language: C++
 
 This example allocates the destination data using any valid Allocator. 
@@ -36,8 +36,8 @@ If you want to move data to a new Allocator and deallocate the old copy, Umpire
 provides a :func:`umpire::ResourceManager::move` operation.
 
 .. literalinclude:: ../../../examples/tutorial/tut_move.cpp
-   :start-after: _umpire_tut_move_start
-   :end-before: _umpire_tut_move_end
+   :start-after: _sphinx_tag_tut_move_start
+   :end-before: _sphinx_tag_tut_move_end
    :language: C++
 
 The move operation combines an allocation, a copy, and a deallocate into one
@@ -55,8 +55,8 @@ most people know as a memset. Umpire provides a
 any allocation, regardless of where it came from:
 
 .. literalinclude:: ../../../examples/tutorial/tut_memset.cpp
-   :start-after: _umpire_tut_memset_start
-   :end-before: _umpire_tut_memset_end
+   :start-after: _sphinx_tag_tut_memset_start
+   :end-before: _sphinx_tag_tut_memset_end
    :language: C++
 
 ----------
@@ -69,8 +69,8 @@ however, you can be out of luck. Umpire provides a
 :func:`umpire::ResourceManager::reallocate` operation:
 
 .. literalinclude:: ../../../examples/tutorial/tut_reallocate.cpp
-   :start-after: _umpire_tut_realloc_start
-   :end-before: _umpire_tut_realloc_end
+   :start-after: _sphinx_tag_tut_realloc_start
+   :end-before: _sphinx_tag_tut_realloc_end
    :language: C++
 
 This method returns a pointer to the reallocated data. Like all operations,

--- a/docs/sphinx/tutorial/replay.rst
+++ b/docs/sphinx/tutorial/replay.rst
@@ -16,21 +16,21 @@ of the run that generated the log.
 The file ``tut_replay.cpp`` makes a :class:`umpire::strategy::DynamicPool`:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay.cpp
-   :start-after: _umpire_tut_replay_make_allocate_start
-   :end-before: _umpire_tut_replay_make_allocate_end
+   :start-after: _sphinx_tag_tut_replay_make_allocate_start
+   :end-before: _sphinx_tag_tut_replay_make_allocate_end
    :language: C++
 
 This allocator is used to perform some randomly sized allocations, and later
 free them:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay.cpp
-   :start-after: _umpire_tut_replay_allocate_start
-   :end-before: _umpire_tut_replay_allocate_end
+   :start-after: _sphinx_tag_tut_replay_allocate_start
+   :end-before: _sphinx_tag_tut_replay_allocate_end
    :language: C++
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay.cpp
-   :start-after: _umpire_tut_replay_dealocate_start
-   :end-before: _umpire_tut_replay_dealocate_end
+   :start-after: _sphinx_tag_tut_replay_dealocate_start
+   :end-before: _sphinx_tag_tut_replay_dealocate_end
    :language: C++
 
 Running the Example

--- a/docs/sphinx/tutorial/replay.rst
+++ b/docs/sphinx/tutorial/replay.rst
@@ -16,17 +16,22 @@ of the run that generated the log.
 The file ``tut_replay.cpp`` makes a :class:`umpire::strategy::DynamicPool`:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay.cpp
-                    :lines: 27-29
-                    :language: c++
+   :start-after: _umpire_tut_replay_make_allocate_start
+   :end-before: _umpire_tut_replay_make_allocate_end
+   :language: C++
 
 This allocator is used to perform some randomly sized allocations, and later
 free them:
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay.cpp
-                    :lines: 32-33
+   :start-after: _umpire_tut_replay_allocate_start
+   :end-before: _umpire_tut_replay_allocate_end
+   :language: C++
 
 .. literalinclude:: ../../../examples/tutorial/tut_replay.cpp
-                    :lines: 36
+   :start-after: _umpire_tut_replay_dealocate_start
+   :end-before: _umpire_tut_replay_dealocate_end
+   :language: C++
 
 Running the Example
 -------------------

--- a/docs/sphinx/tutorial/resources.rst
+++ b/docs/sphinx/tutorial/resources.rst
@@ -31,8 +31,8 @@ and you can get them using the same
 example:
 
 .. literalinclude:: ../../../examples/tutorial/tut_resources.cpp
-   :start-after: _umpire_tut_get_allocator_start
-   :end-before: _umpire_tut_get_allocator_end
+   :start-after: _sphinx_tag_tut_get_allocator_start
+   :end-before: _sphinx_tag_tut_get_allocator_end
    :language: C++
 
 Note that since every allocator supports the same calls, no matter which resource 

--- a/docs/sphinx/tutorial/resources.rst
+++ b/docs/sphinx/tutorial/resources.rst
@@ -31,7 +31,9 @@ and you can get them using the same
 example:
 
 .. literalinclude:: ../../../examples/tutorial/tut_resources.cpp
-                    :lines: 16
+   :start-after: _umpire_tut_get_allocator_start
+   :end-before: _umpire_tut_get_allocator_end
+   :language: C++
 
 Note that since every allocator supports the same calls, no matter which resource 
 it is for, this means we can run the same code for all the resources available in

--- a/docs/sphinx/tutorial/typed_allocators.rst
+++ b/docs/sphinx/tutorial/typed_allocators.rst
@@ -14,8 +14,8 @@ However, when you call allocate, this argument is the number of objects you
 want to allocate, no the total number of bytes:
 
 .. literalinclude:: ../../../examples/tutorial/tut_typed_allocator.cpp
-   :start-after: _umpire_tut_typed_alloc_start
-   :end-before: _umpire_tut_typed_alloc_end
+   :start-after: _sphinx_tag_tut_typed_alloc_start
+   :end-before: _sphinx_tag_tut_typed_alloc_end
    :language: C++
 
 To use this allocator with an STL object like a vector, you need to pass the
@@ -23,8 +23,8 @@ type as a template parameter for the vector, and also pass the allocator to the
 vector when you construct it:
 
 .. literalinclude:: ../../../examples/tutorial/tut_typed_allocator.cpp
-   :start-after: _umpire_tut_vector_alloc_start
-   :end-before: _umpire_tut_vector_alloc_end
+   :start-after: _sphinx_tag_tut_vector_alloc_start
+   :end-before: _sphinx_tag_tut_vector_alloc_end
    :language: C++
 
 One thing to remember is that whatever allocator you use with an STL object, it

--- a/docs/sphinx/tutorial/typed_allocators.rst
+++ b/docs/sphinx/tutorial/typed_allocators.rst
@@ -14,14 +14,18 @@ However, when you call allocate, this argument is the number of objects you
 want to allocate, no the total number of bytes:
 
 .. literalinclude:: ../../../examples/tutorial/tut_typed_allocator.cpp
-                    :lines: 16-20
+   :start-after: _umpire_tut_typed_alloc_start
+   :end-before: _umpire_tut_typed_alloc_end
+   :language: C++
 
 To use this allocator with an STL object like a vector, you need to pass the
 type as a template parameter for the vector, and also pass the allocator to the
 vector when you construct it:
 
 .. literalinclude:: ../../../examples/tutorial/tut_typed_allocator.cpp
-                    :lines: 22-25
+   :start-after: _umpire_tut_vector_alloc_start
+   :end-before: _umpire_tut_vector_alloc_end
+   :language: C++
 
 One thing to remember is that whatever allocator you use with an STL object, it
 must be compatible with the inner workings of that object. For example, if you

--- a/examples/cookbook/recipe_advice_device_id.cpp
+++ b/examples/cookbook/recipe_advice_device_id.cpp
@@ -17,7 +17,7 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("UM");
 
-  // _umpire_tut_device_advice_start
+  // _sphinx_tag_tut_device_advice_start
   //
   // Create an allocator that applied "PREFFERED_LOCATION" advice to set a
   // specific GPU device as the preferred location.
@@ -32,7 +32,7 @@ int main(int, char**)
             "preferred_location_device_2", allocator, "PREFERRED_LOCATION",
             device_id);
 
-    // _umpire_tut_device_advice_end
+    // _sphinx_tag_tut_device_advice_end
     void* data = preferred_location_allocator.allocate(1024);
 
     preferred_location_allocator.deallocate(data);

--- a/examples/cookbook/recipe_advice_device_id.cpp
+++ b/examples/cookbook/recipe_advice_device_id.cpp
@@ -17,12 +17,13 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("UM");
 
-  /*
-   * Create an allocator that applied "PREFFERED_LOCATION" advice to set a
-   * specific GPU device as the preferred location.
-   *
-   * In this case, device #2.
-   */
+  // _umpire_tut_device_advice_start
+  //
+  // Create an allocator that applied "PREFFERED_LOCATION" advice to set a
+  // specific GPU device as the preferred location.
+  //
+  // In this case, device #2.
+  //
   const int device_id = 2;
 
   try {
@@ -31,6 +32,7 @@ int main(int, char**)
             "preferred_location_device_2", allocator, "PREFERRED_LOCATION",
             device_id);
 
+    // _umpire_tut_device_advice_end
     void* data = preferred_location_allocator.allocate(1024);
 
     preferred_location_allocator.deallocate(data);

--- a/examples/cookbook/recipe_coalesce_pool.cpp
+++ b/examples/cookbook/recipe_coalesce_pool.cpp
@@ -20,11 +20,15 @@ int main(int, char**)
   auto pool = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "pool", rm.getAllocator("HOST"));
 
+  // _umpire_tut_unwrap_strategy_start
   auto dynamic_pool =
       umpire::util::unwrap_allocator<umpire::strategy::DynamicPool>(pool);
+  // _umpire_tut_unwrap_strategy_end
 
   if (dynamic_pool) {
+    // _umpire_tut_call_coalesce_start
     dynamic_pool->coalesce();
+    // _umpire_tut_call_coalesce_end
   } else {
     UMPIRE_ERROR(pool.getName() << " is not a DynamicPool, cannot coalesce!");
   }

--- a/examples/cookbook/recipe_coalesce_pool.cpp
+++ b/examples/cookbook/recipe_coalesce_pool.cpp
@@ -20,15 +20,15 @@ int main(int, char**)
   auto pool = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "pool", rm.getAllocator("HOST"));
 
-  // _umpire_tut_unwrap_strategy_start
+  // _sphinx_tag_tut_unwrap_strategy_start
   auto dynamic_pool =
       umpire::util::unwrap_allocator<umpire::strategy::DynamicPool>(pool);
-  // _umpire_tut_unwrap_strategy_end
+  // _sphinx_tag_tut_unwrap_strategy_end
 
   if (dynamic_pool) {
-    // _umpire_tut_call_coalesce_start
+    // _sphinx_tag_tut_call_coalesce_start
     dynamic_pool->coalesce();
-    // _umpire_tut_call_coalesce_end
+    // _sphinx_tag_tut_call_coalesce_end
   } else {
     UMPIRE_ERROR(pool.getName() << " is not a DynamicPool, cannot coalesce!");
   }

--- a/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
+++ b/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
@@ -24,6 +24,7 @@ int main(int, char**)
       umpire::strategy::DynamicPool::percent_releasable(75);
   // _umpire_tut_creat_heuristic_fun_end
 
+  // _umpire_tut_use_heuristic_fun_start
   //
   // Create a pool with an initial block size of 1 Kb and 1 Kb block size for
   // all subsequent allocations and with our previously created heuristic
@@ -31,8 +32,8 @@ int main(int, char**)
   //
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "HOST_POOL", allocator, 1024ul, 1024ul, 16, heuristic_function);
+  // _umpire_tut_use_heuristic_fun_end
 
-  // _umpire_tut_use_heuristic_fun_start
   //
   // Obtain a pointer to our specifi DynamicPool instance in order to see the
   // DynamicPool-specific statistics
@@ -40,7 +41,6 @@ int main(int, char**)
   auto dynamic_pool =
       umpire::util::unwrap_allocator<umpire::strategy::DynamicPool>(
           pooled_allocator);
-  // _umpire_tut_use_heuristic_fun_end
 
   void* a[4];
   for (int i = 0; i < 4; ++i)

--- a/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
+++ b/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
@@ -15,16 +15,16 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("HOST");
 
-  // _umpire_tut_creat_heuristic_fun_start
+  // _sphinx_tag_tut_creat_heuristic_fun_start
   //
   // Create a heuristic function that will return true to the DynamicPool
   // object when the threshold of releasable size to total size is 75%.
   //
   auto heuristic_function =
       umpire::strategy::DynamicPool::percent_releasable(75);
-  // _umpire_tut_creat_heuristic_fun_end
+  // _sphinx_tag_tut_creat_heuristic_fun_end
 
-  // _umpire_tut_use_heuristic_fun_start
+  // _sphinx_tag_tut_use_heuristic_fun_start
   //
   // Create a pool with an initial block size of 1 Kb and 1 Kb block size for
   // all subsequent allocations and with our previously created heuristic
@@ -32,7 +32,7 @@ int main(int, char**)
   //
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "HOST_POOL", allocator, 1024ul, 1024ul, 16, heuristic_function);
-  // _umpire_tut_use_heuristic_fun_end
+  // _sphinx_tag_tut_use_heuristic_fun_end
 
   //
   // Obtain a pointer to our specifi DynamicPool instance in order to see the

--- a/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
+++ b/examples/cookbook/recipe_dynamic_pool_heuristic.cpp
@@ -15,12 +15,14 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("HOST");
 
+  // _umpire_tut_creat_heuristic_fun_start
   //
   // Create a heuristic function that will return true to the DynamicPool
   // object when the threshold of releasable size to total size is 75%.
   //
   auto heuristic_function =
       umpire::strategy::DynamicPool::percent_releasable(75);
+  // _umpire_tut_creat_heuristic_fun_end
 
   //
   // Create a pool with an initial block size of 1 Kb and 1 Kb block size for
@@ -30,6 +32,7 @@ int main(int, char**)
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "HOST_POOL", allocator, 1024ul, 1024ul, 16, heuristic_function);
 
+  // _umpire_tut_use_heuristic_fun_start
   //
   // Obtain a pointer to our specifi DynamicPool instance in order to see the
   // DynamicPool-specific statistics
@@ -37,6 +40,7 @@ int main(int, char**)
   auto dynamic_pool =
       umpire::util::unwrap_allocator<umpire::strategy::DynamicPool>(
           pooled_allocator);
+  // _umpire_tut_use_heuristic_fun_end
 
   void* a[4];
   for (int i = 0; i < 4; ++i)

--- a/examples/cookbook/recipe_filesystem_memory_allocation.cpp
+++ b/examples/cookbook/recipe_filesystem_memory_allocation.cpp
@@ -10,12 +10,16 @@
 
 int main(int, char** argv)
 {
+  // _umpire_tut_file_allocate_start
   auto& rm = umpire::ResourceManager::getInstance();
   umpire::Allocator alloc = rm.getAllocator("FILE");
 
   std::size_t* A = (std::size_t*)alloc.allocate(sizeof(size_t));
+  // _umpire_tut_file_allocate_end
 
+  // _umpire_tut_file_deallocate_start
   alloc.deallocate(A);
+  // _umpire_tut_file_deallocate_end
 
   return 0;
 }

--- a/examples/cookbook/recipe_filesystem_memory_allocation.cpp
+++ b/examples/cookbook/recipe_filesystem_memory_allocation.cpp
@@ -10,16 +10,16 @@
 
 int main(int, char** argv)
 {
-  // _umpire_tut_file_allocate_start
+  // _sphinx_tag_tut_file_allocate_start
   auto& rm = umpire::ResourceManager::getInstance();
   umpire::Allocator alloc = rm.getAllocator("FILE");
 
   std::size_t* A = (std::size_t*)alloc.allocate(sizeof(size_t));
-  // _umpire_tut_file_allocate_end
+  // _sphinx_tag_tut_file_allocate_end
 
-  // _umpire_tut_file_deallocate_start
+  // _sphinx_tag_tut_file_deallocate_start
   alloc.deallocate(A);
-  // _umpire_tut_file_deallocate_end
+  // _sphinx_tag_tut_file_deallocate_end
 
   return 0;
 }

--- a/examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
+++ b/examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
@@ -16,11 +16,13 @@ int main(int, char**)
 {
   auto& rm = umpire::ResourceManager::getInstance();
 
+  // _umpire_tut_unwrap_start
   auto pool = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "pool", rm.getAllocator("HOST"));
 
   auto dynamic_pool =
       umpire::util::unwrap_allocator<umpire::strategy::DynamicPool>(pool);
+  // _umpire_tut_unwrap_end
 
   if (dynamic_pool == nullptr) {
     UMPIRE_ERROR(pool.getName() << " is not a DynamicPool");
@@ -28,9 +30,11 @@ int main(int, char**)
 
   auto ptr = pool.allocate(1024);
 
+  // _umpire_tut_get_info_start
   std::cout << "Largest available block in pool is "
             << dynamic_pool->getLargestAvailableBlock() << " bytes in size"
             << std::endl;
+  // _umpire_tut_get_info_end
 
   pool.deallocate(ptr);
 

--- a/examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
+++ b/examples/cookbook/recipe_get_largest_available_block_in_pool.cpp
@@ -16,13 +16,13 @@ int main(int, char**)
 {
   auto& rm = umpire::ResourceManager::getInstance();
 
-  // _umpire_tut_unwrap_start
+  // _sphinx_tag_tut_unwrap_start
   auto pool = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "pool", rm.getAllocator("HOST"));
 
   auto dynamic_pool =
       umpire::util::unwrap_allocator<umpire::strategy::DynamicPool>(pool);
-  // _umpire_tut_unwrap_end
+  // _sphinx_tag_tut_unwrap_end
 
   if (dynamic_pool == nullptr) {
     UMPIRE_ERROR(pool.getName() << " is not a DynamicPool");
@@ -30,11 +30,11 @@ int main(int, char**)
 
   auto ptr = pool.allocate(1024);
 
-  // _umpire_tut_get_info_start
+  // _sphinx_tag_tut_get_info_start
   std::cout << "Largest available block in pool is "
             << dynamic_pool->getLargestAvailableBlock() << " bytes in size"
             << std::endl;
-  // _umpire_tut_get_info_end
+  // _sphinx_tag_tut_get_info_end
 
   pool.deallocate(ptr);
 

--- a/examples/cookbook/recipe_move_to_managed.cpp
+++ b/examples/cookbook/recipe_move_to_managed.cpp
@@ -12,23 +12,25 @@ int main(int, char**)
   constexpr std::size_t SIZE = 1024;
 
   auto& rm = umpire::ResourceManager::getInstance();
+  // _umpire_tut_move_host_to_managed_start
   auto allocator = rm.getAllocator("HOST");
 
-  /*
-   * Allocate host data
-   */
+  //
+  // Allocate host data
+  //
   double* host_data =
       static_cast<double*>(allocator.allocate(SIZE * sizeof(double)));
 
-  /*
-   * Move data to unified memory
-   */
+  //
+  // Move data to unified memory
+  //
   auto um_allocator = rm.getAllocator("UM");
   double* um_data = static_cast<double*>(rm.move(host_data, um_allocator));
+  // _umpire_tut_move_host_to_managed_end
 
-  /*
-   * Deallocate um_data, host_data is already deallocated by move operation.
-   */
+  //
+  // Deallocate um_data, host_data is already deallocated by move operation.
+  //
   rm.deallocate(um_data);
 
   return 0;

--- a/examples/cookbook/recipe_move_to_managed.cpp
+++ b/examples/cookbook/recipe_move_to_managed.cpp
@@ -12,7 +12,6 @@ int main(int, char**)
   constexpr std::size_t SIZE = 1024;
 
   auto& rm = umpire::ResourceManager::getInstance();
-  // _sphinx_tag_tut_move_host_to_managed_start
   auto allocator = rm.getAllocator("HOST");
 
   //
@@ -25,6 +24,7 @@ int main(int, char**)
   // Move data to unified memory
   //
   auto um_allocator = rm.getAllocator("UM");
+  // _sphinx_tag_tut_move_host_to_managed_start
   double* um_data = static_cast<double*>(rm.move(host_data, um_allocator));
   // _sphinx_tag_tut_move_host_to_managed_end
 

--- a/examples/cookbook/recipe_move_to_managed.cpp
+++ b/examples/cookbook/recipe_move_to_managed.cpp
@@ -12,7 +12,7 @@ int main(int, char**)
   constexpr std::size_t SIZE = 1024;
 
   auto& rm = umpire::ResourceManager::getInstance();
-  // _umpire_tut_move_host_to_managed_start
+  // _sphinx_tag_tut_move_host_to_managed_start
   auto allocator = rm.getAllocator("HOST");
 
   //
@@ -26,7 +26,7 @@ int main(int, char**)
   //
   auto um_allocator = rm.getAllocator("UM");
   double* um_data = static_cast<double*>(rm.move(host_data, um_allocator));
-  // _umpire_tut_move_host_to_managed_end
+  // _sphinx_tag_tut_move_host_to_managed_end
 
   //
   // Deallocate um_data, host_data is already deallocated by move operation.

--- a/examples/cookbook/recipe_no_introspection.cpp
+++ b/examples/cookbook/recipe_no_introspection.cpp
@@ -20,19 +20,19 @@ int main(int, char**)
   //
   // Create a pool with introspection disabled (can improve performance)
   //
-  // _umpire_tut_nointro_start
+  // _sphinx_tag_tut_nointro_start
   auto pooled_allocator =
       rm.makeAllocator<umpire::strategy::DynamicPool, false>(
           "NO_INTROSPECTION_POOL", allocator);
-  // _umpire_tut_nointro_end
+  // _sphinx_tag_tut_nointro_end
 
   void* data = pooled_allocator.allocate(1024);
 
-  // _umpire_tut_getsize_start
+  // _sphinx_tag_tut_getsize_start
   std::cout << "Pool has allocated " << pooled_allocator.getActualSize()
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
-  // _umpire_tut_getsize_end
+  // _sphinx_tag_tut_getsize_end
 
   pooled_allocator.deallocate(data);
 

--- a/examples/cookbook/recipe_no_introspection.cpp
+++ b/examples/cookbook/recipe_no_introspection.cpp
@@ -17,18 +17,22 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("HOST");
 
-  /*
-   * Create a pool with introspection disabled (can improve performance)
-   */
+  //
+  // Create a pool with introspection disabled (can improve performance)
+  //
+  // _umpire_tut_nointro_start
   auto pooled_allocator =
       rm.makeAllocator<umpire::strategy::DynamicPool, false>(
           "NO_INTROSPECTION_POOL", allocator);
+  // _umpire_tut_nointro_end
 
   void* data = pooled_allocator.allocate(1024);
 
+  // _umpire_tut_getsize_start
   std::cout << "Pool has allocated " << pooled_allocator.getActualSize()
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
+  // _umpire_tut_getsize_end
 
   pooled_allocator.deallocate(data);
 

--- a/examples/cookbook/recipe_pinned_pool.F
+++ b/examples/cookbook/recipe_pinned_pool.F
@@ -15,7 +15,7 @@ program umpire_f_pinned_pool
       type(UmpireAllocator) pinned_pool
       type(UmpireResourceManager) rm
 
-      ! _umpire_tut_pinned_fortran_start
+      ! _sphinx_tag_tut_pinned_fortran_start
       rm = rm%get_instance()
       base_allocator = rm%get_allocator_by_name("PINNED")
 
@@ -23,7 +23,7 @@ program umpire_f_pinned_pool
                                            base_allocator, &
                                            512_8*1024_8, &
                                            1024_8)
-      ! _umpire_tut_pinned_fortran_end
+      ! _sphinx_tag_tut_pinned_fortran_end
 
       call pinned_pool%allocate(array, [10])
 end program umpire_f_pinned_pool

--- a/examples/cookbook/recipe_pinned_pool.F
+++ b/examples/cookbook/recipe_pinned_pool.F
@@ -15,6 +15,7 @@ program umpire_f_pinned_pool
       type(UmpireAllocator) pinned_pool
       type(UmpireResourceManager) rm
 
+      ! _umpire_tut_pinned_fortran_start
       rm = rm%get_instance()
       base_allocator = rm%get_allocator_by_name("PINNED")
 
@@ -22,6 +23,7 @@ program umpire_f_pinned_pool
                                            base_allocator, &
                                            512_8*1024_8, &
                                            1024_8)
+      ! _umpire_tut_pinned_fortran_end
 
       call pinned_pool%allocate(array, [10])
 end program umpire_f_pinned_pool

--- a/examples/cookbook/recipe_pool_advice.cpp
+++ b/examples/cookbook/recipe_pool_advice.cpp
@@ -18,20 +18,22 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("UM");
 
-  /*
-   * Create an allocator that applied "PREFFERED_LOCATION" advice to set the
-   * GPU as the preferred location.
-   */
+  // _umpire_tut_pool_advice_start
+  //
+  // Create an allocator that applied "PREFFERED_LOCATION" advice to set the
+  // GPU as the preferred location.
+  //
   auto preferred_location_allocator =
       rm.makeAllocator<umpire::strategy::AllocationAdvisor>(
           "preferred_location_device", allocator, "PREFERRED_LOCATION");
 
-  /*
-   * Create a pool using the preferred_location_allocator. This makes all
-   * allocations in the pool have the same preferred location, the GPU.
-   */
+  //
+  // Create a pool using the preferred_location_allocator. This makes all
+  // allocations in the pool have the same preferred location, the GPU.
+  //
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "GPU_POOL", preferred_location_allocator);
+  // _umpire_tut_pool_advice_end
 
   UMPIRE_USE_VAR(pooled_allocator);
 

--- a/examples/cookbook/recipe_pool_advice.cpp
+++ b/examples/cookbook/recipe_pool_advice.cpp
@@ -18,7 +18,7 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("UM");
 
-  // _umpire_tut_pool_advice_start
+  // _sphinx_tag_tut_pool_advice_start
   //
   // Create an allocator that applied "PREFFERED_LOCATION" advice to set the
   // GPU as the preferred location.
@@ -33,7 +33,7 @@ int main(int, char**)
   //
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "GPU_POOL", preferred_location_allocator);
-  // _umpire_tut_pool_advice_end
+  // _sphinx_tag_tut_pool_advice_end
 
   UMPIRE_USE_VAR(pooled_allocator);
 

--- a/examples/cookbook/recipe_shrink.cpp
+++ b/examples/cookbook/recipe_shrink.cpp
@@ -17,11 +17,14 @@ int main(int, char**)
 
   auto allocator = rm.getAllocator("DEVICE");
 
-  /*
-   * Create a 4 Gb pool and reserve one word (to maintain aligment)
-   */
+  //
+  // Create a 4 Gb pool and reserve one word (to maintain aligment)
+  //
+  // _umpire_tut_create_pool_start
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "GPU_POOL", allocator, 4ul * 1024ul * 1024ul * 1024ul + 1);
+  // _umpire_tut_create_pool_end
+
   void* hold = pooled_allocator.allocate(64);
   UMPIRE_USE_VAR(hold);
 
@@ -29,23 +32,27 @@ int main(int, char**)
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
 
-  /*
-   * Grow pool to ~12 by grabbing a 8Gb chunk
-   */
+  //
+  // Grow pool to ~12 by grabbing a 8Gb chunk
+  //
+  // _umpire_tut_grow_pool_start
   void* grow = pooled_allocator.allocate(8ul * 1024ul * 1024ul * 1024ul);
   pooled_allocator.deallocate(grow);
 
   std::cout << "Pool has allocated " << pooled_allocator.getActualSize()
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
+  // _umpire_tut_grow_pool_end
 
-  /*
-   * Shrink pool back to ~4Gb
-   */
+  //
+  // Shrink pool back to ~4Gb
+  //
+  // _umpire_tut_shrink_pool_back_start
   pooled_allocator.release();
   std::cout << "Pool has allocated " << pooled_allocator.getActualSize()
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
+  // _umpire_tut_shrink_pool_back_end
 
   return 0;
 }

--- a/examples/cookbook/recipe_shrink.cpp
+++ b/examples/cookbook/recipe_shrink.cpp
@@ -20,10 +20,10 @@ int main(int, char**)
   //
   // Create a 4 Gb pool and reserve one word (to maintain aligment)
   //
-  // _umpire_tut_create_pool_start
+  // _sphinx_tag_tut_create_pool_start
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       "GPU_POOL", allocator, 4ul * 1024ul * 1024ul * 1024ul + 1);
-  // _umpire_tut_create_pool_end
+  // _sphinx_tag_tut_create_pool_end
 
   void* hold = pooled_allocator.allocate(64);
   UMPIRE_USE_VAR(hold);
@@ -35,24 +35,24 @@ int main(int, char**)
   //
   // Grow pool to ~12 by grabbing a 8Gb chunk
   //
-  // _umpire_tut_grow_pool_start
+  // _sphinx_tag_tut_grow_pool_start
   void* grow = pooled_allocator.allocate(8ul * 1024ul * 1024ul * 1024ul);
   pooled_allocator.deallocate(grow);
 
   std::cout << "Pool has allocated " << pooled_allocator.getActualSize()
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
-  // _umpire_tut_grow_pool_end
+  // _sphinx_tag_tut_grow_pool_end
 
   //
   // Shrink pool back to ~4Gb
   //
-  // _umpire_tut_shrink_pool_back_start
+  // _sphinx_tag_tut_shrink_pool_back_start
   pooled_allocator.release();
   std::cout << "Pool has allocated " << pooled_allocator.getActualSize()
             << " bytes of memory. " << pooled_allocator.getCurrentSize()
             << " bytes are used" << std::endl;
-  // _umpire_tut_shrink_pool_back_end
+  // _sphinx_tag_tut_shrink_pool_back_end
 
   return 0;
 }

--- a/examples/cookbook/recipe_thread_safe.cpp
+++ b/examples/cookbook/recipe_thread_safe.cpp
@@ -11,7 +11,7 @@
 
 int main(int, char**)
 {
-  // _umpire_tut_thread_safe_start
+  // _sphinx_tag_tut_thread_safe_start
   auto& rm = umpire::ResourceManager::getInstance();
 
   auto pool = rm.makeAllocator<umpire::strategy::DynamicPool>(
@@ -20,7 +20,7 @@ int main(int, char**)
   auto thread_safe_pool =
       rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>(
           "thread_safe_pool", pool);
-  // _umpire_tut_thread_safe_end
+  // _sphinx_tag_tut_thread_safe_end
 
   auto allocation = thread_safe_pool.allocate(256);
   thread_safe_pool.deallocate(allocation);

--- a/examples/cookbook/recipe_thread_safe.cpp
+++ b/examples/cookbook/recipe_thread_safe.cpp
@@ -11,6 +11,7 @@
 
 int main(int, char**)
 {
+  // _umpire_tut_thread_safe_start
   auto& rm = umpire::ResourceManager::getInstance();
 
   auto pool = rm.makeAllocator<umpire::strategy::DynamicPool>(
@@ -19,6 +20,7 @@ int main(int, char**)
   auto thread_safe_pool =
       rm.makeAllocator<umpire::strategy::ThreadSafeAllocator>(
           "thread_safe_pool", pool);
+  // _umpire_tut_thread_safe_end
 
   auto allocation = thread_safe_pool.allocate(256);
   thread_safe_pool.deallocate(allocation);

--- a/examples/tutorial/c/tut_allocator.c
+++ b/examples/tutorial/c/tut_allocator.c
@@ -11,21 +11,21 @@
 #define SIZE 1024
 
 int main() {
-  /* _umpire_tut_c_get_allocator_start */
+  /* _sphinx_tag_tut_c_get_allocator_start */
   umpire_resourcemanager rm;
   umpire_resourcemanager_get_instance(&rm);
 
   umpire_allocator allocator;
   umpire_resourcemanager_get_allocator_by_name(&rm, "HOST", &allocator);
-  /* _umpire_tut_c_get_allocator_end */
+  /* _sphinx_tag_tut_c_get_allocator_end */
 
-  /* _umpire_tut_c_allocate_start */
+  /* _sphinx_tag_tut_c_allocate_start */
   double* data = (double*) umpire_allocator_allocate(&allocator, SIZE*sizeof(double));
 
   printf("Allocated %lu bytes using the %s allocator...", (SIZE*sizeof(double)), umpire_allocator_get_name(&allocator));
 
   umpire_allocator_deallocate(&allocator, data);
-  /* _umpire_tut_c_allocate_end */
+  /* _sphinx_tag_tut_c_allocate_end */
 
   printf("deallocated.\n");
 

--- a/examples/tutorial/c/tut_allocator.c
+++ b/examples/tutorial/c/tut_allocator.c
@@ -11,17 +11,21 @@
 #define SIZE 1024
 
 int main() {
+  /* _umpire_tut_c_get_allocator_start */
   umpire_resourcemanager rm;
   umpire_resourcemanager_get_instance(&rm);
 
   umpire_allocator allocator;
   umpire_resourcemanager_get_allocator_by_name(&rm, "HOST", &allocator);
+  /* _umpire_tut_c_get_allocator_end */
 
+  /* _umpire_tut_c_allocate_start */
   double* data = (double*) umpire_allocator_allocate(&allocator, SIZE*sizeof(double));
 
   printf("Allocated %lu bytes using the %s allocator...", (SIZE*sizeof(double)), umpire_allocator_get_name(&allocator));
 
   umpire_allocator_deallocate(&allocator, data);
+  /* _umpire_tut_c_allocate_end */
 
   printf("deallocated.\n");
 

--- a/examples/tutorial/c/tut_pool.c
+++ b/examples/tutorial/c/tut_pool.c
@@ -12,7 +12,7 @@
 
 int main()
 {
-  /* _umpire_tut_pool_create_start */
+  /* _sphinx_tag_tut_pool_create_start */
   umpire_resourcemanager rm;
   umpire_resourcemanager_get_instance(&rm);
 
@@ -21,16 +21,16 @@ int main()
 
   umpire_allocator pool;
   umpire_resourcemanager_make_allocator_pool(&rm, "pool", allocator, 1024*512, 512, &pool);
-  /* _umpire_tut_pool_create_end */
+  /* _sphinx_tag_tut_pool_create_end */
 
-  /* _umpire_tut_allocate_start */
+  /* _sphinx_tag_tut_allocate_start */
   double* data = (double*) umpire_allocator_allocate(&pool, SIZE*sizeof(double));
 
   printf("Allocated %lu bytes using the %s allocator...", 
       (SIZE*sizeof(double)), umpire_allocator_get_name(&allocator));
 
   umpire_allocator_deallocate(&allocator, data);
-  /* _umpire_tut_allocate_end */
+  /* _sphinx_tag_tut_allocate_end */
 
   printf("deallocated.\n");
 

--- a/examples/tutorial/c/tut_pool.c
+++ b/examples/tutorial/c/tut_pool.c
@@ -12,6 +12,7 @@
 
 int main()
 {
+  /* _umpire_tut_pool_create_start */
   umpire_resourcemanager rm;
   umpire_resourcemanager_get_instance(&rm);
 
@@ -20,13 +21,16 @@ int main()
 
   umpire_allocator pool;
   umpire_resourcemanager_make_allocator_pool(&rm, "pool", allocator, 1024*512, 512, &pool);
+  /* _umpire_tut_pool_create_end */
 
+  /* _umpire_tut_allocate_start */
   double* data = (double*) umpire_allocator_allocate(&pool, SIZE*sizeof(double));
 
   printf("Allocated %lu bytes using the %s allocator...", 
       (SIZE*sizeof(double)), umpire_allocator_get_name(&allocator));
 
   umpire_allocator_deallocate(&allocator, data);
+  /* _umpire_tut_allocate_end */
 
   printf("deallocated.\n");
 

--- a/examples/tutorial/c/tut_resources.c
+++ b/examples/tutorial/c/tut_resources.c
@@ -12,14 +12,17 @@
 
 void allocate_and_deallocate(const char* resource)
 {
+  /* _umpire_tut_create_allocator_start */
   umpire_resourcemanager rm;
   umpire_resourcemanager_get_instance(&rm);
 
   umpire_allocator allocator;
   umpire_resourcemanager_get_allocator_by_name(&rm, resource, &allocator);
+  /* _umpire_tut_create_allocator_end */
 
+  /* _umpire_tut_allocate_start */
   double* data = (double*) umpire_allocator_allocate(&allocator, SIZE*sizeof(double));
-
+  /* _umpire_tut_allocate_end */
 
   printf("Allocated %lu bytes using the %s allocator...",
       (SIZE*sizeof(double)), umpire_allocator_get_name(&allocator));
@@ -31,6 +34,7 @@ void allocate_and_deallocate(const char* resource)
 
 int main()
 {
+  /* _umpire_tut_resource_types_start */
   allocate_and_deallocate("HOST");
 
 #if defined(UMPIRE_ENABLE_CUDA)
@@ -42,6 +46,7 @@ int main()
   allocate_and_deallocate("DEVICE");
   allocate_and_deallocate("PINNED");
 #endif
+  /* _umpire_tut_resource_types_end */
 
   return 0;
 }

--- a/examples/tutorial/c/tut_resources.c
+++ b/examples/tutorial/c/tut_resources.c
@@ -12,17 +12,17 @@
 
 void allocate_and_deallocate(const char* resource)
 {
-  /* _umpire_tut_create_allocator_start */
+  /* _sphinx_tag_tut_create_allocator_start */
   umpire_resourcemanager rm;
   umpire_resourcemanager_get_instance(&rm);
 
   umpire_allocator allocator;
   umpire_resourcemanager_get_allocator_by_name(&rm, resource, &allocator);
-  /* _umpire_tut_create_allocator_end */
+  /* _sphinx_tag_tut_create_allocator_end */
 
-  /* _umpire_tut_allocate_start */
+  /* _sphinx_tag_tut_allocate_start */
   double* data = (double*) umpire_allocator_allocate(&allocator, SIZE*sizeof(double));
-  /* _umpire_tut_allocate_end */
+  /* _sphinx_tag_tut_allocate_end */
 
   printf("Allocated %lu bytes using the %s allocator...",
       (SIZE*sizeof(double)), umpire_allocator_get_name(&allocator));
@@ -34,7 +34,7 @@ void allocate_and_deallocate(const char* resource)
 
 int main()
 {
-  /* _umpire_tut_resource_types_start */
+  /* _sphinx_tag_tut_resource_types_start */
   allocate_and_deallocate("HOST");
 
 #if defined(UMPIRE_ENABLE_CUDA)
@@ -46,7 +46,7 @@ int main()
   allocate_and_deallocate("DEVICE");
   allocate_and_deallocate("PINNED");
 #endif
-  /* _umpire_tut_resource_types_end */
+  /* _sphinx_tag_tut_resource_types_end */
 
   return 0;
 }

--- a/examples/tutorial/fortran/tut_allocator.f
+++ b/examples/tutorial/fortran/tut_allocator.f
@@ -14,18 +14,18 @@ program fortran_test
       type(UmpireAllocator) allocator
       type(UmpireResourceManager) rm
 
-      ! _umpire_tut_get_allocator_start
+      ! _sphinx_tag_tut_get_allocator_start
       rm = rm%get_instance()
       allocator = rm%get_allocator_by_id(0)
-      ! _umpire_tut_get_allocator_end
+      ! _sphinx_tag_tut_get_allocator_end
 
-      ! _umpire_tut_allocate_start
+      ! _sphinx_tag_tut_allocate_start
       call allocator%allocate(array, [ 10 ])
 
       write(10,*) "Allocated array of size ", 10
 
       call allocator%deallocate(array)
-      ! _umpire_tut_allocate_end
+      ! _sphinx_tag_tut_allocate_end
 
       write(10,*) "deallocated."
 end program fortran_test

--- a/examples/tutorial/fortran/tut_allocator.f
+++ b/examples/tutorial/fortran/tut_allocator.f
@@ -14,14 +14,18 @@ program fortran_test
       type(UmpireAllocator) allocator
       type(UmpireResourceManager) rm
 
+      ! _umpire_tut_get_allocator_start
       rm = rm%get_instance()
       allocator = rm%get_allocator_by_id(0)
+      ! _umpire_tut_get_allocator_end
 
+      ! _umpire_tut_allocate_start
       call allocator%allocate(array, [ 10 ])
 
       write(10,*) "Allocated array of size ", 10
 
       call allocator%deallocate(array)
+      ! _umpire_tut_allocate_end
 
       write(10,*) "deallocated."
 end program fortran_test

--- a/examples/tutorial/tut_allocator.cpp
+++ b/examples/tutorial/tut_allocator.cpp
@@ -9,11 +9,14 @@
 
 int main(int, char**)
 {
-  constexpr std::size_t SIZE = 1024;
-
+  // _umpire_tut_get_allocator_start
   auto& rm = umpire::ResourceManager::getInstance();
 
   umpire::Allocator allocator = rm.getAllocator("HOST");
+  // _umpire_tut_get_allocator_end
+
+  // _umpire_tut_de_allocate_start
+  constexpr std::size_t SIZE = 1024;
 
   double* data =
       static_cast<double*>(allocator.allocate(SIZE * sizeof(double)));
@@ -22,8 +25,10 @@ int main(int, char**)
             << allocator.getName() << " allocator...";
 
   allocator.deallocate(data);
+  // _umpire_tut_de_allocate_end
 
   std::cout << " deallocated." << std::endl;
 
   return 0;
 }
+

--- a/examples/tutorial/tut_allocator.cpp
+++ b/examples/tutorial/tut_allocator.cpp
@@ -9,13 +9,13 @@
 
 int main(int, char**)
 {
-  // _umpire_tut_get_allocator_start
+  // _sphinx_tag_tut_get_allocator_start
   auto& rm = umpire::ResourceManager::getInstance();
 
   umpire::Allocator allocator = rm.getAllocator("HOST");
-  // _umpire_tut_get_allocator_end
+  // _sphinx_tag_tut_get_allocator_end
 
-  // _umpire_tut_de_allocate_start
+  // _sphinx_tag_tut_de_allocate_start
   constexpr std::size_t SIZE = 1024;
 
   double* data =
@@ -25,7 +25,7 @@ int main(int, char**)
             << allocator.getName() << " allocator...";
 
   allocator.deallocate(data);
-  // _umpire_tut_de_allocate_end
+  // _sphinx_tag_tut_de_allocate_end
 
   std::cout << " deallocated." << std::endl;
 

--- a/examples/tutorial/tut_allocator.cpp
+++ b/examples/tutorial/tut_allocator.cpp
@@ -9,23 +9,25 @@
 
 int main(int, char**)
 {
-  // _sphinx_tag_tut_get_allocator_start
   auto& rm = umpire::ResourceManager::getInstance();
 
+  // _sphinx_tag_tut_get_allocator_start
   umpire::Allocator allocator = rm.getAllocator("HOST");
   // _sphinx_tag_tut_get_allocator_end
 
-  // _sphinx_tag_tut_de_allocate_start
   constexpr std::size_t SIZE = 1024;
 
+  // _sphinx_tag_tut_allocate_start
   double* data =
       static_cast<double*>(allocator.allocate(SIZE * sizeof(double)));
+  // _sphinx_tag_tut_allocate_end
 
   std::cout << "Allocated " << (SIZE * sizeof(double)) << " bytes using the "
             << allocator.getName() << " allocator...";
 
+  // _sphinx_tag_tut_deallocate_start
   allocator.deallocate(data);
-  // _sphinx_tag_tut_de_allocate_end
+  // _sphinx_tag_tut_deallocate_end
 
   std::cout << " deallocated." << std::endl;
 

--- a/examples/tutorial/tut_copy.cpp
+++ b/examples/tutorial/tut_copy.cpp
@@ -16,9 +16,9 @@ void copy_data(double* source_data, std::size_t size,
   double* dest_data =
       static_cast<double*>(dest_allocator.allocate(size * sizeof(double)));
 
-  // _umpire_tut_copy_start
+  // _sphinx_tag_tut_copy_start
   rm.copy(dest_data, source_data);
-  // _umpire_tut_copy_end
+  // _sphinx_tag_tut_copy_end
 
   std::cout << "Copied source data (" << source_data << ") to destination "
             << destination << " (" << dest_data << ")" << std::endl;

--- a/examples/tutorial/tut_copy.cpp
+++ b/examples/tutorial/tut_copy.cpp
@@ -16,7 +16,9 @@ void copy_data(double* source_data, std::size_t size,
   double* dest_data =
       static_cast<double*>(dest_allocator.allocate(size * sizeof(double)));
 
+  // _umpire_tut_copy_start
   rm.copy(dest_data, source_data);
+  // _umpire_tut_copy_end
 
   std::cout << "Copied source data (" << source_data << ") to destination "
             << destination << " (" << dest_data << ")" << std::endl;

--- a/examples/tutorial/tut_dynamic_pool_1.cpp
+++ b/examples/tutorial/tut_dynamic_pool_1.cpp
@@ -14,12 +14,12 @@ void allocate_and_deallocate_pool(const std::string& resource)
 
   auto allocator = rm.getAllocator(resource);
 
-  // _umpire_tut_makepool_start
+  // _sphinx_tag_tut_makepool_start
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       resource + "_pool", allocator);
-  // _umpire_tut_makepool_end
+  // _sphinx_tag_tut_makepool_end
 
-  // _umpire_tut_allocate_start
+  // _sphinx_tag_tut_allocate_start
   constexpr std::size_t SIZE = 1024;
 
   double* data =
@@ -29,14 +29,14 @@ void allocate_and_deallocate_pool(const std::string& resource)
             << pooled_allocator.getName() << " allocator...";
 
   pooled_allocator.deallocate(data);
-  // _umpire_tut_allocate_end
+  // _sphinx_tag_tut_allocate_end
 
   std::cout << " deallocated." << std::endl;
 }
 
 int main(int, char**)
 {
-  // _umpire_tut_anyallocator_start
+  // _sphinx_tag_tut_anyallocator_start
   allocate_and_deallocate_pool("HOST");
 
 #if defined(UMPIRE_ENABLE_CUDA)
@@ -48,7 +48,7 @@ int main(int, char**)
   allocate_and_deallocate_pool("DEVICE");
   allocate_and_deallocate_pool("PINNED");
 #endif
-  // _umpire_tut_anyallocator_end
+  // _sphinx_tag_tut_anyallocator_end
 
   return 0;
 }

--- a/examples/tutorial/tut_dynamic_pool_1.cpp
+++ b/examples/tutorial/tut_dynamic_pool_1.cpp
@@ -19,17 +19,19 @@ void allocate_and_deallocate_pool(const std::string& resource)
       resource + "_pool", allocator);
   // _sphinx_tag_tut_makepool_end
 
-  // _sphinx_tag_tut_allocate_start
   constexpr std::size_t SIZE = 1024;
 
+  // _sphinx_tag_tut_allocate_start
   double* data =
       static_cast<double*>(pooled_allocator.allocate(SIZE * sizeof(double)));
+  // _sphinx_tag_tut_allocate_end
 
   std::cout << "Allocated " << (SIZE * sizeof(double)) << " bytes using the "
             << pooled_allocator.getName() << " allocator...";
 
+  // _sphinx_tag_tut_deallocate_start
   pooled_allocator.deallocate(data);
-  // _sphinx_tag_tut_allocate_end
+  // _sphinx_tag_tut_deallocate_end
 
   std::cout << " deallocated." << std::endl;
 }

--- a/examples/tutorial/tut_dynamic_pool_1.cpp
+++ b/examples/tutorial/tut_dynamic_pool_1.cpp
@@ -10,14 +10,17 @@
 
 void allocate_and_deallocate_pool(const std::string& resource)
 {
-  constexpr std::size_t SIZE = 1024;
-
   auto& rm = umpire::ResourceManager::getInstance();
 
   auto allocator = rm.getAllocator(resource);
 
+  // _umpire_tut_makepool_start
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       resource + "_pool", allocator);
+  // _umpire_tut_makepool_end
+
+  // _umpire_tut_allocate_start
+  constexpr std::size_t SIZE = 1024;
 
   double* data =
       static_cast<double*>(pooled_allocator.allocate(SIZE * sizeof(double)));
@@ -26,12 +29,14 @@ void allocate_and_deallocate_pool(const std::string& resource)
             << pooled_allocator.getName() << " allocator...";
 
   pooled_allocator.deallocate(data);
+  // _umpire_tut_allocate_end
 
   std::cout << " deallocated." << std::endl;
 }
 
 int main(int, char**)
 {
+  // _umpire_tut_anyallocator_start
   allocate_and_deallocate_pool("HOST");
 
 #if defined(UMPIRE_ENABLE_CUDA)
@@ -43,6 +48,7 @@ int main(int, char**)
   allocate_and_deallocate_pool("DEVICE");
   allocate_and_deallocate_pool("PINNED");
 #endif
+  // _umpire_tut_anyallocator_end
 
   return 0;
 }

--- a/examples/tutorial/tut_dynamic_pool_2.cpp
+++ b/examples/tutorial/tut_dynamic_pool_2.cpp
@@ -18,11 +18,11 @@ void allocate_and_deallocate_pool(const std::string& resource,
 
   auto allocator = rm.getAllocator(resource);
 
-  // _umpire_tut_allocator_tuning_start
+  // _sphinx_tag_tut_allocator_tuning_start
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       resource + "_pool", allocator, initial_size, /* default = 512Mb*/
       min_block_size /* default = 1Mb */);
-  // _umpire_tut_allocator_tuning_end
+  // _sphinx_tag_tut_allocator_tuning_end
 
   double* data =
       static_cast<double*>(pooled_allocator.allocate(SIZE * sizeof(double)));
@@ -37,7 +37,7 @@ void allocate_and_deallocate_pool(const std::string& resource,
 
 int main(int, char**)
 {
-  // _umpire_tut_device_sized_pool_start
+  // _sphinx_tag_tut_device_sized_pool_start
   allocate_and_deallocate_pool("HOST", 65536, 512);
 #if defined(UMPIRE_ENABLE_CUDA)
   allocate_and_deallocate_pool("DEVICE", (1024 * 1024 * 1024), (1024 * 1024));
@@ -48,7 +48,7 @@ int main(int, char**)
   allocate_and_deallocate_pool("DEVICE", (1024 * 1024 * 1024), (1024 * 1024));
   allocate_and_deallocate_pool("PINNED", (1024 * 16), 1024);
 #endif
-  // _umpire_tut_device_sized_pool_end
+  // _sphinx_tag_tut_device_sized_pool_end
 
   return 0;
 }

--- a/examples/tutorial/tut_dynamic_pool_2.cpp
+++ b/examples/tutorial/tut_dynamic_pool_2.cpp
@@ -18,9 +18,11 @@ void allocate_and_deallocate_pool(const std::string& resource,
 
   auto allocator = rm.getAllocator(resource);
 
+  // _umpire_tut_allocator_tuning_start
   auto pooled_allocator = rm.makeAllocator<umpire::strategy::DynamicPool>(
       resource + "_pool", allocator, initial_size, /* default = 512Mb*/
       min_block_size /* default = 1Mb */);
+  // _umpire_tut_allocator_tuning_end
 
   double* data =
       static_cast<double*>(pooled_allocator.allocate(SIZE * sizeof(double)));
@@ -35,6 +37,7 @@ void allocate_and_deallocate_pool(const std::string& resource,
 
 int main(int, char**)
 {
+  // _umpire_tut_device_sized_pool_start
   allocate_and_deallocate_pool("HOST", 65536, 512);
 #if defined(UMPIRE_ENABLE_CUDA)
   allocate_and_deallocate_pool("DEVICE", (1024 * 1024 * 1024), (1024 * 1024));
@@ -45,6 +48,7 @@ int main(int, char**)
   allocate_and_deallocate_pool("DEVICE", (1024 * 1024 * 1024), (1024 * 1024));
   allocate_and_deallocate_pool("PINNED", (1024 * 16), 1024);
 #endif
+  // _umpire_tut_device_sized_pool_end
 
   return 0;
 }

--- a/examples/tutorial/tut_introspection.cpp
+++ b/examples/tutorial/tut_introspection.cpp
@@ -36,20 +36,20 @@ int main(int, char**)
     std::cout << "Allocated " << (SIZE * sizeof(double)) << " bytes using the "
               << allocator.getName() << " allocator." << std::endl;
 
-    // _umpire_tut_getallocator_start
+    // _sphinx_tag_tut_getallocator_start
     auto found_allocator = rm.getAllocator(data);
-    // _umpire_tut_getallocator_end
+    // _sphinx_tag_tut_getallocator_end
 
-    // _umpire_tut_getinfo_start
+    // _sphinx_tag_tut_getinfo_start
     std::cout << "According to the ResourceManager, the Allocator used is "
               << found_allocator.getName() << ", which has the Platform "
               << static_cast<int>(found_allocator.getPlatform()) << std::endl;
-    // _umpire_tut_getinfo_end
+    // _sphinx_tag_tut_getinfo_end
 
-    // _umpire_tut_getsize_start
+    // _sphinx_tag_tut_getsize_start
     std::cout << "The size of the allocation is << "
               << found_allocator.getSize(data) << std::endl;
-    // _umpire_tut_getsize_end
+    // _sphinx_tag_tut_getsize_end
 
     allocator.deallocate(data);
   }

--- a/examples/tutorial/tut_introspection.cpp
+++ b/examples/tutorial/tut_introspection.cpp
@@ -36,14 +36,20 @@ int main(int, char**)
     std::cout << "Allocated " << (SIZE * sizeof(double)) << " bytes using the "
               << allocator.getName() << " allocator." << std::endl;
 
+    // _umpire_tut_getallocator_start
     auto found_allocator = rm.getAllocator(data);
+    // _umpire_tut_getallocator_end
 
+    // _umpire_tut_getinfo_start
     std::cout << "According to the ResourceManager, the Allocator used is "
               << found_allocator.getName() << ", which has the Platform "
               << static_cast<int>(found_allocator.getPlatform()) << std::endl;
+    // _umpire_tut_getinfo_end
 
+    // _umpire_tut_getsize_start
     std::cout << "The size of the allocation is << "
               << found_allocator.getSize(data) << std::endl;
+    // _umpire_tut_getsize_end
 
     allocator.deallocate(data);
   }

--- a/examples/tutorial/tut_memset.cpp
+++ b/examples/tutorial/tut_memset.cpp
@@ -36,7 +36,9 @@ int main(int, char**)
     std::cout << "Allocated " << (SIZE * sizeof(double)) << " bytes using the "
               << allocator.getName() << " allocator." << std::endl;
 
+    // _umpire_tut_memset_start
     rm.memset(data, 0);
+    // _umpire_tut_memset_end
 
     std::cout << "Set data from " << destination << " (" << data << ") to 0."
               << std::endl;

--- a/examples/tutorial/tut_memset.cpp
+++ b/examples/tutorial/tut_memset.cpp
@@ -36,9 +36,9 @@ int main(int, char**)
     std::cout << "Allocated " << (SIZE * sizeof(double)) << " bytes using the "
               << allocator.getName() << " allocator." << std::endl;
 
-    // _umpire_tut_memset_start
+    // _sphinx_tag_tut_memset_start
     rm.memset(data, 0);
-    // _umpire_tut_memset_end
+    // _sphinx_tag_tut_memset_end
 
     std::cout << "Set data from " << destination << " (" << data << ") to 0."
               << std::endl;

--- a/examples/tutorial/tut_move.cpp
+++ b/examples/tutorial/tut_move.cpp
@@ -14,8 +14,10 @@ double* move_data(double* source_data, const std::string& destination)
 
   std::cout << "Moved source data (" << source_data << ") to destination ";
 
+  // _umpire_tut_move_start
   double* dest_data =
       static_cast<double*>(rm.move(source_data, dest_allocator));
+  // _umpire_tut_move_end
 
   std::cout << destination << " (" << dest_data << ")" << std::endl;
 

--- a/examples/tutorial/tut_move.cpp
+++ b/examples/tutorial/tut_move.cpp
@@ -14,10 +14,10 @@ double* move_data(double* source_data, const std::string& destination)
 
   std::cout << "Moved source data (" << source_data << ") to destination ";
 
-  // _umpire_tut_move_start
+  // _sphinx_tag_tut_move_start
   double* dest_data =
       static_cast<double*>(rm.move(source_data, dest_allocator));
-  // _umpire_tut_move_end
+  // _sphinx_tag_tut_move_end
 
   std::cout << destination << " (" << dest_data << ")" << std::endl;
 

--- a/examples/tutorial/tut_reallocate.cpp
+++ b/examples/tutorial/tut_reallocate.cpp
@@ -40,9 +40,9 @@ int main(int, char**)
     std::cout << "Reallocating data (" << data << ") to size "
               << REALLOCATED_SIZE << "...";
 
-    // _umpire_tut_realloc_start
+    // _sphinx_tag_tut_realloc_start
     data = static_cast<double*>(rm.reallocate(data, REALLOCATED_SIZE));
-    // _umpire_tut_realloc_end
+    // _sphinx_tag_tut_realloc_end
 
     std::cout << "done.  Reallocated data (" << data << ")" << std::endl;
 

--- a/examples/tutorial/tut_reallocate.cpp
+++ b/examples/tutorial/tut_reallocate.cpp
@@ -40,7 +40,9 @@ int main(int, char**)
     std::cout << "Reallocating data (" << data << ") to size "
               << REALLOCATED_SIZE << "...";
 
+    // _umpire_tut_realloc_start
     data = static_cast<double*>(rm.reallocate(data, REALLOCATED_SIZE));
+    // _umpire_tut_realloc_end
 
     std::cout << "done.  Reallocated data (" << data << ")" << std::endl;
 

--- a/examples/tutorial/tut_replay.cpp
+++ b/examples/tutorial/tut_replay.cpp
@@ -24,23 +24,23 @@ int main(int, char**)
   auto& rm = umpire::ResourceManager::getInstance();
 
   // Make an allocator
-  // _umpire_tut_replay_make_allocate_start
+  // _sphinx_tag_tut_replay_make_allocate_start
   auto allocator = rm.getAllocator("HOST");
   auto pool =
       rm.makeAllocator<umpire::strategy::DynamicPool>("pool", allocator);
-  // _umpire_tut_replay_make_allocate_end
+  // _sphinx_tag_tut_replay_make_allocate_end
 
   // Do some allocations
-  // _umpire_tut_replay_allocate_start
+  // _sphinx_tag_tut_replay_allocate_start
   std::generate(allocations.begin(), allocations.end(),
                 [&]() { return pool.allocate(random_number()); });
-  // _umpire_tut_replay_allocate_end
+  // _sphinx_tag_tut_replay_allocate_end
 
   // Clean up
-  // _umpire_tut_replay_dealocate_start
+  // _sphinx_tag_tut_replay_dealocate_start
   for (auto& ptr : allocations)
     pool.deallocate(ptr);
-  // _umpire_tut_replay_dealocate_end
+  // _sphinx_tag_tut_replay_dealocate_end
 
   return 0;
 }

--- a/examples/tutorial/tut_replay.cpp
+++ b/examples/tutorial/tut_replay.cpp
@@ -24,17 +24,23 @@ int main(int, char**)
   auto& rm = umpire::ResourceManager::getInstance();
 
   // Make an allocator
+  // _umpire_tut_replay_make_allocate_start
   auto allocator = rm.getAllocator("HOST");
   auto pool =
       rm.makeAllocator<umpire::strategy::DynamicPool>("pool", allocator);
+  // _umpire_tut_replay_make_allocate_end
 
   // Do some allocations
+  // _umpire_tut_replay_allocate_start
   std::generate(allocations.begin(), allocations.end(),
                 [&]() { return pool.allocate(random_number()); });
+  // _umpire_tut_replay_allocate_end
 
   // Clean up
+  // _umpire_tut_replay_dealocate_start
   for (auto& ptr : allocations)
     pool.deallocate(ptr);
+  // _umpire_tut_replay_dealocate_end
 
   return 0;
 }

--- a/examples/tutorial/tut_replay_log.json
+++ b/examples/tutorial/tut_replay_log.json
@@ -4,24 +4,24 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-# _umpire_doc_version_start
+# _sphinx_tag_doc_version_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052211435757, "event": "version", "payload": { "major":0, "minor":3, "patch":3 } }
-# _umpire_doc_version_end
-# _umpire_doc_makememoryresource_start
+# _sphinx_tag_doc_version_end
+# _sphinx_tag_doc_makememoryresource_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052211477678, "event": "makeMemoryResource", "payload": { "name": "HOST" }, "result": "0x101626b0" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052471684134, "event": "makeMemoryResource", "payload": { "name": "DEVICE" }, "result": "0x101d79a0" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052471698804, "event": "makeMemoryResource", "payload": { "name": "PINNED" }, "result": "0x101d7a50" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052472972935, "event": "makeMemoryResource", "payload": { "name": "UM" }, "result": "0x101d7b00" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595814979, "event": "makeMemoryResource", "payload": { "name": "DEVICE_CONST" }, "result": "0x101d7bb0" }
-# _umpire_doc_makememoryresource_end
-# _umpire_doc_makeallocator_start
+# _sphinx_tag_doc_makememoryresource_end
+# _sphinx_tag_doc_makeallocator_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052595864262, "event": "makeAllocator", "payload": { "type":"umpire::strategy::DynamicPool", "with_introspection":true, "allocator_name":"pool", "args": [ "HOST" ] } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595903505, "event": "makeAllocator", "payload": { "type":"umpire::strategy::DynamicPool", "with_introspection":true, "allocator_name":"pool", "args": [ "HOST" ] }, "result": { "allocator_ref":"0x108a8730" } }
-# _umpire_doc_makeallocator_end
-# _umpire_doc_allocate_start
+# _sphinx_tag_doc_makeallocator_end
+# _sphinx_tag_doc_allocate_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052595911583, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 0 } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595934822, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 0 }, "result": { "memory_ptr": "0x200040000010" } }
-# _umpire_doc_allocate_end
+# _sphinx_tag_doc_allocate_end
 { "kind":"replay", "uid":27494, "timestamp":1558388052595939623, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 134 } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595943793, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 134 }, "result": { "memory_ptr": "0x200040000010" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595947408, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 774 } }
@@ -148,9 +148,9 @@
 { "kind":"replay", "uid":27494, "timestamp":1558388052596350263, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 529 }, "result": { "memory_ptr": "0x200040007ed0" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596352741, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 327 } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596356087, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 327 }, "result": { "memory_ptr": "0x2000400080f0" } }
-# _umpire_doc_deallocate_start
+# _sphinx_tag_doc_deallocate_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052596358577, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x200040000010" } }
-# _umpire_doc_deallocate_end
+# _sphinx_tag_doc_deallocate_end
 { "kind":"replay", "uid":27494, "timestamp":1558388052596364727, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x200040000010" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596369203, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x2000400000a0" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596374324, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x2000400003b0" } }

--- a/examples/tutorial/tut_replay_log.json
+++ b/examples/tutorial/tut_replay_log.json
@@ -4,16 +4,24 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
+# _umpire_doc_version_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052211435757, "event": "version", "payload": { "major":0, "minor":3, "patch":3 } }
+# _umpire_doc_version_end
+# _umpire_doc_makememoryresource_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052211477678, "event": "makeMemoryResource", "payload": { "name": "HOST" }, "result": "0x101626b0" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052471684134, "event": "makeMemoryResource", "payload": { "name": "DEVICE" }, "result": "0x101d79a0" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052471698804, "event": "makeMemoryResource", "payload": { "name": "PINNED" }, "result": "0x101d7a50" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052472972935, "event": "makeMemoryResource", "payload": { "name": "UM" }, "result": "0x101d7b00" }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595814979, "event": "makeMemoryResource", "payload": { "name": "DEVICE_CONST" }, "result": "0x101d7bb0" }
+# _umpire_doc_makememoryresource_end
+# _umpire_doc_makeallocator_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052595864262, "event": "makeAllocator", "payload": { "type":"umpire::strategy::DynamicPool", "with_introspection":true, "allocator_name":"pool", "args": [ "HOST" ] } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595903505, "event": "makeAllocator", "payload": { "type":"umpire::strategy::DynamicPool", "with_introspection":true, "allocator_name":"pool", "args": [ "HOST" ] }, "result": { "allocator_ref":"0x108a8730" } }
+# _umpire_doc_makeallocator_end
+# _umpire_doc_allocate_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052595911583, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 0 } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595934822, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 0 }, "result": { "memory_ptr": "0x200040000010" } }
+# _umpire_doc_allocate_end
 { "kind":"replay", "uid":27494, "timestamp":1558388052595939623, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 134 } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595943793, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 134 }, "result": { "memory_ptr": "0x200040000010" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052595947408, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 774 } }
@@ -140,7 +148,9 @@
 { "kind":"replay", "uid":27494, "timestamp":1558388052596350263, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 529 }, "result": { "memory_ptr": "0x200040007ed0" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596352741, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 327 } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596356087, "event": "allocate", "payload": { "allocator_ref": "0x108a8730", "size": 327 }, "result": { "memory_ptr": "0x2000400080f0" } }
+# _umpire_doc_deallocate_start
 { "kind":"replay", "uid":27494, "timestamp":1558388052596358577, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x200040000010" } }
+# _umpire_doc_deallocate_end
 { "kind":"replay", "uid":27494, "timestamp":1558388052596364727, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x200040000010" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596369203, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x2000400000a0" } }
 { "kind":"replay", "uid":27494, "timestamp":1558388052596374324, "event": "deallocate", "payload": { "allocator_ref": "0x108a8730", "memory_ptr": "0x2000400003b0" } }

--- a/examples/tutorial/tut_resources.cpp
+++ b/examples/tutorial/tut_resources.cpp
@@ -11,9 +11,9 @@ void allocate_and_deallocate(const std::string& resource)
 {
   auto& rm = umpire::ResourceManager::getInstance();
 
-  // _umpire_tut_get_allocator_start
+  // _sphinx_tag_tut_get_allocator_start
   umpire::Allocator allocator = rm.getAllocator(resource);
-  // _umpire_tut_get_allocator_end
+  // _sphinx_tag_tut_get_allocator_end
 
   constexpr std::size_t SIZE = 1024;
 

--- a/examples/tutorial/tut_resources.cpp
+++ b/examples/tutorial/tut_resources.cpp
@@ -9,11 +9,13 @@
 
 void allocate_and_deallocate(const std::string& resource)
 {
-  constexpr std::size_t SIZE = 1024;
-
   auto& rm = umpire::ResourceManager::getInstance();
 
+  // _umpire_tut_get_allocator_start
   umpire::Allocator allocator = rm.getAllocator(resource);
+  // _umpire_tut_get_allocator_end
+
+  constexpr std::size_t SIZE = 1024;
 
   double* data =
       static_cast<double*>(allocator.allocate(SIZE * sizeof(double)));

--- a/examples/tutorial/tut_typed_allocator.cpp
+++ b/examples/tutorial/tut_typed_allocator.cpp
@@ -18,7 +18,7 @@ int main(int, char**)
 
   double* my_doubles = double_allocator.allocate(1024);
 
-  double_allocator.deallocate(my_doubles);
+  double_allocator.deallocate(my_doubles, 1024);
   // _umpire_tut_typed_alloc_end
 
   // _umpire_tut_vector_alloc_start

--- a/examples/tutorial/tut_typed_allocator.cpp
+++ b/examples/tutorial/tut_typed_allocator.cpp
@@ -13,14 +13,18 @@ int main(int, char**)
   auto& rm = umpire::ResourceManager::getInstance();
   auto alloc = rm.getAllocator("HOST");
 
+  // _umpire_tut_typed_alloc_start
   umpire::TypedAllocator<double> double_allocator{alloc};
 
   double* my_doubles = double_allocator.allocate(1024);
 
-  double_allocator.deallocate(my_doubles, 1024);
+  double_allocator.deallocate(my_doubles);
+  // _umpire_tut_typed_alloc_end
 
+  // _umpire_tut_vector_alloc_start
   std::vector<double, umpire::TypedAllocator<double>> my_vector{
       double_allocator};
+  // _umpire_tut_vector_alloc_end
 
   my_vector.resize(100);
 

--- a/examples/tutorial/tut_typed_allocator.cpp
+++ b/examples/tutorial/tut_typed_allocator.cpp
@@ -13,18 +13,18 @@ int main(int, char**)
   auto& rm = umpire::ResourceManager::getInstance();
   auto alloc = rm.getAllocator("HOST");
 
-  // _umpire_tut_typed_alloc_start
+  // _sphinx_tag_tut_typed_alloc_start
   umpire::TypedAllocator<double> double_allocator{alloc};
 
   double* my_doubles = double_allocator.allocate(1024);
 
   double_allocator.deallocate(my_doubles, 1024);
-  // _umpire_tut_typed_alloc_end
+  // _sphinx_tag_tut_typed_alloc_end
 
-  // _umpire_tut_vector_alloc_start
+  // _sphinx_tag_tut_vector_alloc_start
   std::vector<double, umpire::TypedAllocator<double>> my_vector{
       double_allocator};
-  // _umpire_tut_vector_alloc_end
+  // _sphinx_tag_tut_vector_alloc_end
 
   my_vector.resize(100);
 


### PR DESCRIPTION
This addresses issue #429 

All references by line number in the documentation have been updated to use anchors instead.  This will protect us from future code style changes making the line numbers get out of sync with what is being displayed.

Updated documentation for this branch may be reviewed here: https://umpire.readthedocs.io/en/bugfix-um-762-source-examples-in-tutorial-documentation-need-fixup-post-style-updates/