### PR TITLE
Remove process high watermark memory test

### DIFF
--- a/tests/integration/interface/allocator_c_tests.cpp
+++ b/tests/integration/interface/allocator_c_tests.cpp
@@ -101,11 +101,6 @@ TEST_P(AllocatorCTest, Introspection)
   ASSERT_FALSE(umpire_pointer_overlaps(data_one, data_two));
   ASSERT_GE(umpire_get_process_memory_usage(), 0);
 
-  //
-  // Be careful with the following test case.  The _hwm call must be called last when compared
-  // to the live amount of system memory in use
-  //
-  ASSERT_LE(umpire_get_process_memory_usage(), umpire_get_process_memory_usage_hwm());
   ASSERT_GE(umpire_get_device_memory_usage(0), 0);
 
   umpire_allocator_deallocate(&m_allocator, data_three);

--- a/tests/unit/umpire_tests.cpp
+++ b/tests/unit/umpire_tests.cpp
@@ -10,12 +10,5 @@
 TEST(Umpire, ProcessorMemoryStatistics)
 {
   ASSERT_GE(umpire::get_process_memory_usage(), 0);
-
-  //
-  // Be careful with the following test.  The _hwm call must be called last when compared
-  // to the live amount of system memory in use
-  //
-  ASSERT_LE(umpire::get_process_memory_usage(), umpire::get_process_memory_usage_hwm());
-
   ASSERT_GE(umpire::get_device_memory_usage(0), 0);
 }


### PR DESCRIPTION
For linux systems, the current process resident set size and its high
watermark are obtained by examing "/proc/self/statm" and "VmHWM" in
"/proc/self/status" respectively.

For reasons that we do not understand, we are occastionally seeing high
watermark values that are less than the resident set size.  Since these
numbers appear to be unreliable on some platforms, the asserting test
has been removed.