### PR TITLE
Adding GitHub citation to make Umpire easier to cite

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.1.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Beckingsale 
+    given-names: David
+    orcid: https://orcid.org/0000-0003-2545-4837
+  - family-names: McFadden
+    given-names: Marty
+  - family-names: Dahm
+    given-names: Johann
+  - family-names: Pankajakshan
+    given-names: Ramesh 
+    orcid: https://orcid.org/0000-0002-4249-2555
+  - family-names: Hornung 
+    given-names: Rich
+    orcid: https://orcid.org/0000-0002-9495-6972
+title: "Umpire: Application-focused management and coordination of complex hierarchical memory"
+version: develop
+doi: 10.1147/JRD.2019.2954403
+date-released: 2020-05-01


### PR DESCRIPTION
Hi Umpire team!

GitHub has [recently added](https://twitter.com/natfriedman/status/1420122675813441540) this standard file, CITATION.cff, that will render a sidebar link to easily copy paste bibtex information to cite the work. it looks super cool, and I thought this would be great for LLNL projects, and I found that you have a publication so I'm adding the file here.  I chose to use develop as a version since it's a moving target, and a citer will likely change that to the version they used (and it won't require extra work on your part to keep updated). I had trouble finding Orcid's for all but two  of you - and I pinged @mcfadden8 on slack and he reports that he doesn't have one so I suspect others might not other. I'm thinking it's okay (the fields [appear to be all optional](https://github.com/citation-file-format/citation-file-format#person-objects) but if anyone else here has an ORCID I'd be happy to update the PR.

I hope this might be useful!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>