### PR TITLE
Make ResourceManager::isAllocator work for resources

### DIFF
--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -302,7 +302,11 @@ Allocator ResourceManager::getAllocator(void* ptr)
 
 bool ResourceManager::isAllocator(const std::string& name) noexcept
 {
-  return (m_allocators_by_name.find(name) != m_allocators_by_name.end());
+  resource::MemoryResourceRegistry& registry{resource::MemoryResourceRegistry::getInstance()};
+  auto resource_names = registry.getResourceNames();
+
+  return (m_allocators_by_name.find(name) != m_allocators_by_name.end() ||
+          std::find(resource_names.begin(), resource_names.end(), name) != std::end(resource_names));
 }
 
 bool ResourceManager::isAllocator(int id) noexcept

--- a/tests/integration/allocator_integration_tests.cpp
+++ b/tests/integration/allocator_integration_tests.cpp
@@ -17,6 +17,7 @@ class AllocatorTest : public ::testing::TestWithParam<std::string> {
   virtual void SetUp()
   {
     auto& rm = umpire::ResourceManager::getInstance();
+    ASSERT_TRUE(rm.isAllocator(GetParam()));
     m_allocator = new umpire::Allocator(rm.getAllocator(GetParam()));
   }
 


### PR DESCRIPTION
MemoryResources like HOST are created lazily, and constructed the first
time they are requested through ResourceManager::getAllocator

The isAllocator function previously only considered created allocators,
this change makes it check the list of (potentially not yet created)
memory resources.