### PR TITLE
Compilation issues due to missing <limits> include

### DIFF
--- a/src/umpire/util/allocation_statistics.cpp
+++ b/src/umpire/util/allocation_statistics.cpp
@@ -8,6 +8,7 @@
 #include "umpire/util/allocation_statistics.hpp"
 
 #include <algorithm>
+#include <limits>     // for std::numeric_limits
 
 namespace umpire {
 namespace util {


### PR DESCRIPTION
Summary
========

Encountered compilation issues with Clang 9 and Clang 10 compilers
on Linux due to not including `<limits>` in a file. This include is needed 
for calls to `std::numeric_limits< TYPE >::epsilon()` in that file.