### PR TITLE
Add ResourceManager::prefetch method

### DIFF
--- a/src/umpire/ResourceManager.cpp
+++ b/src/umpire/ResourceManager.cpp
@@ -698,6 +698,25 @@ void* ResourceManager::move(void* ptr, Allocator allocator)
   return dst_ptr;
 }
 
+camp::resources::EventProxy<camp::resources::Resource> ResourceManager::prefetch(void* ptr, int device,
+                                                                                 camp::resources::Resource& ctx)
+{
+  UMPIRE_LOG(Debug, "(ptr=" << ptr << ", device=" << device << ")");
+
+  auto& op_registry = op::MemoryOperationRegistry::getInstance();
+  auto alloc_record = m_allocations.find(ptr);
+
+  if (alloc_record->strategy->getTraits().resource != umpire::MemoryResourceTraits::resource_type::um) {
+    UMPIRE_ERROR("ResourceManager::prefetch only works on allocations from a UM resource.");
+  }
+
+  std::ptrdiff_t offset = static_cast<char*>(ptr) - static_cast<char*>(alloc_record->ptr);
+  std::size_t size = alloc_record->size - offset;
+
+  auto op = op_registry.find("PREFETCH", alloc_record->strategy, alloc_record->strategy);
+  return op->apply_async(ptr, alloc_record, device, size, ctx);
+}
+
 void ResourceManager::deallocate(void* ptr)
 {
   UMPIRE_LOG(Debug, "(ptr=" << ptr << ")");

--- a/src/umpire/ResourceManager.hpp
+++ b/src/umpire/ResourceManager.hpp
@@ -281,6 +281,16 @@ class ResourceManager {
   void deallocate(void* ptr);
 
   /*!
+   * \brief Asynchronously prefetch memory ptr to device.
+   *
+   * \param ptr Pointer to prefech
+   * \param device Device to prefetch data to
+   * \param ctx Resource to use for asynchronous operation
+   */
+  camp::resources::EventProxy<camp::resources::Resource> prefetch(void* ptr, int device,
+                                                                  camp::resources::Resource& ctx);
+
+  /*!
    * \brief Get the size in bytes of the allocation for the given pointer.
    *
    * \param ptr Pointer to find size of.

--- a/src/umpire/op/CudaMemPrefetchOperation.hpp
+++ b/src/umpire/op/CudaMemPrefetchOperation.hpp
@@ -15,6 +15,10 @@ namespace op {
 class CudaMemPrefetchOperation : public MemoryOperation {
  public:
   void apply(void* src_ptr, umpire::util::AllocationRecord* src_allocation, int value, std::size_t length);
+
+  camp::resources::EventProxy<camp::resources::Resource> apply_async(void* src_ptr, util::AllocationRecord* ptr,
+                                                                     int value, std::size_t length,
+                                                                     camp::resources::Resource& ctx);
 };
 
 } // end of namespace op

--- a/tests/integration/operation_tests.cpp
+++ b/tests/integration/operation_tests.cpp
@@ -807,3 +807,24 @@ TEST(AsyncTest, Reallocate)
   device_alloc.deallocate(source_array);
 }
 #endif
+
+#if defined(UMPIRE_ENABLE_CUDA)
+TEST(AsyncTest, Prefetch)
+{
+  auto resource = camp::resources::Resource{resource_type{}};
+  auto& rm = umpire::ResourceManager::getInstance();
+
+  constexpr std::size_t size = 1024;
+
+  auto alloc = rm.getAllocator("UM");
+  float* array = static_cast<float*>(alloc.allocate(size * sizeof(float)));
+
+  ASSERT_NE(array, nullptr);
+
+  // Prefetch to device 0
+  camp::resources::Event event = rm.prefetch(array, 0, resource);
+  event.wait();
+
+  alloc.deallocate(array);
+}
+#endif


### PR DESCRIPTION
Add apply_async to the CudaMemPrefetchOperation that takes a
camp::resource to determine which stream to perform the prefetch on.

Expose the "PREFETCH" operations registered with the
MemoryOperationRegistry with a new ResourceManager::prefetch method.
Previously, these operations were only accessible manually, or through
the AllocationPrefetcher strategy.