### PR TITLE
Alphabetize config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Documentation on allocator (in)accessibility.
 
+### Changed
+
+- Organized configuration options in config.hpp.in in alphabetical order
+
 ### Removed
 
 - Removed extraneous function definition in HipDeviceMemoryResource

--- a/src/umpire/config.hpp.in
+++ b/src/umpire/config.hpp.in
@@ -9,28 +9,27 @@
 
 #include <string>
 
-#cmakedefine UMPIRE_ENABLE_CUDA
-#cmakedefine UMPIRE_ENABLE_NUMA
-#cmakedefine UMPIRE_ENABLE_SLIC
-#cmakedefine UMPIRE_ENABLE_LOGGING
-#cmakedefine UMPIRE_ENABLE_INACCESSIBILITY_TESTS
+//
+// Please keep the list below organized in alphabetical order.
+//
 #cmakedefine UMPIRE_ENABLE_BACKTRACE
 #cmakedefine UMPIRE_ENABLE_BACKTRACE_SYMBOLS
-#cmakedefine UMPIRE_ENABLE_HIP
-#cmakedefine UMPIRE_ENABLE_SYCL
-#cmakedefine UMPIRE_ENABLE_OPENMP_TARGET
-#cmakedefine UMPIRE_HAS_ASAN
-
-#cmakedefine UMPIRE_ENABLE_DEVICE
-#cmakedefine UMPIRE_ENABLE_PINNED
-#cmakedefine UMPIRE_ENABLE_UM
 #cmakedefine UMPIRE_ENABLE_CONST
-
-#cmakedefine UMPIRE_ENABLE_MPI
-
+#cmakedefine UMPIRE_ENABLE_CUDA
+#cmakedefine UMPIRE_ENABLE_DEVICE
 #cmakedefine UMPIRE_ENABLE_FILESYSTEM
-
 #cmakedefine UMPIRE_ENABLE_FILE_RESOURCE
+#cmakedefine UMPIRE_ENABLE_HIP
+#cmakedefine UMPIRE_ENABLE_INACCESSIBILITY_TESTS
+#cmakedefine UMPIRE_ENABLE_LOGGING
+#cmakedefine UMPIRE_ENABLE_MPI
+#cmakedefine UMPIRE_ENABLE_NUMA
+#cmakedefine UMPIRE_ENABLE_OPENMP_TARGET
+#cmakedefine UMPIRE_ENABLE_PINNED
+#cmakedefine UMPIRE_ENABLE_SLIC
+#cmakedefine UMPIRE_ENABLE_SYCL
+#cmakedefine UMPIRE_ENABLE_UM
+#cmakedefine UMPIRE_HAS_ASAN
 
 #define UMPIRE_VERSION_MAJOR @Umpire_VERSION_MAJOR@
 #define UMPIRE_VERSION_MINOR @Umpire_VERSION_MINOR@


### PR DESCRIPTION
Addressing a minor nit.  Umpire is getting enough configuration options now that I think it is easier to deal with them when they are organized in alphabetical order.