### PR TITLE
Add replay --introspection-off option

### DIFF
--- a/tools/replay/ReplayOperationManager.cpp
+++ b/tools/replay/ReplayOperationManager.cpp
@@ -300,6 +300,10 @@ void ReplayOperationManager::makeAllocator(ReplayFile::Operation* op)
     }
   }
 
+  if (m_options.introspection_off) {
+    alloc->introspection = false;
+  }
+
   switch (alloc->type) {
     case ReplayFile::rtype::MEMORY_RESOURCE:
       alloc->allocator = new umpire::Allocator(rm.getAllocator(alloc->name));

--- a/tools/replay/ReplayOptions.hpp
+++ b/tools/replay/ReplayOptions.hpp
@@ -45,6 +45,7 @@ struct ReplayOptions {
   bool force_compile{false};      // -r,--recompile
   bool do_not_demangle{false};    // --no-demangle
   bool quiet{false};              // -q,--quiet
+  bool introspection_off{false};  // --introspection-off
   std::string input_file;         // -i,-infile input_file
   std::string pool_to_use;        // -p,--use-pool
   std::string heuristic_to_use{}; // --use-heuristic

--- a/tools/replay/replay.cpp
+++ b/tools/replay/replay.cpp
@@ -37,6 +37,8 @@ int main(int argc, char* argv[])
 
   app.add_flag("-q,--quiet", options.quiet, "Only errors will be displayed.");
 
+  app.add_flag("--introspection-off", options.introspection_off, "Turn off Umpire introspection");
+
   app.add_flag("-t,--time-run", options.time_replay_run, "Display time information for replay running operations");
 
   app.add_flag("-d,--dump", options.dump_statistics,


### PR DESCRIPTION
This option will allow for replays to be run with introspection
turned off for all allocators being replayed.