### PR TITLE
Bugfix/um 779 quickpool needs to correctly account for releasable bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Added 'isAllocator' method that takes integer ID, and returns true if that
   ID corresponds to an Allocator.
 
+- Added option to replay to display current/actual/watermark statistic for each
+  allocator.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Made replay test tool aware of `memset` operation and added CI tests to
   find and report future missing replay operations in the tool.
 
+- Fixed accounting for number of releasable bytes in Quickpool that was causing
+  coalesce operations to not work properly.
+  
 ## [v4.1.2] - 2020-10-06
 
 ### Fixed

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -217,6 +217,7 @@ void QuickPool::release()
       UMPIRE_LOG(Debug, "Releasing chunk " << chunk->data);
 
       m_actual_bytes -= chunk->chunk_size;
+      m_releasable_bytes -= chunk->chunk_size;
 
       try {
         aligned_deallocate(chunk->data);

--- a/tools/replay/ReplayOperationManager.cpp
+++ b/tools/replay/ReplayOperationManager.cpp
@@ -115,7 +115,7 @@ namespace {
 
     TrackedCounter log2_buckets[64];
   };
-};
+}
 
 void ReplayOperationManager::runOperations()
 {

--- a/tools/replay/ReplayOptions.hpp
+++ b/tools/replay/ReplayOptions.hpp
@@ -27,6 +27,7 @@ struct ReplayOptions {
   bool time_replay_parse{false};  // --time-parse
   bool info_only{false};         // --info
   bool print_statistics{false};   // -s,--stats
+  bool print_stats_on_release{false};// --stats-on-release
   bool skip_operations{false};    // --skip-operations
   bool force_compile{false};      // -r,--recompile
   bool do_not_demangle{false};    // --no-demangle

--- a/tools/replay/replay.cpp
+++ b/tools/replay/replay.cpp
@@ -44,6 +44,9 @@ int main(int argc, char* argv[])
   app.add_flag("-s,--stats", options.print_statistics,
       "Dump ULTRA file containing memory usage stats for each Allocator");
 
+  app.add_flag("--stats-on-release", options.print_stats_on_release,
+      "Display pool statistics at pool->release() boundaries");
+
   app.add_flag("--info-only" , options.info_only,
       "Information about replay file, no actual replay performed");
 


### PR DESCRIPTION
This PR contains two items:

1. Replay was updated to provide summary statistics at the end of the run and at `release()` call boundaries.
2. `QuickPool::release()` was fixed to correctly account for the number of releasable bytes.