### PR TITLE
Add 0 value for rtype in enum

### DIFF
--- a/tools/replay/ReplayFile.hpp
+++ b/tools/replay/ReplayFile.hpp
@@ -16,7 +16,8 @@
 class ReplayFile {
 public:
   enum rtype {
-      MEMORY_RESOURCE = 1
+      UNKNOWN = 0
+    , MEMORY_RESOURCE = 1
     , ALLOCATION_ADVISOR
     , DYNAMIC_POOL_LIST
     , MONOTONIC


### PR DESCRIPTION
This allows us to use memset to initialize AllocatorTableEntry to all 0.

Prior to this change, this warning would be triggered in GCC 10.2.1:
`error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type`

The warning is valid, since prior to this change, 0 was not a valid value
for the rtype enum.