### PR TITLE
Fix source documentation link to doxygen

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,21 +28,23 @@
 
 import os, subprocess
 
+
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
-
 if read_the_docs_build:
-  # Makes sure directory exists for doxygen output
-  cwd=os.getcwd()
-  buildpath=os.path.join(cwd,"_build")
-  if (os.path.isdir(buildpath) == 0):
-    os.mkdir(buildpath)
-  htmlpath=os.path.join(buildpath,"html")
-  if (os.path.isdir(htmlpath) == 0):
-    os.mkdir(htmlpath)
-
-  # Call doxygen
-  from subprocess import call
-  call(['doxygen', "./doxygen/Doxyfile"])
+    # Generate an RST file for Doxygen index, this is replaced by the real
+    # index.html by hooking into the Sphinx build-finished event at the bottom of
+    # this file
+    cwd=os.getcwd()
+    fpath=os.path.join(cwd,"doxygen/html")
+    if (os.path.isdir(fpath) == 0):
+        os.makedirs(fpath)
+    with open(os.path.join(fpath,"index.rst"), 'w') as f:
+        print("Writing file {}", f)
+        f.write(".. _doxygen:\n")
+        f.write("\n")
+        f.write("*******\n")
+        f.write("Doxygen\n")
+        f.write("*******\n")
 
 # Get current directory
 conf_directory = os.path.dirname(os.path.realpath(__file__))
@@ -200,4 +202,24 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+
+# Generate Doxygen, and overwrite the index.rst in doxygen/html
+# Only do this on readthedocs
+def gendoxy(app, exception):
+    if read_the_docs_build:
+        buildpath=os.path.join(conf_directory,"_build/html/doxygen/html")
+        if (os.path.isdir(buildpath) == 0):
+            os.makedirs(buildpath)
+
+        if (os.path.exists(os.path.join(buildpath, 'index.html"'))):
+            print("Removing existing index.html")
+            os.remove(os.path.join(buildpath, "index.html"))
+
+        # Call doxygen
+        from subprocess import call
+        call(['doxygen', "./doxygen/Doxyfile"])
+
+
+def setup(app):
+    app.connect('build-finished', gendoxy)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Any questions? File an issue on GitHub, or email umpire-dev@llnl.gov
   sphinx/advanced_configuration
   sphinx/cookbook
   sphinx/features
-  Source Documentation <doxygen/html/index.html#http://>
+  doxygen/html/index
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
Check the docs here: https://umpire.readthedocs.io/en/bugfix-um-959-fix-source-docs-link/

You should see the "Doxygen" sidebar link that goes directly to the Doxgen index.