### PR TITLE
PosixMemalignAllocator werror warn_unused

### DIFF
--- a/src/umpire/alloc/PosixMemalignAllocator.hpp
+++ b/src/umpire/alloc/PosixMemalignAllocator.hpp
@@ -30,7 +30,7 @@ struct PosixMemalignAllocator {
   void* allocate(std::size_t bytes)
   {
     void* ret = NULL;
-    int err = ::posix_memalign(&ret, get_page_size(), bytes);    
+    int err = ::posix_memalign(&ret, get_page_size(), bytes);
 
     UMPIRE_LOG(Debug, "(bytes=" << bytes << ") returning " << ret);
 

--- a/src/umpire/alloc/PosixMemalignAllocator.hpp
+++ b/src/umpire/alloc/PosixMemalignAllocator.hpp
@@ -30,12 +30,13 @@ struct PosixMemalignAllocator {
   void* allocate(std::size_t bytes)
   {
     void* ret = NULL;
-    ::posix_memalign(&ret, get_page_size(), bytes);
+    int err = ::posix_memalign(&ret, get_page_size(), bytes);    
 
     UMPIRE_LOG(Debug, "(bytes=" << bytes << ") returning " << ret);
 
     if (ret == nullptr) {
-      UMPIRE_ERROR("posix_memalign( bytes = " << bytes << ", pagesize = " << get_page_size() << " ) failed");
+      UMPIRE_ERROR("posix_memalign( bytes = " << bytes << ", pagesize = " << get_page_size() 
+                                              << " ) failed with error = ", err);
     }
 
     return ret;

--- a/src/umpire/alloc/PosixMemalignAllocator.hpp
+++ b/src/umpire/alloc/PosixMemalignAllocator.hpp
@@ -35,8 +35,8 @@ struct PosixMemalignAllocator {
     UMPIRE_LOG(Debug, "(bytes=" << bytes << ") returning " << ret);
 
     if (ret == nullptr) {
-      UMPIRE_ERROR("posix_memalign( bytes = " << bytes << ", pagesize = " << get_page_size() 
-                                              << " ) failed with error = ", err);
+      UMPIRE_ERROR(
+          "posix_memalign( bytes = " << bytes << ", pagesize = " << get_page_size() << " ) failed with error = ", err);
     }
 
     return ret;


### PR DESCRIPTION
silencing 

```
umpire/src/umpire/alloc/PosixMemalignAllocator.hpp: In member function ‘void* umpire::alloc::PosixMemalignAllocator::allocate(std::size_t)’:
umpire/src/umpire/alloc/PosixMemalignAllocator.hpp:33:21: error: ignoring return value of ‘int posix_memalign(void**, size_t, size_t)’, declared with attribute warn_unused_result [-Werror=unused-result]
```