### PR TITLE
Removing umpire_interface install targets since not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Changed
 
 - Reorganized cmake object library for c/fortran interface. NOTE: This is a breaking
-  change since the include paths are different.
+  change since the include paths are different. 
 
 ### Removed
 

--- a/src/umpire/interface/c_fortran/CMakeLists.txt
+++ b/src/umpire/interface/c_fortran/CMakeLists.txt
@@ -52,14 +52,6 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-install(TARGETS
-  umpire_interface
-  EXPORT umpire-targets
-  OBJECTS DESTINATION lib
-  RUNTIME DESTINATION lib
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
-
 install(FILES
   ${umpire_interface_c_fortran_headers}
   DESTINATION include/umpire/interface/c_fortran)


### PR DESCRIPTION
PR #631 accidentally introduced this bug, this just takes out the unnecessary cmake install command.