### PR TITLE
Fix typos and links within ReadTheDocs pages

### DIFF
--- a/docs/sphinx/contribution_guide.rst
+++ b/docs/sphinx/contribution_guide.rst
@@ -92,12 +92,12 @@ tests and reviews, it will be merged into Umpire.
 Tests
 ^^^^^
 
-Umpire uses Bamboo and Gitlab for continuous integration tests. Our tests are
-automatically run against every new pull request, and passing all tests is a
-requirement for merging your PR. If you are developing a bugfix or a new
-feature, please add a test that checks the correctness of your new code. Umpire
-is used on a wide variety of systems with a number of configurations, and adding
-new tests helps ensure that all features work as expected across these
-environments.
+Umpire uses a combination of Github Actions, Azure pipelines, and Gitlab continuous
+integration for our tests. Our tests are automatically run against every new pull
+request, and passing all tests is a requirement for merging your PR. If you are
+developing a bugfix or a new feature, please add a test that checks the correctness
+of your new code. Umpire is used on a wide variety of systems with a number of
+configurations, and adding new tests helps ensure that all features work as expected
+across these environments.
 
 Umpire's tests are all in the ``test`` directory and are split up by component.

--- a/docs/sphinx/cookbook/file_allocation.rst
+++ b/docs/sphinx/cookbook/file_allocation.rst
@@ -33,9 +33,9 @@ The complete example is included below:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_filesystem_memory_allocation.cpp
 
-=============================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Using Burst Buffers On Lassen
-=============================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On Lassen, 1) Download the latest version of Umpire 2) request a private node to build:
 
@@ -68,8 +68,8 @@ To run the built-in benchmarks in Umpire from the build run:
 
   $ lrun -n 1 --threads=** ./bin/file_resource_benchmarks ##
 
-** is a placeholder for the amount of threads wanted to run the benchmark on. 
-## stands for the number of array elements wanted to be passed through the benchmark. 
+In the snippet above, "**" is a placeholder for the amount of threads wanted to run the benchmark on. 
+"##" stands for the number of array elements wanted to be passed through the benchmark. 
 This number can range from 1-100,000,000,000.
 
 Results should appear like:

--- a/docs/sphinx/cookbook/move_between_numa.rst
+++ b/docs/sphinx/cookbook/move_between_numa.rst
@@ -7,7 +7,7 @@ Move Allocations Between NUMA Nodes
 When using NUMA (cache coherent or non uniform memory access) systems, there
 are different latencies to parts of the memory. From an application
 perspective, the memory looks the same, yet especially for high-performance
-computing it is advantageous to have finer control. `malloc()` attempts to
+computing it is advantageous to have finer control. ``malloc()`` attempts to
 allocate memory close to your node, but it can make no guarantees. Therefore,
 Linux provides both a process-level interface for setting NUMA policies with
 the system utility `numactl`, and a fine-grained interface with `libnuma`.

--- a/docs/sphinx/cookbook/thread_safe.rst
+++ b/docs/sphinx/cookbook/thread_safe.rst
@@ -6,11 +6,11 @@ Thread Safe Allocator
 
 If you want thread-safe access to allocations that come from a particular
 :class:`umpire::Allocator`, you can create an instance of a
-`umpire::strategy::ThreadSafeAllocator` object that will synchronize access
+:class:`umpire::strategy::ThreadSafeAllocator` object that will synchronize access
 to it.
 
-In this recipe, we look at creating a `umpire::strategy::ThreadSafeAllocator`
-for an `umpire::strategy::QuickPool` object:
+In this recipe, we look at creating a :class:`umpire::strategy::ThreadSafeAllocator`
+for an :class:`umpire::strategy::QuickPool` object:
 
 .. literalinclude:: ../../../examples/cookbook/recipe_thread_safe.cpp
    :start-after: _sphinx_tag_tut_thread_safe_start

--- a/docs/sphinx/developer/uberenv.rst
+++ b/docs/sphinx/developer/uberenv.rst
@@ -10,7 +10,7 @@ therefore `shared <https://radiuss-ci.readthedocs.io/en/latest/uberenv.html#uber
 This page will provides some Umpire specific examples to illustrate the
 workflow described in the documentation.
 
-Before to start
+Before starting
 ---------------
 
 First of all, it is worth noting that Umpire does not have dependencies, except
@@ -24,9 +24,11 @@ pre-configured.
 Machine specific configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+To view the different configurations for Umpire, follow the steps below:
+
 .. code-block:: bash
 
-  $ ls -c1 scripts/uberenv/spack_configs
+  $ ls -c1 scripts/radiuss-spack-configs
   blueos_3_ppc64le_ib
   darwin
   toss_3_x86_64_ib
@@ -38,27 +40,24 @@ Umpire has been configured for ``toss_3_x86_64_ib`` and other systems.
 Vetted specs
 ^^^^^^^^^^^^
 
+To view the CI jobs for diffrent LC machines, follow the steps below:
+
 .. code-block:: bash
 
   $ ls -c1 .gitlab/*jobs.yml
+  .gitlab/corona-jobs.yml
   .gitlab/lassen-jobs.yml
   .gitlab/ruby-jobs.yml
 
-CI contains jobs for ruby.
+This shows that the CI contains jobs for corona, lassen, and ruby.
 
 .. code-block:: bash
 
   $ git grep -h "SPEC" .gitlab/ruby-jobs.yml | grep "gcc"
       SPEC: "%gcc@4.9.3"
-      SPEC: "%gcc@6.1.0"
-      SPEC: "%gcc@7.1.0"
-      SPEC: "%gcc@7.3.0"
       SPEC: "%gcc@8.1.0"
 
-We now have a list of the specs vetted on ``ruby``/``toss_3_x86_64_ib``.
-
-.. note::
-  In practice, one should check if the job is not *allowed to fail*, or even deactivated.
+In the example above, we see a list of the specs vetted on ``ruby``/``toss_3_x86_64_ib``.
 
 MacOS case
 ^^^^^^^^^^
@@ -69,7 +68,7 @@ In Umpire, the Spack configuration for MacOS contains the default compilers depe
 Using Uberenv to generate the host-config file
 ----------------------------------------------
 
-We have seen that we can safely use `gcc@8.1.0` on ruby. Let us ask for the default configuration first, and then produce static libs, have OpenMP support and run the benchmarks:
+We have seen that we can safely use `gcc@8.1.0` on ruby. Let us ask for the default configuration first, then produce static libs with OpenMP support and run the benchmarks:
 
 .. code-block:: bash
 
@@ -80,7 +79,7 @@ Each will generate a CMake cache file, e.g.:
 
 .. code-block:: bash
 
-  hc-ruby-toss_3_x86_64_ib-gcc@8.1.0-fjcjwd6ec3uen5rh6msdqujydsj74ubf.cmake
+  ruby-toss_3_x86_64_ib-gcc@8.1.0-<some_hash>.cmake
 
 Using host-config files to build Umpire
 ---------------------------------------
@@ -107,12 +106,12 @@ During development, it may be beneficial to regularly check for memory leaks. Th
 
   $ srun -ppdebug -N1 --exclusive python scripts/uberenv/uberenv.py --spec="%clang@9.0.0 cxxflags=-fsanitize=address"
   $ cd build
-  $ cmake -C <path_to>/hc-ruby-toss_3_x86_64_ib-clang@9.0.0.cmake ..
+  $ cmake -C <path_to>/<host-config>.cmake ..
   $ cmake --build -j
   $ ASAN_OPTIONS=detect_leaks=1 make test
 
 .. note::
-  The host config file (i.e., ``hc-ruby-...cmake``) can be reused in order to rebuild with the same configuration if needed.
+  The host config file can be reused in order to rebuild with the same configuration if needed.
 
 This will configure a build with Clang 9.0.0 and the Leak Sanitizer. If there is a leak in one of the tests, it can be useful to gather more information about what happened and more details about where it happened. One way to do this is to run:
 

--- a/docs/sphinx/features/allocator_accessibility.rst
+++ b/docs/sphinx/features/allocator_accessibility.rst
@@ -45,7 +45,7 @@ desired platform and then run ``ctest -T test -R allocator_accessibility_tests -
 for the test code and ``./bin/alloc_access`` for the example code.
 
 .. note::
-   The `Developer's Guide <https://umpire.readthedocs.io/en/develop/developer/uberenv.html>`_ shows
+   The `Developer's Guide <../developer/uberenv.html>`_ shows
    how to configure Umpire with uberenv to build with different CAMP platforms.
 
 Below, the ``allocator_access.cpp`` code is shown to demonstrate how this functionality can be 

--- a/docs/sphinx/features/backtrace.rst
+++ b/docs/sphinx/features/backtrace.rst
@@ -13,11 +13,13 @@ Build Configuration
 -------------------
 Backtrace is enabled in Umpire builds with the following:
 
-- **``cmake ... -DUMPIRE_ENABLE_BACKTRACE=On ...``** to backtrace capability in Umpire.
-- **``cmake -DUMPIRE_ENABLE_BACKTRACE=On -DUMPIRE_ENABLE_BACKTRACE_SYMBOLS=On ...``** to
-  enable Umpire to display symbol information with backtrace.  **Note:**
-  Using programs will need to add the ``-rdyanmic`` and ``-ldl`` linker flags
-  in order to properly link with this configuration of the Umpire library.
+- ``cmake ... -DUMPIRE_ENABLE_BACKTRACE=On ...`` to backtrace capability in Umpire.
+- ``cmake -DUMPIRE_ENABLE_BACKTRACE=On -DUMPIRE_ENABLE_BACKTRACE_SYMBOLS=On ...`` to
+  enable Umpire to display symbol information with backtrace.  
+
+.. note::
+    Using programs will need to add the ``-rdyanmic`` and ``-ldl`` linker flags
+    in order to properly link with this configuration of the Umpire library.
 
 Runtime Configuration
 ---------------------
@@ -35,7 +37,7 @@ Umpire to log backtrace information for each of the leaked Umpire allocations
 found during application exit.
 
 A programatic interface is also availble via the
-func::`umpire::print_allocator_records` free function.
+:func:`umpire::print_allocator_records` free function.
 
 An example for checking and displaying the information this information
 logged above may be found here:

--- a/docs/sphinx/features/device_allocators.rst
+++ b/docs/sphinx/features/device_allocators.rst
@@ -5,14 +5,13 @@ Device Allocators
 =================
 
 The DeviceAllocator is designed for memory allocations on the GPU. 
-Currently there is only support for CUDA, although HIP support is coming soon.
 
 Creating a Device Allocator
 --------------------------
 
 To create a DeviceAllocator, users can call the :class:`umpire::make_device_allocator` host function.
 This function takes an allocator, the total amount of memory the DeviceAllocator will have, and a name
-for the new DeviceAllocator object, as shown below. Currently, a maximum of 64 unique DeviceAllocators can be
+for the new DeviceAllocator object, as shown below. A maximum of 64 unique DeviceAllocators can be
 created at a time.
 
 .. literalinclude:: ../../../examples/device-allocator.cpp
@@ -23,7 +22,8 @@ created at a time.
 When the DeviceAllocator is created, the ``size`` parameter that is passed to the :class:`umpire::make_device_allocator`
 function is the total memory, in bytes, available to that allocator. Whenever the ``allocate`` function is
 called on the GPU, it is simply atomically incrementing a counter which offsets a pointer to the start of that
-memory.
+memory. In other words, the total size from all of the allocates performed on the device with the DeviceAllocator may not 
+exceed the size that was used when making the device allocator.
 
 Retrieving a DeviceAllocator Object
 -----------------------------------

--- a/docs/sphinx/features/logging_and_replay.rst
+++ b/docs/sphinx/features/logging_and_replay.rst
@@ -8,7 +8,7 @@ Logging
 -------
 When debugging memory operation problems, it is sometimes helpful to enable
 Umpire's logging facility.  The logging functionality is enabled for default
-builds unless -DUMPIRE_ENABLE_LOGGING='Off' has been specified in which case it is
+builds unless ``-DUMPIRE_ENABLE_LOGGING=Off`` has been specified in which case it is
 disabled.
 
 If Umpire logging is enabled, it may be controlled by setting the
@@ -99,7 +99,7 @@ to the object that was created within Umpire for that resource.
 makeAllocator Event
 -------------------
 The **makeAllocator** event occurs whenever a new allocator instance is being
-created.  Each call to *makeAllocator* will generate a pair of JSON lines.  The
+created.  Each call to **makeAllocator** will generate a pair of JSON lines.  The
 first line will show the intent of the call and the second line will show both
 the intent and the result.  This is because the makeAllocator call can fail
 and keeping both the intent and result allows us to reproduce this failure

--- a/docs/sphinx/features/operations.rst
+++ b/docs/sphinx/features/operations.rst
@@ -5,10 +5,6 @@ Operations
 ==========
 
 Operations provide an abstract interface to modifying and moving data between
-Umpire :class:`umpire::Allocator`s. 
+Umpire :class:`umpire::Allocator` s. 
 
--------------------
-Provided Operations 
--------------------
-
-.. doxygennamespace:: umpire::op
+A list of provided operations can be found in our source doxygen `here <../../doxygen/html/index.html>`_.

--- a/docs/sphinx/features/strategies.rst
+++ b/docs/sphinx/features/strategies.rst
@@ -10,20 +10,4 @@ pooling methods to speed up allocations to applying different operations to
 every alloctaion.  Strategies can be composed to combine their functionality,
 allowing flexible and reusable implementations of different components.
 
-.. doxygenclass:: umpire::strategy::AllocationStrategy
-
--------------------
-Provided Strategies 
--------------------
-
-.. doxygenclass:: umpire::strategy::AllocationAdvisor
-
-.. doxygenclass:: umpire::strategy::DynamicPoolList
-
-.. doxygenclass:: umpire::strategy::FixedPool
-
-.. doxygenclass:: umpire::strategy::MonotonicAllocationStrategy
-
-.. doxygenclass:: umpire::strategy::SlotPool
-
-.. doxygenclass:: umpire::strategy::ThreadSafeAllocator
+A list of our provided strategies can be found in our source doxygen `here <../../doxygen/html/index.html>`_.

--- a/docs/sphinx/tutorial/resources.rst
+++ b/docs/sphinx/tutorial/resources.rst
@@ -51,7 +51,7 @@ example of how to query this information.
    In order to test some memory resources, you may need to configure your Umpire
    build to use a particular platform (a member of the ``umpire::Allocator``, defined by
    ``Platform.hpp``) that has access to that resource. See the `Developer's 
-   Guide <https://umpire.readthedocs.io/en/develop/developer_guide.html>`_ for more information. 
+   Guide <../developer_guide.html>`_ for more information. 
 
 Next, we will see an example of how to move data between resources using
 operations.


### PR DESCRIPTION
Update sections of ReadTheDocs with relevant info (DeviceAllocator, Developer's Guide, etc.)
Fixed typos and readability (many sections)

https://umpire.readthedocs.io/en/bugfix-um-960-fix-typos-in-docs/index.html
