### PR TITLE
Removing Hip/OMP dependency to tests/debug/ CMakeLists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Removed
 
+- Removed unneeded hip dependency in the tests/debug/ CMake file.
+
 ### Fixed
 
 ## [v6.0.0 - 2021-08-18]

--- a/tests/debug/CMakeLists.txt
+++ b/tests/debug/CMakeLists.txt
@@ -8,18 +8,6 @@
 #Intend to add more debug helper tests like this, so setting a variable specifically
 set (test_debug_depends umpire)
 
-if (ENABLE_HIP)
-  set (test_debug_depends
-      ${test_debug_depends}
-      hip_runtime)
-endif()
-
-if (ENABLE_OPENMP_TARGET)
-  set (test_debug_depends
-      ${test_debug_depends}
-      openmp)
-endif()
-
 blt_add_executable(
   NAME allocate_deallocate
   SOURCES allocate_deallocate.cpp


### PR DESCRIPTION
At the time, we added the dependency only because it was needed in order to compile, not because it actually depended on hip. Now that blt has been updated, the dependency is no longer needed. See UM-816.