### PR TITLE
restructuring the no-op stress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Changed most internal and test uses of DynamicPoolMap to QuickPool.
 
+- Reorganized the way that the no-op benchmark is structured to match the
+  pool benchmarks.
+
 ### Removed
 
 - Removed extraneous function definition in HipDeviceMemoryResource.

--- a/benchmarks/no-op_stress_test.cpp
+++ b/benchmarks/no-op_stress_test.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <random>
 #include <map>
+#include <numeric>
 
 #include "umpire/config.hpp"
 #include "umpire/ResourceManager.hpp"

--- a/benchmarks/no-op_stress_test.cpp
+++ b/benchmarks/no-op_stress_test.cpp
@@ -6,11 +6,10 @@
 //////////////////////////////////////////////////////////////////////////////
 #include <iostream>
 #include <chrono>
-
 #include <random>
+#include <map>
 
 #include "umpire/config.hpp"
-
 #include "umpire/ResourceManager.hpp"
 #include "umpire/Allocator.hpp"
 
@@ -21,24 +20,30 @@
 const int size = 4096;
 
 /*
- * This functions measures the time it takes to do ALLOCATIONS no-op allocations and 
- * then do ALLOCATIONS no-op deallocations in the same order. The time is averaged across 3 rounds. 
+ * \brief Function that tests the deallocation pattern performance of the no-op allocator. 
+ *   The allocation, deallocation, and "lifespan" times are calculated and printed out for
+ *   each allocator.
+ *   
+ * \param alloc, the no-op allocator
+ * \param test_name, name of the deallocation pattern, used for output
+ * \param indices, a vector of indices which are either structured in same_order, reverse_order, or
+ *   shuffle_order, depending on the deallocation pattern being measured.
  */
-void same_order(umpire::Allocator alloc)
+void test_deallocation_performance(umpire::Allocator alloc, const std::string test_name, const std::vector<std::size_t> &indices)
 {
   double time[2] = {0.0, 0.0};
-  void* allocations[ALLOCATIONS];
+  std::vector<void*> allocations(ALLOCATIONS);
 
   for(int i = 0; i < NUM_ITER; i++) {
     auto begin_alloc = std::chrono::system_clock::now();
-    for (int j = 0; j < ALLOCATIONS; j++)
+    for (size_t j{0}; j < ALLOCATIONS; j++)
       allocations[j] = alloc.allocate(size);
     auto end_alloc = std::chrono::system_clock::now();
     time[0] += std::chrono::duration<double>(end_alloc - begin_alloc).count()/ALLOCATIONS;
 
     auto begin_dealloc = std::chrono::system_clock::now();
-    for (int h = 0; h < ALLOCATIONS; h++)
-      alloc.deallocate(allocations[h]);
+    for (size_t h{0}; h < ALLOCATIONS; h++)
+      alloc.deallocate(allocations[indices[h]]);
     auto end_dealloc = std::chrono::system_clock::now();
     time[1] += std::chrono::duration<double>(end_dealloc - begin_dealloc).count()/ALLOCATIONS;
   }
@@ -46,74 +51,7 @@ void same_order(umpire::Allocator alloc)
   double alloc_t{(time[0]/double(NUM_ITER)*CONVERT)};
   double dealloc_t{(time[1]/double(NUM_ITER)*CONVERT)};
 
-  std::cout << "  SAME_ORDER:" << std::endl; 
-  std::cout << "    alloc: " << alloc_t << "(us)" << std::endl;
-  std::cout << "    dealloc: " << dealloc_t << "(us)" << std::endl;
-  std::cout << "    lifetime: " << alloc_t+dealloc_t << "(us)" << std::endl << std::endl;
-}
-
-/*
- * This functions measures the time it takes to do ALLOCATIONS no-op allocations and 
- * then do ALLOCATIONS no-op deallocations in reverse order. The time is averaged across 3 rounds. 
- */
-void reverse_order(umpire::Allocator alloc)
-{
-  double time[2] = {0.0, 0.0};
-  void* allocations[ALLOCATIONS];
-
-  for(int i = 0; i < NUM_ITER; i++) {
-    auto begin_alloc = std::chrono::system_clock::now();
-    for (int j = 0; j < ALLOCATIONS; j++)
-      allocations[j] = alloc.allocate(size);
-    auto end_alloc = std::chrono::system_clock::now();
-    time[0] += std::chrono::duration<double>(end_alloc - begin_alloc).count()/ALLOCATIONS;
-
-    auto begin_dealloc = std::chrono::system_clock::now();
-    for (int h = (ALLOCATIONS-1); h >=0; h--)
-      alloc.deallocate(allocations[h]);
-    auto end_dealloc = std::chrono::system_clock::now();
-    time[1] += std::chrono::duration<double>(end_dealloc - begin_dealloc).count()/ALLOCATIONS;
-  }
-
-  double alloc_t{(time[0]/double(NUM_ITER)*CONVERT)};
-  double dealloc_t{(time[1]/double(NUM_ITER)*CONVERT)};
-
-  std::cout << "  REVERSE_ORDER:" << std::endl; 
-  std::cout << "    alloc: " << alloc_t << "(us)" << std::endl;
-  std::cout << "    dealloc: " << dealloc_t << "(us)" << std::endl;
-  std::cout << "    lifetime: " << alloc_t+dealloc_t << "(us)" << std::endl << std::endl;
-}
-
-/*
- * This functions measures the time it takes to do ALLOCATIONS no-op allocations, shuffle the 
- * array of returned pointers, and then do ALLOCATIONS no-op deallocations. The time is averaged
- * across 3 rounds. 
- */
-void shuffle(umpire::Allocator alloc)
-{
-  std::mt19937 gen(ALLOCATIONS);
-  double time[2] = {0.0, 0.0};
-  void* allocations[ALLOCATIONS];
-
-  for(int i = 0; i < NUM_ITER; i++) {
-    auto begin_alloc = std::chrono::system_clock::now();
-    for (int j = 0; j < ALLOCATIONS; j++)
-      allocations[j] = alloc.allocate(size);
-    auto end_alloc = std::chrono::system_clock::now();
-    time[0] += std::chrono::duration<double>(end_alloc - begin_alloc).count()/ALLOCATIONS;
-
-    std::shuffle(&allocations[0], &allocations[ALLOCATIONS], gen);
-    auto begin_dealloc = std::chrono::system_clock::now();
-    for (int h = 0; h < ALLOCATIONS; h++)
-      alloc.deallocate(allocations[h]);
-    auto end_dealloc = std::chrono::system_clock::now();
-    time[1] += std::chrono::duration<double>(end_dealloc - begin_dealloc).count()/ALLOCATIONS;
-  }
-
-  double alloc_t{(time[0]/double(NUM_ITER)*CONVERT)};
-  double dealloc_t{(time[1]/double(NUM_ITER)*CONVERT)};
-
-  std::cout << "  SHUFFLE:" << std::endl; 
+  std::cout << "  " << test_name << ":" << std::endl; 
   std::cout << "    alloc: " << alloc_t << "(us)" << std::endl;
   std::cout << "    dealloc: " << dealloc_t << "(us)" << std::endl;
   std::cout << "    lifetime: " << alloc_t+dealloc_t << "(us)" << std::endl << std::endl;
@@ -125,12 +63,30 @@ int main(int, char**) {
 
   auto& rm = umpire::ResourceManager::getInstance();
   umpire::Allocator alloc = rm.getAllocator("NO_OP");
+  std::mt19937 gen(ALLOCATIONS);
+
+  //create map with name and vector of indices for tests
+  std::map<const std::string, const std::vector<std::size_t>&> indexing_pairs;  
+  std::vector<std::size_t> same_order(ALLOCATIONS);
+  std::iota(same_order.begin(), same_order.end(), 0);
+  
+  std::vector<std::size_t> reverse_order(same_order.begin(), same_order.end());
+  std::reverse(reverse_order.begin(), reverse_order.end());
+  
+  std::vector<std::size_t> shuffle_order(same_order.begin(), same_order.end());
+  std::shuffle(shuffle_order.begin(), shuffle_order.end(), gen);
+  
+  //insert indexing vectoring into map
+  indexing_pairs.insert({"SAME_ORDER", same_order});
+  indexing_pairs.insert({"REVERSE_ORDER", reverse_order});
+  indexing_pairs.insert({"SHUFFLE_ORDER", shuffle_order});
 
   std::cout << " Testing allocating and deallocating " << std::endl
             << " with NO_OP resource: " << std::endl << std::endl;
-  same_order(alloc);
-  reverse_order(alloc);
-  shuffle(alloc);
+ 
+  for(auto i : indexing_pairs) {
+    test_deallocation_performance(alloc, i.first, i.second);
+  }
 
   return 0;
 }


### PR DESCRIPTION
Potential changes:
- To keep this test more consistent with the pool benchmark, consider changing the names/formatting of variables to match equivalent vars in the pool benchmark (caps vs. lowercase, num_rnd vs NUM_ITER, etc.)