### PR TITLE
Add get_process_memory_usage_hwm helper

### DIFF
--- a/src/umpire/Umpire.hpp
+++ b/src/umpire/Umpire.hpp
@@ -151,6 +151,12 @@ std::string get_backtrace(void* ptr);
 std::size_t get_process_memory_usage();
 
 /*!
+ * \brief Get high watermark memory usage of the current process (uses underlying
+ * system-dependent calls)
+ */
+std::size_t get_process_memory_usage_hwm();
+
+/*!
  * \brief Mark an application-specific event string within Umpire life cycle.
  */
 void mark_event(const std::string& event);

--- a/src/umpire/interface/c_fortran/wrapUmpire.cpp
+++ b/src/umpire/interface/c_fortran/wrapUmpire.cpp
@@ -74,6 +74,14 @@ size_t umpire_get_process_memory_usage(void)
     // splicer end function.get_process_memory_usage
 }
 
+size_t umpire_get_process_memory_usage_hwm(void)
+{
+    // splicer begin function.get_process_memory_usage_hwm
+    size_t SHC_rv = umpire::get_process_memory_usage_hwm();
+    return SHC_rv;
+    // splicer end function.get_process_memory_usage_hwm
+}
+
 size_t umpire_get_device_memory_usage(int device_id)
 {
     // splicer begin function.get_device_memory_usage

--- a/src/umpire/interface/c_fortran/wrapUmpire.h
+++ b/src/umpire/interface/c_fortran/wrapUmpire.h
@@ -40,6 +40,8 @@ void umpire_get_backtrace_bufferify(void * ptr,
 
 size_t umpire_get_process_memory_usage(void);
 
+size_t umpire_get_process_memory_usage_hwm(void);
+
 size_t umpire_get_device_memory_usage(int device_id);
 
 int umpire_get_major_version(void);

--- a/src/umpire/interface/c_fortran/wrapfumpire.f
+++ b/src/umpire/interface/c_fortran/wrapfumpire.f
@@ -856,6 +856,14 @@ module umpire_mod
             integer(C_SIZE_T) :: SHT_rv
         end function get_process_memory_usage
 
+        function get_process_memory_usage_hwm() &
+                result(SHT_rv) &
+                bind(C, name="umpire_get_process_memory_usage_hwm")
+            use iso_c_binding, only : C_SIZE_T
+            implicit none
+            integer(C_SIZE_T) :: SHT_rv
+        end function get_process_memory_usage_hwm
+
         function get_device_memory_usage(device_id) &
                 result(SHT_rv) &
                 bind(C, name="umpire_get_device_memory_usage")

--- a/src/umpire/interface/umpire_shroud.yaml
+++ b/src/umpire/interface/umpire_shroud.yaml
@@ -35,6 +35,7 @@ declarations:
   - decl: bool pointer_contains(void* left, void* right)
   - decl: string get_backtrace(void* ptr)
   - decl: size_t get_process_memory_usage()
+  - decl: size_t get_process_memory_usage_hwm()
   - decl: size_t get_device_memory_usage(int device_id)
   - decl: int get_major_version()
   - decl: int get_minor_version()

--- a/tests/integration/interface/allocator_c_tests.cpp
+++ b/tests/integration/interface/allocator_c_tests.cpp
@@ -100,6 +100,7 @@ TEST_P(AllocatorCTest, Introspection)
   ASSERT_FALSE(umpire_pointer_contains(data_one, data_two));
   ASSERT_FALSE(umpire_pointer_overlaps(data_one, data_two));
   ASSERT_GE(umpire_get_process_memory_usage(), 0);
+  ASSERT_GE(umpire_get_process_memory_usage_hwm(), umpire_get_process_memory_usage());
   ASSERT_GE(umpire_get_device_memory_usage(0), 0);
 
   umpire_allocator_deallocate(&m_allocator, data_three);

--- a/tests/integration/interface/fortran/introspection_fortran_tests.F
+++ b/tests/integration/interface/fortran/introspection_fortran_tests.F
@@ -21,7 +21,7 @@ module umpire_fortran_introspection_tests
           type(UmpireAllocator) allocator
 
           integer(C_INT), pointer, dimension(:) :: array
-          integer(C_SIZE_T) :: memory_usage, allocation_count
+          integer(C_SIZE_T) :: memory_usage, memory_hwm, allocation_count
           integer(C_SIZE_T) :: zero
 
           zero = 0
@@ -31,6 +31,9 @@ module umpire_fortran_introspection_tests
 
           memory_usage = get_process_memory_usage()
           call assert_true(memory_usage .ge. zero)
+
+          memory_hwm = get_process_memory_usage_hwm()
+          call assert_true(memory_hwm .ge. zero)
 
           call allocator%allocate(array, [10])
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -32,6 +32,15 @@ blt_add_test(
   NAME version_tests
   COMMAND version_tests)
 
+blt_add_executable(
+  NAME umpire_tests
+  SOURCES umpire_tests.cpp
+  DEPENDS_ON ${unit_depends})
+
+blt_add_test(
+  NAME umpire_tests
+  COMMAND umpire_tests)
+
 add_subdirectory(alloc)
 add_subdirectory(op)
 add_subdirectory(resource)

--- a/tests/unit/umpire_tests.cpp
+++ b/tests/unit/umpire_tests.cpp
@@ -1,0 +1,15 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC and Umpire
+// project contributors. See the COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (MIT)
+//////////////////////////////////////////////////////////////////////////////
+#include "gtest/gtest.h"
+#include "umpire/Umpire.hpp"
+
+TEST(Umpire, ProcessorMemoryStatistics)
+{
+  ASSERT_GE(umpire::get_process_memory_usage(), 0);
+  ASSERT_GE(umpire::get_process_memory_usage_hwm(), umpire::get_process_memory_usage());
+  ASSERT_GE(umpire::get_device_memory_usage(0), 0);
+}


### PR DESCRIPTION
This function has been added to the umpire namespace and will
return the high watermark reached for process resident set size.