### PR TITLE
Feature/um 836 replay per allocator statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Install thirdparty exports in CMake configuration file
 
+- UM-837 - Replay will now display high water mark statistics per allocator.
+
 ### Changed
 
 - Organized configuration options in config.hpp.in in alphabetical order.

--- a/tools/replay/ReplayOperationManager.cpp
+++ b/tools/replay/ReplayOperationManager.cpp
@@ -250,13 +250,15 @@ void ReplayOperationManager::runOperations()
   if (m_options.print_size_stats) {
     for (const auto& alloc_name : rm.getAllocatorNames()) {
       auto alloc = rm.getAllocator(alloc_name);
-      std::cout
-        << std::setw(name_width) << std::left << m_replay_file->getInputFileName()
-        << std::setw(name_width) << std::left << alloc_name
-        << std::setw(num_width) << std::left << alloc.getCurrentSize()
-        << std::setw(num_width) << std::left << alloc.getActualSize()
-        << std::setw(num_width) << std::left << alloc.getHighWatermark()
-        << std::endl;
+      if (alloc.getHighWatermark()) {
+        std::cout
+          << std::setw(name_width) << std::left << m_replay_file->getInputFileName()
+          << std::setw(name_width) << std::left << alloc_name
+          << std::setw(num_width) << std::left << alloc.getCurrentSize()
+          << std::setw(num_width) << std::left << alloc.getActualSize()
+          << std::setw(num_width) << std::left << alloc.getHighWatermark()
+          << std::endl;
+      }
     }
 
     for (auto const& x : size_histogram)

--- a/tools/replay/ReplayOperationManager.cpp
+++ b/tools/replay/ReplayOperationManager.cpp
@@ -97,6 +97,10 @@ namespace {
   struct TrackedHistogram {
     void increment(std::size_t size) {
       int index{ log2_64(size) };
+
+      if ( size > largest_allocation )
+        largest_allocation = size;
+
       log2_buckets[index].increment();
     };
 
@@ -106,14 +110,27 @@ namespace {
     };
 
     void print() const {
-      std::cout << log2_buckets[0].high_watermark;
-      for ( int i = 1; i < 64; i++ ) {
-        std::cout << ", " << log2_buckets[i].high_watermark;
+      std::cout << std::endl << "    ";
+      std::cout << "Largest Allocation: " << largest_allocation << std::endl;
+      std::cout << std::endl << "    ";
+      bool print_comma{false};
+
+      for ( int i = 0; i < 64; i++ ) {
+        if (print_comma)
+          std::cout << ", ";
+        if (log2_buckets[i].high_watermark) {
+          print_comma = true;
+          std::cout << "[2^" << i << " - 2^" << i+1 << ") = ";
+          std::cout << log2_buckets[i].high_watermark;
+        }
       }
       std::cout << std::endl;
     };
 
     TrackedCounter log2_buckets[64]{};
+    std::size_t largest_allocation{0};
+    std::size_t allocations{0};
+    std::size_t deallocations{0};
   };
 }
 

--- a/tools/replay/ReplayOperationManager.cpp
+++ b/tools/replay/ReplayOperationManager.cpp
@@ -113,7 +113,7 @@ namespace {
 
     void print(std::string name) const {
       if (largest_allocation > 0) {
-        std::cout << std::endl << name << ":";
+        std::cout << std::endl << name << ":" << std::endl;
         std::cout << "    Total Deallocations:  " << deallocations << std::endl;
         std::cout << "    Total Allocations:    " << allocations << std::endl;
         std::cout << "    Largest Allocation:   " << largest_allocation << std::endl;
@@ -124,6 +124,7 @@ namespace {
             std::cout << log2_buckets[i].high_watermark << std::endl;
           }
         }
+        std::cout << std::endl;
       }
     };
 

--- a/tools/replay/ReplayOptions.hpp
+++ b/tools/replay/ReplayOptions.hpp
@@ -27,7 +27,7 @@ struct ReplayOptions {
   bool time_replay_parse{false};  // --time-parse
   bool info_only{false};         // --info
   bool print_statistics{false};   // -s,--stats
-  bool print_stats_on_release{false};// --stats-on-release
+  bool print_size_stats{false};// --size-stats
   bool skip_operations{false};    // --skip-operations
   bool force_compile{false};      // -r,--recompile
   bool do_not_demangle{false};    // --no-demangle

--- a/tools/replay/replay.cpp
+++ b/tools/replay/replay.cpp
@@ -44,8 +44,8 @@ int main(int argc, char* argv[])
   app.add_flag("-s,--stats", options.print_statistics,
       "Dump ULTRA file containing memory usage stats for each Allocator");
 
-  app.add_flag("--stats-on-release", options.print_stats_on_release,
-      "Display pool statistics at pool->release() boundaries");
+  app.add_flag("--size-stats", options.print_size_stats,
+      "Display pool allocaiton size statistics");
 
   app.add_flag("--info-only" , options.info_only,
       "Information about replay file, no actual replay performed");

--- a/tools/replay/replay.cpp
+++ b/tools/replay/replay.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
       "Dump ULTRA file containing memory usage stats for each Allocator");
 
   app.add_flag("--size-stats", options.print_size_stats,
-      "Display pool allocaiton size statistics");
+      "Display pool allocation size statistics");
 
   app.add_flag("--info-only" , options.info_only,
       "Information about replay file, no actual replay performed");


### PR DESCRIPTION
Replay will now track and display the following allocation size statistics when requested:
```
$ ../install/bin/replay -i umpire.130469.0.replay --size-stats
Filename                                Allocator                               Current Size    Actual Size     High Watermark
umpire.130469.0.replay                  UM_pool_temps                           0               778558976       676982088
umpire.130469.0.replay                  preferred_location_device               16884687360     16884687360     16884692480
umpire.130469.0.replay                  UM                                      17408975376     17408975376     17408980496
umpire.130469.0.replay                  UM_pool                                 8080938944      16106127360     13541160960

UM_pool:
    Total Deallocations:  102
    Total Allocations:    245
    Largest Allocation:   760569040
    Allocation Sizes Histogram:
    [2^2 - 2^3) = 1
    [2^4 - 2^5) = 1
    [2^7 - 2^8) = 9
    [2^8 - 2^9) = 2
    [2^9 - 2^10) = 4
    [2^10 - 2^11) = 6
    [2^11 - 2^12) = 16
    [2^12 - 2^13) = 10
    [2^18 - 2^19) = 8
    [2^19 - 2^20) = 4
    [2^20 - 2^21) = 15
    [2^21 - 2^22) = 3
    [2^22 - 2^23) = 6
    [2^23 - 2^24) = 15
    [2^24 - 2^25) = 40
    [2^25 - 2^26) = 13
    [2^26 - 2^27) = 61
    [2^27 - 2^28) = 2
    [2^28 - 2^29) = 16
    [2^29 - 2^30) = 2


UM_pool_temps:
    Total Deallocations:  2918
    Total Allocations:    2918
    Largest Allocation:   122473944
    Allocation Sizes Histogram:
    [2^16 - 2^17) = 1
    [2^19 - 2^20) = 5
    [2^21 - 2^22) = 5
    [2^22 - 2^23) = 1
    [2^23 - 2^24) = 4
    [2^24 - 2^25) = 4
    [2^26 - 2^27) = 4


UM_object_pool:
    Total Deallocations:  0
    Total Allocations:    96
    Largest Allocation:   184
    Allocation Sizes Histogram:
    [2^7 - 2^8) = 96
```