### PR TITLE
Make umpire-config.cmake package relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,13 +128,15 @@ include(cmake/SetupUmpireThirdParty.cmake)
 
 add_subdirectory(src)
 
-configure_file(
-  umpire-config.cmake.in
-  "${PROJECT_BINARY_DIR}/umpire-config.cmake" @ONLY)
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/umpire-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/umpire-config.cmake"
+  PATH_VARS CMAKE_INSTALL_PREFIX
+  INSTALL_DESTINATION lib/cmake/umpire)
 
 install(FILES
-  "${PROJECT_BINARY_DIR}/umpire-config.cmake"
-  DESTINATION share/umpire/cmake)
+  ${PROJECT_BINARY_DIR}/umpire-config.cmake
+  DESTINATION lib/cmake/umpire)
 
 write_basic_package_version_file(
   ${PROJECT_BINARY_DIR}/umpire-config-version.cmake
@@ -142,9 +144,9 @@ write_basic_package_version_file(
 
 install(FILES 
   "${PROJECT_BINARY_DIR}/umpire-config-version.cmake"
-  DESTINATION share/umpire/cmake)
+  DESTINATION lib/cmake/umpire)
 
-install(EXPORT umpire-targets DESTINATION share/umpire/cmake)
+install(EXPORT umpire-targets DESTINATION lib/cmake/umpire)
 
 if (UMPIRE_ENABLE_TESTS)
   add_subdirectory(tests)

--- a/src/umpire/tpl/CMakeLists.txt
+++ b/src/umpire/tpl/CMakeLists.txt
@@ -85,10 +85,8 @@ if (NOT TARGET camp)
       ${camp_DIR}/lib/cmake/camp
     )
     set_target_properties(camp PROPERTIES IMPORTED_GLOBAL TRUE)
-    set(umpire_camp_DIR ${camp_DIR} CACHE PATH "")
   else ()
     add_subdirectory(camp)
-    set(umpire_camp_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/camp CACHE PATH "")
   endif()
 
   if(UMPIRE_ENABLE_CUDA)

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -4,23 +4,13 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-get_filename_component(UMPIRE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(UMPIRE_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
+@PACKAGE_INIT@
 
 if (NOT TARGET camp)
-  if (NOT DEFINED camp_DIR)
-    set(camp_DIR @umpire_camp_DIR@)
-  endif ()
-  find_package(camp REQUIRED
-    NO_DEFAULT_PATH
-    PATHS ${camp_DIR}
-    ${camp_DIR}/lib/cmake/camp
-  )
+  include(CMakeFindDependencyMacro)
+  find_dependency(camp CONFIG PATHS @PACKAGE_CMAKE_INSTALL_PREFIX@)
 endif ()
 
-set(Umpire_VERSION_MAJOR  @Umpire_VERSION_MAJOR@)
-set(Umpire_VERSION_MINOR @Umpire_VERSION_MINOR@)
-set(Umpire_VERSION_PATCH @Umpire_VERSION_PATCH@)
-set(Umpire_VERSION_RC "@UMPIRE_VERSION_RC@")
+include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 
-include("${UMPIRE_CMAKE_DIR}/umpire-targets.cmake")
+check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
Use configure_package_config_file to make the umpire-config.cmake
package file "relocatable". The file can be moved after install and
still work. See: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html