### PR TITLE
Fix m_current_bytes accounting in DynamicPoolMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Python is now explicitly python3 or python2 (most likely python3)
 
+- Fix incorrect accounting for m_current_bytes in DynamicPoolMap, this addresses an
+  issue that would mean the pool would never coalesce automatically.
+
 ## [v5.0.0] - 2020-11-18
 
 ### Added

--- a/src/umpire/strategy/DynamicPoolMap.cpp
+++ b/src/umpire/strategy/DynamicPoolMap.cpp
@@ -120,7 +120,7 @@ void* DynamicPoolMap::allocate(std::size_t bytes)
                  false, alloc_bytes);
   }
 
-  m_current_bytes += bytes;
+  m_current_bytes += rounded_bytes;
 
   UMPIRE_UNPOISON_MEMORY_REGION(m_allocator, ptr, bytes);
   return ptr;

--- a/tests/integration/primary_pool_tests.cpp
+++ b/tests/integration/primary_pool_tests.cpp
@@ -590,7 +590,7 @@ TYPED_TEST(PrimaryPoolTest, heuristic_100_percent)
     ASSERT_EQ(dynamic_pool->getReleasableSize(), 0);
   }
 
-  // ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4);
+  ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4);
   ASSERT_NO_THROW({ alloc.deallocate(a[3]); }); // 25% releasable
   ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4);
   ASSERT_NO_THROW({ alloc.deallocate(a[2]); }); // 50% releasable

--- a/tests/integration/primary_pool_tests.cpp
+++ b/tests/integration/primary_pool_tests.cpp
@@ -563,3 +563,40 @@ TYPED_TEST(PrimaryPoolTest, heuristic_75_percent)
   ASSERT_NO_THROW({ alloc.deallocate(a[0]); });  // 100% releasable
   ASSERT_EQ(dynamic_pool->getBlocksInPool(), 1); // Collapse happened
 }
+
+TYPED_TEST(PrimaryPoolTest, heuristic_100_percent)
+{
+  const int initial_size{1024};
+  const int subsequent_min_size{1024};
+  const int alignment{1024};
+  using Pool = typename TestFixture::Pool;
+  auto& rm = umpire::ResourceManager::getInstance();
+
+  auto h_fun = Pool::percent_releasable(100);
+  auto alloc = rm.makeAllocator<Pool>(this->m_pool_name + std::string{"_100"},
+                                      rm.getAllocator(this->m_resource_name),
+                                      initial_size, subsequent_min_size,
+                                      alignment, h_fun);
+
+  auto dynamic_pool = umpire::util::unwrap_allocator<Pool>(alloc);
+
+  ASSERT_NE(dynamic_pool, nullptr);
+
+  void* a[4];
+  for (int i{0}; i < 4; ++i) {
+    ASSERT_NO_THROW({ a[i] = alloc.allocate(768); });
+    ASSERT_EQ(alloc.getActualSize(), (1024 * (i + 1)));
+    ASSERT_EQ(dynamic_pool->getBlocksInPool(), (i + 1));
+    ASSERT_EQ(dynamic_pool->getReleasableSize(), 0);
+  }
+
+  // ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4);
+  ASSERT_NO_THROW({ alloc.deallocate(a[3]); }); // 25% releasable
+  ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4);
+  ASSERT_NO_THROW({ alloc.deallocate(a[2]); }); // 50% releasable
+  ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4);
+  ASSERT_NO_THROW({ alloc.deallocate(a[1]); });  // 75% releasable
+  ASSERT_EQ(dynamic_pool->getBlocksInPool(), 4); // Collapse happened
+  ASSERT_NO_THROW({ alloc.deallocate(a[0]); });  // 100% releasable
+  ASSERT_EQ(dynamic_pool->getBlocksInPool(), 1); // Collapse happened
+}


### PR DESCRIPTION
Addresses an issue where the pool will never coalesce, since getCurrentSize will never return 0.