### PR TITLE
Force gcc to treate Replay tool object as POD

### DIFF
--- a/tools/replay/ReplayInterpreter.cpp
+++ b/tools/replay/ReplayInterpreter.cpp
@@ -63,7 +63,7 @@ void ReplayInterpreter::buildOperations()
 
     hdr = m_ops->getOperationsTable();
     hdr->num_allocators = 0;
-    memset(hdr->allocators, 0, sizeof(hdr->allocators));
+    memset(static_cast<void*>(hdr->allocators), 0, sizeof(hdr->allocators));
     op = &hdr->ops[0];
     memset(op, 0, sizeof(*op));
     op->op_type = ReplayFile::otype::ALLOCATE;


### PR DESCRIPTION
By type casting the pointer to an AllocatorTableEntry to be 'void*',
this will circumvent the typecheck being done by gcc 8 or higher to
determine whether the object is a POD or not. (see:
https://github.com/dotnet/runtime/issues/12684)

Prior to this change, this warning would be triggered in GCC 10.2.1:
  error: 'void* memset(void*, int, size_t)' clearing an object of
  non-trivial type`

It is unclear why gcc is considering this POD to be non-trivial.