### PR TITLE
Set default of ENABLE_HOST_SHARED_MEMORY to be value of ENABLE_MPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - In Gitlab CI, upload junit reports for corona and lassen.
 
-- Initial support for IPC Shared Memory via a "SHARED" resource allocator.
+- Initial support for IPC Shared Memory via a "SHARED" resource allocator. Host
+  Shared memory will default to the value of `ENABLE_MPI`.
 
 - get_communicator_for_allocator to get an MPI Communicator for the scope of a shared allocator.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,8 @@ cmake_dependent_option( UMPIRE_ENABLE_EXAMPLES "Build Umpire examples" On
                         "ENABLE_EXAMPLES" Off )
 
 cmake_dependent_option(
-  ENABLE_HOST_SHARED_MEMORY "Enable Host Shared Memory Resource" Off
-  "ENABLE_MPI;NOT WIN32;NOT APPLE" Off )
+  ENABLE_HOST_SHARED_MEMORY "Enable Host Shared Memory Resource" ${ENABLE_MPI}
+  "NOT WIN32;NOT APPLE" Off )
 
 if (Git_FOUND)
   blt_git_hashcode (HASHCODE umpire_sha1

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -14,27 +14,27 @@ argument is a boolean option, and  can be turned on or off:
 
 Here is a summary of the configuration options, their default value, and meaning:
 
-    ============================  ========        ===========================================================================
-    Variable                      Default         Meaning
-    ============================  ========        ===========================================================================
-    ``ENABLE_CUDA``               Off             Enable CUDA support
-    ``ENABLE_HIP``                Off             Enable HIP support
-    ``ENABLE_NUMA``               Off             Enable NUMA support
-    ``ENABLE_FILE_RESOURCE``      Off             Enable FILE support      
-    ``ENABLE_TESTS``              On              Build test executables
-    ``ENABLE_BENCHMARKS``         On              Build benchmark programs
-    ``ENABLE_LOGGING``            On              Enable Logging within Umpire
-    ``ENABLE_SLIC``               Off             Enable SLIC logging
-    ``ENABLE_BACKTRACE``          Off             Enable backtraces for allocations
-    ``ENABLE_BACKTRACE_SYMBOLS``  Off             Enable symbol lookup for backtraces
-    ``ENABLE_TOOLS``              Off             Enable tools like replay
-    ``ENABLE_DOCS``               Off             Build documentation (requires Sphinx and/or Doxygen)
-    ``ENABLE_C``                  Off             Build the C API
-    ``ENABLE_FORTRAN``            Off             Build the Fortran API
-    ``ENABLE_PERFORMANCE_TESTS``  Off             Build and run performance tests
-    ``ENABLE_HOST_SHARED_MEMORY`` ``ENABLE_MPI``  Enable Host Shared Memory support
-    ``ENABLE_ASAN``               Off             Enable ASAN support
-    ============================  ========        ===========================================================================
+    =============================  ==========  ===========================================================================
+    Variable                       Default     Meaning
+    =============================  ==========  ===========================================================================
+    ``ENABLE_CUDA``                Off         Enable CUDA support
+    ``ENABLE_HIP``                 Off         Enable HIP support
+    ``ENABLE_NUMA``                Off         Enable NUMA support
+    ``ENABLE_FILE_RESOURCE``       Off         Enable FILE support      
+    ``ENABLE_TESTS``               On          Build test executables
+    ``ENABLE_BENCHMARKS``          On          Build benchmark programs
+    ``ENABLE_LOGGING``             On          Enable Logging within Umpire
+    ``ENABLE_SLIC``                Off         Enable SLIC logging
+    ``ENABLE_BACKTRACE``           Off         Enable backtraces for allocations
+    ``ENABLE_BACKTRACE_SYMBOLS``   Off         Enable symbol lookup for backtraces
+    ``ENABLE_TOOLS``               Off         Enable tools like replay
+    ``ENABLE_DOCS``                Off         Build documentation (requires Sphinx and/or Doxygen)
+    ``ENABLE_C``                   Off         Build the C API
+    ``ENABLE_FORTRAN``             Off         Build the Fortran API
+    ``ENABLE_PERFORMANCE_TESTS``   Off         Build and run performance tests
+    ``ENABLE_HOST_SHARED_MEMORY``  ENABLE_MPI  Enable Host Shared Memory support
+    ``ENABLE_ASAN``                Off         Enable ASAN support
+    =============================  ==========  ===========================================================================
 
 These arguments are explained in more detail below:
 

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -14,27 +14,27 @@ argument is a boolean option, and  can be turned on or off:
 
 Here is a summary of the configuration options, their default value, and meaning:
 
-    ============================  ======== ===========================================================================
-    Variable                      Default  Meaning
-    ============================  ======== ===========================================================================
-    ``ENABLE_CUDA``               Off      Enable CUDA support
-    ``ENABLE_HIP``                Off      Enable HIP support
-    ``ENABLE_NUMA``               Off      Enable NUMA support
-    ``ENABLE_FILE_RESOURCE``      Off      Enable FILE support      
-    ``ENABLE_TESTS``              On       Build test executables
-    ``ENABLE_BENCHMARKS``         On       Build benchmark programs
-    ``ENABLE_LOGGING``            On       Enable Logging within Umpire
-    ``ENABLE_SLIC``               Off      Enable SLIC logging
-    ``ENABLE_BACKTRACE``          Off      Enable backtraces for allocations
-    ``ENABLE_BACKTRACE_SYMBOLS``  Off      Enable symbol lookup for backtraces
-    ``ENABLE_TOOLS``              Off      Enable tools like replay
-    ``ENABLE_DOCS``               Off      Build documentation (requires Sphinx and/or Doxygen)
-    ``ENABLE_C``                  Off      Build the C API
-    ``ENABLE_FORTRAN``            Off      Build the Fortran API
-    ``ENABLE_PERFORMANCE_TESTS``  Off      Build and run performance tests
-    ``ENABLE_HOST_SHARED_MEMORY`` Off      Enable Host Shared Memory support
-    ``ENABLE_ASAN``               Off      Enable ASAN support
-    ============================  ======== ===========================================================================
+    ============================  ========        ===========================================================================
+    Variable                      Default         Meaning
+    ============================  ========        ===========================================================================
+    ``ENABLE_CUDA``               Off             Enable CUDA support
+    ``ENABLE_HIP``                Off             Enable HIP support
+    ``ENABLE_NUMA``               Off             Enable NUMA support
+    ``ENABLE_FILE_RESOURCE``      Off             Enable FILE support      
+    ``ENABLE_TESTS``              On              Build test executables
+    ``ENABLE_BENCHMARKS``         On              Build benchmark programs
+    ``ENABLE_LOGGING``            On              Enable Logging within Umpire
+    ``ENABLE_SLIC``               Off             Enable SLIC logging
+    ``ENABLE_BACKTRACE``          Off             Enable backtraces for allocations
+    ``ENABLE_BACKTRACE_SYMBOLS``  Off             Enable symbol lookup for backtraces
+    ``ENABLE_TOOLS``              Off             Enable tools like replay
+    ``ENABLE_DOCS``               Off             Build documentation (requires Sphinx and/or Doxygen)
+    ``ENABLE_C``                  Off             Build the C API
+    ``ENABLE_FORTRAN``            Off             Build the Fortran API
+    ``ENABLE_PERFORMANCE_TESTS``  Off             Build and run performance tests
+    ``ENABLE_HOST_SHARED_MEMORY`` ``ENABLE_MPI``  Enable Host Shared Memory support
+    ``ENABLE_ASAN``               Off             Enable ASAN support
+    ============================  ========        ===========================================================================
 
 These arguments are explained in more detail below:
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -31,7 +31,7 @@ import os, subprocess
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 
 if read_the_docs_build:
-    print 'Running on read the docs'
+    print('Running on read the docs')
     subprocess.call('cd ../doxygen; doxygen', shell=True)
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
The updated documenation page in ReadTheDocs may be found here: https://umpire.readthedocs.io/en/um901-shmem-config-options/advanced_configuration.html
