### PR TITLE
Fixed link to Resources Page in Docs

### DIFF
--- a/docs/sphinx/features/allocator_accessibility.rst
+++ b/docs/sphinx/features/allocator_accessibility.rst
@@ -6,8 +6,7 @@ Allocator Accessibility
 
 The Umpire library provides a variety of :class:`umpire::resource::MemoryResource` s 
 which can be used to create :class:`umpire::Allocator` s depending on what's available on
-your system. The resources are explained more on the `Resources <https://umpire.readthedocs.io/en/develop/tutorial/resources.html>`_
-page.
+your system. The resources are explained more on the :ref:`Resources` page.
 
 Additionally, the `platforms <https://github.com/LLNL/Umpire/blob/develop/src/umpire/util/Platform.hpp>`_ that Umpire supports is defined by the `CAMP <https://github.com/LLNL/camp/blob/master/include/camp/resource/platform.hpp>`_ library.
 This means that there is also a selection of platforms for which an allocator can


### PR DESCRIPTION
Before, the Allocator Accessibility page had a hard link to the Resources page. When the docs got reorganized, the link broke. To make the link more robust to changes to the docs, I changed it to use the :ref: keyword which references another page in the docs. It should withstand reorg changes.

Note: Tried for a long time to figure out how to use the :doc: keyword instead, but nothing seemed to work right. Will stick to using :ref: since it seems to work well.