### PR TITLE
Add a umpire-config-version cmake file to allow version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Use C++17 for SYCL backend.
 
+- Fixed a cmake install config issue so that now users can find a package of Umpire
+  with a version constraint.
+
 ## [v6.0.0 - 2021-08-18]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,8 +136,12 @@ install(FILES
   DESTINATION share/umpire/cmake)
 
 write_basic_package_version_file(
-  umpire-config-version.cmake
+  ${PROJECT_BINARY_DIR}/umpire-config-version.cmake
   COMPATIBILITY SameMajorVersion)
+
+install(FILES 
+  "${PROJECT_BINARY_DIR}/umpire-config-version.cmake"
+  DESTINATION share/umpire/cmake)
 
 install(EXPORT umpire-targets DESTINATION share/umpire/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,10 @@ install(FILES
   "${PROJECT_BINARY_DIR}/umpire-config.cmake"
   DESTINATION share/umpire/cmake)
 
+write_basic_package_version_file(
+  ${CMAKE_INSTALL_PREFIX}/umpire-config-version.cmake
+  COMPATIBILITY SameMajorVersion)
+
 install(EXPORT umpire-targets DESTINATION share/umpire/cmake)
 
 if (UMPIRE_ENABLE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ install(FILES
   DESTINATION share/umpire/cmake)
 
 write_basic_package_version_file(
-  ${CMAKE_INSTALL_PREFIX}/umpire-config-version.cmake
+  umpire-config-version.cmake
   COMPATIBILITY SameMajorVersion)
 
 install(EXPORT umpire-targets DESTINATION share/umpire/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ cmake_policy(SET CMP0057 NEW)
 cmake_policy(SET CMP0054 NEW)
 
 include(CMakeDependentOption)
+include(CMakePackageConfigHelpers)
 
 project(Umpire
   LANGUAGES CXX C


### PR DESCRIPTION
Closes #654 

CMake's documentation [here](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html?highlight=cmakepackageconfighelpers#command:write_basic_package_version_file)