### PR TITLE
Fix comparison operators for TypedAllocators

### DIFF
--- a/src/umpire/TypedAllocator.hpp
+++ b/src/umpire/TypedAllocator.hpp
@@ -16,15 +16,11 @@ namespace umpire {
 template <typename T>
 class TypedAllocator;
 
-}
+template <typename U, typename V>
+bool operator==(const TypedAllocator<U>&, const TypedAllocator<V>&);
 
 template <typename U, typename V>
-bool operator==(const umpire::TypedAllocator<U>&, const umpire::TypedAllocator<V>&);
-
-template <typename U, typename V>
-bool operator!=(const umpire::TypedAllocator<U>&, const umpire::TypedAllocator<V>&);
-
-namespace umpire {
+bool operator!=(const TypedAllocator<U>&, const TypedAllocator<V>&);
 
 /*!
  * \brief Allocator for objects of type T
@@ -71,10 +67,10 @@ class TypedAllocator {
   void deallocate(T* ptr, std::size_t size);
 
   template <typename U, typename V>
-  friend bool ::operator==(const TypedAllocator<U>&, const TypedAllocator<V>&);
+  friend bool operator==(const TypedAllocator<U>&, const TypedAllocator<V>&);
 
   template <typename U, typename V>
-  friend bool ::operator!=(const TypedAllocator<U>&, const TypedAllocator<V>&);
+  friend bool operator!=(const TypedAllocator<U>&, const TypedAllocator<V>&);
 
  private:
   umpire::Allocator m_allocator;

--- a/src/umpire/TypedAllocator.inl
+++ b/src/umpire/TypedAllocator.inl
@@ -34,18 +34,18 @@ void TypedAllocator<T>::deallocate(T* ptr, std::size_t UMPIRE_UNUSED_ARG(size))
   m_allocator.deallocate(ptr);
 }
 
-} // end of namespace umpire
-
 template <typename U, typename V>
-bool operator==(const umpire::TypedAllocator<U>& lhs, const umpire::TypedAllocator<V>& rhs)
+bool operator==(const TypedAllocator<U>& lhs, const TypedAllocator<V>& rhs)
 {
   return lhs.m_allocator.getId() == rhs.m_allocator.getId();
 }
 
 template <typename U, typename V>
-bool operator!=(const umpire::TypedAllocator<U>& lhs, const umpire::TypedAllocator<V>& rhs)
+bool operator!=(const TypedAllocator<U>& lhs, const TypedAllocator<V>& rhs)
 {
   return !(lhs == rhs);
 }
+
+} // end of namespace umpire
 
 #endif // UMPIRE_TypedAllocator_INL


### PR DESCRIPTION
Move the operators into the same namespace as TypedAllocator for ADL instead of leaving them in the global namespace.