### PR TITLE
Add documentation for the device allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Added a reset function to the DeviceAllocator so that old data can be rewritten.
 
+- Added documentation of the DeviceAllocator.
+
 ### Changed
 
 - Reorganized cmake object library for c/fortran interface. NOTE: This is a breaking

--- a/docs/sphinx/features.rst
+++ b/docs/sphinx/features.rst
@@ -9,6 +9,7 @@ Features
 
   features/allocators
   features/allocator_accessibility
+  features/device_allocators
   features/backtrace
   features/file_output
   features/logging_and_replay

--- a/docs/sphinx/features/allocators.rst
+++ b/docs/sphinx/features/allocators.rst
@@ -4,3 +4,25 @@ Allocators
 
 Allocators are the fundamental object used to allocate and deallocate memory
 using Umpire.
+
+Allocators provide a unified interface to allocate and free data. 
+They also encapsulate all the details of how and where allocations will be made, and can also be used to introspect the memory resource. 
+The allocator objects do not return typed allocations, so the pointer returned from the allocate method must be cast to the relevant type.
+
+Typed Allocator
+--------------
+
+The Typed Allocator is an allocator for objects of type `T`.
+
+This class is an adaptor that allows using an Allocator to allocate objects of type `T`. 
+You can use this class as an allocator for STL containers like `std::vector`.
+
+Device Allocator
+----------------
+
+The Device Allocator is an allocator specifically designed to be used on the GPU.
+
+The Device Allocator is created with a `size` parameter that specifies the maximum amount of memory
+available for the Device Allocator to use. Hence, the Device Allocator doesn't actually allocate
+new memory when the ``allocate`` member function is called. Instead, it increments a pointer
+atomically to the relevant data.

--- a/docs/sphinx/features/device_allocators.rst
+++ b/docs/sphinx/features/device_allocators.rst
@@ -1,0 +1,79 @@
+.. _device_allocators:
+
+=================
+Device Allocators
+=================
+
+The DeviceAllocator is designed for memory allocations on the GPU. 
+Currently there is only support for CUDA, although HIP support is coming soon.
+
+Creating a Device Allocator
+--------------------------
+
+To create a DeviceAllocator, users can call the :class:`umpire::make_device_allocator` host function.
+This function takes an allocator, the total amount of memory the DeviceAllocator will have, and a name
+for the new DeviceAllocator object, as shown below. Currently, a maximum of 64 unique DeviceAllocators can be
+created at a time.
+
+.. literalinclude:: ../../../examples/device-allocator.cpp
+   :start-after: _sphinx_tag_make_dev_allocator_start
+   :end-before: _sphinx_tag_make_dev_allocator_end
+   :language: C++
+
+When the DeviceAllocator is created, the ``size`` parameter that is passed to the :class:`umpire::make_device_allocator`
+function is the total memory, in bytes, available to that allocator. Whenever the ``allocate`` function is
+called on the GPU, it is simply atomically incrementing a counter which offsets a pointer to the start of that
+memory.
+
+Retrieving a DeviceAllocator Object
+-----------------------------------
+
+The :class:`umpire::get_device_allocator` host/device function returns the DeviceAllocator object that corresponds 
+to the ID or name given. The DeviceAllocator class also includes a helper function, :class:`umpire::is_device_allocator`,
+to query whether or not a given ID corresponds to an existing DeviceAllocator. Below is an example of using the **ID** to 
+obtain the DeviceAllocator object:
+
+.. literalinclude:: ../../../examples/device-allocator.cpp
+   :start-after: _sphinx_tag_get_dev_allocator_id_start
+   :end-before: _sphinx_tag_get_dev_allocator_id_end
+   :language: C++
+
+And next is an example of using the **name** instead:
+
+.. literalinclude:: ../../../examples/device-allocator.cpp
+   :start-after: _sphinx_tag_get_dev_allocator_name_start
+   :end-before: _sphinx_tag_get_dev_allocator_name_end
+   :language: C++
+
+With the :class:`umpire::get_device_allocator` function, there is no need to keep track of a DeviceAllocator, since function
+call stacks can become quite complex. Users can instead use this function to obtain it inside whichever host or device
+function they need.
+
+Under the hood, the :class:`umpire::get_device_allocator` uses global arrays which can be accessed by both 
+the host and device. The global array is indexed by DeviceAllocator ID, which is returned by :class:`DeviceAllocator::getID()`. 
+Because we are using global arrays on host and device, the arrays need to be "set up" after at least one DeviceAllocator
+has been created, but before any kernels which use a DeviceAllocator are called. This process is done by calling 
+the ``UMPIRE_SET_UP_DEVICE_ALLOCS()`` macro. This just ensures that the host and device global arrays are updated and 
+pointing at the same memory.
+
+.. note::
+   In order to use the full capabilities of the DeviceAllocator, relocatable device code must be enabled.
+
+Resetting Memory on the DeviceAllocator
+---------------------------------------
+
+The memory that has been used with the DeviceAllocator is only freed at the end of a program when the 
+ResourceManager is torn down. However, there is a way to overwrite old or outdated data. Users can call
+the :class:`DeviceAllocator::reset()` method which will allows old data to be overwritten. Below is an example:
+
+.. literalinclude:: ../../../examples/device-allocator.cpp
+   :start-after: _sphinx_tag_reset_start
+   :end-before: _sphinx_tag_reset_end
+   :language: C++
+
+The above code snippet shows the ``reset()`` function being called from the host. Calling the function from the host
+utilizes the ResourceManager and Umpire's ``memset`` operation under the hood. Therefore, there is some kind of 
+synchronization guaranteed. However, if the ``reset()`` function is called on the device, there is no synchronization
+guaranteed, so the user must be very careful not to reset memory that other GPU threads still need.
+
+.. literalinclude:: ../../../examples/device-allocator.cpp

--- a/examples/device-allocator.cpp
+++ b/examples/device-allocator.cpp
@@ -24,7 +24,9 @@ using resource_type = camp::resources::Hip;
 __global__ void my_kernel(double** data_ptr)
 {
   if (threadIdx.x == 0) {
+    // _sphinx_tag_get_dev_allocator_id_start
     umpire::DeviceAllocator alloc = umpire::get_device_allocator(0);
+    // _sphinx_tag_get_dev_allocator_id_end
     double* data = static_cast<double*>(alloc.allocate(1 * sizeof(double)));
     *data_ptr = data;
     data[0] = 1024;
@@ -34,7 +36,9 @@ __global__ void my_kernel(double** data_ptr)
 __global__ void my_other_kernel(double** data_ptr)
 {
   if (threadIdx.x == 0) {
+    // _sphinx_tag_get_dev_allocator_name_start
     umpire::DeviceAllocator alloc = umpire::get_device_allocator("my_device_alloc");
+    // _sphinx_tag_get_dev_allocator_name_end
     double* data = static_cast<double*>(alloc.allocate(1 * sizeof(double)));
     *data_ptr = data;
     data[0] = 42;
@@ -43,12 +47,14 @@ __global__ void my_other_kernel(double** data_ptr)
 
 int main(int argc, char const* argv[])
 {
-  auto& rm = umpire::ResourceManager::getInstance();
   auto resource = camp::resources::Resource{resource_type{}};
 
   // Create my allocators.
+  // _sphinx_tag_make_dev_allocator_start
+  auto& rm = umpire::ResourceManager::getInstance();
   auto allocator = rm.getAllocator("UM");
-  auto device_allocator = umpire::make_device_allocator(allocator, 8, "my_device_alloc");
+  auto device_allocator = umpire::make_device_allocator(allocator, sizeof(double), "my_device_alloc");
+  // _sphinx_tag_make_dev_allocator_end
 
   // Checking that a DeviceAllocator exists...
   if (umpire::is_device_allocator(0)) {
@@ -57,8 +63,10 @@ int main(int argc, char const* argv[])
 
   double** ptr_to_data = static_cast<double**>(allocator.allocate(sizeof(double*)));
 
-  // Make sure that device and host side DeviceAllocator pointers are synched.
+  // Make sure that device and host side DeviceAllocator pointers are synched
+  // _sphinx_tag_macro_start
   UMPIRE_SET_UP_DEVICE_ALLOCATORS();
+  // _sphinx_tag_macro_end
 
   my_kernel<<<1, 16>>>(ptr_to_data);
   resource.get_event().wait();


### PR DESCRIPTION
Documented the important aspects of the DeviceAllocator (all except the Hip support functionality which is still in progress).

https://umpire.readthedocs.io/en/task-um-944-document-device-allocator/sphinx/features/device_allocators.html
