### PR TITLE
Fix return value from get_process_highwater_mark

### DIFF
--- a/src/umpire/Umpire.cpp
+++ b/src/umpire/Umpire.cpp
@@ -136,9 +136,12 @@ std::size_t get_process_memory_usage_hwm()
 
     if (key == "VmHWM:") {
       std::size_t resident_hwm;
-      long page_size{::sysconf(_SC_PAGE_SIZE)};
       ss >> resident_hwm;
-      rval = std::size_t{resident_hwm * page_size};
+
+      //
+      // "VmHWM" returns the number of kB in use. Convert this to number of bytes
+      //
+      rval = std::size_t{resident_hwm * 1024};
       break;
     }
   }

--- a/tests/integration/interface/allocator_c_tests.cpp
+++ b/tests/integration/interface/allocator_c_tests.cpp
@@ -100,7 +100,12 @@ TEST_P(AllocatorCTest, Introspection)
   ASSERT_FALSE(umpire_pointer_contains(data_one, data_two));
   ASSERT_FALSE(umpire_pointer_overlaps(data_one, data_two));
   ASSERT_GE(umpire_get_process_memory_usage(), 0);
-  ASSERT_GE(umpire_get_process_memory_usage_hwm(), umpire_get_process_memory_usage());
+
+  //
+  // Be careful with the following test case.  The _hwm call must be called last when compared
+  // to the live amount of system memory in use
+  //
+  ASSERT_LE(umpire_get_process_memory_usage(), umpire_get_process_memory_usage_hwm());
   ASSERT_GE(umpire_get_device_memory_usage(0), 0);
 
   umpire_allocator_deallocate(&m_allocator, data_three);

--- a/tests/unit/umpire_tests.cpp
+++ b/tests/unit/umpire_tests.cpp
@@ -10,6 +10,12 @@
 TEST(Umpire, ProcessorMemoryStatistics)
 {
   ASSERT_GE(umpire::get_process_memory_usage(), 0);
-  ASSERT_GE(umpire::get_process_memory_usage_hwm(), umpire::get_process_memory_usage());
+
+  //
+  // Be careful with the following test.  The _hwm call must be called last when compared
+  // to the live amount of system memory in use
+  //
+  ASSERT_LE(umpire::get_process_memory_usage(), umpire::get_process_memory_usage_hwm());
+
   ASSERT_GE(umpire::get_device_memory_usage(0), 0);
 }


### PR DESCRIPTION
This function obtains the high watermark from the VmHWM line in
/proc/PID/status.  The value associated with this field is expressed in
kB.  The previous implementation treated this value as the number of
pages causing the return value to be off by a factor of PAGESIZE/1024.

This fix corrects this by treating VmHWM as kB instead.