### PR TITLE
Update containers for CI pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-7.3.0 AS gcc7
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace
-RUN mkdir build && \
+RUN mkdir build && cd build && \
     cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
@@ -11,7 +11,7 @@ FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc8
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace
-RUN mkdir build && \
+RUN mkdir build && cd build && \
     cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
@@ -20,7 +20,7 @@ FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-9.4.0 AS gcc9
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace
-RUN mkdir build && \
+RUN mkdir build && cd build && \
     cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
@@ -29,7 +29,7 @@ FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-11.2.0 AS gcc
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace
-RUN mkdir build && \
+RUN mkdir build && cd build && \
     cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,65 +1,27 @@
-FROM axom/compilers:gcc-5 AS gcc5
+FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc
 ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
-
-FROM axom/compilers:gcc-6 AS gcc6
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++  ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
-
-FROM axom/compilers:gcc-7 AS gcc7
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++  ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
-
-FROM axom/compilers:gcc-8 AS gcc
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace
 RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++  ..
 RUN cd build && make -j 16
 RUN cd build && ctest -T test --output-on-failure
 
-FROM axom/compilers:clang-4 AS clang4
+FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang
 ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace
 RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
 RUN cd build && make -j 16
 RUN cd build && ctest -T test --output-on-failure
 
-FROM axom/compilers:clang-5 AS clang5
+FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc
 ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
+COPY . /home/axom/workspace
 WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
-
-FROM axom/compilers:clang-6 AS clang
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
-
-FROM axom/compilers:nvcc-10 AS nvcc
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On ..
-RUN cd build && make -j 16
+RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+    mkdir build && cd build && \
+    cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
+    make -j 16
 
 FROM axom/compilers:rocm AS hip
 ENV GTEST_COLOR=1
@@ -69,9 +31,9 @@ ENV HCC_AMDGPU_TARGET=gfx900
 RUN mkdir build && cd build && cmake -DROCM_ROOT_DIR=/opt/rocm/include -DHIP_RUNTIME_INCLUDE_DIRS="/opt/rocm/include;/opt/rocm/hip/include" -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DENABLE_HIP=On ..
 RUN cd build && make -j 16
 
-FROM axom/compilers:oneapi-2021.2.0 AS sycl
+FROM ghcr.io/rse-ops/intel-ubuntu-20.04:intel-2021.2.0 AS sycl
 ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
+COPY . /home/umpire/workspace
 WORKDIR /home/axom/workspace
 RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh && mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=dpcpp -DENABLE_WARNINGS_AS_ERRORS=Off -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DUMPIRE_ENABLE_SYCL=On .."
 RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh && cd build && make -j 16"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,14 @@ RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DU
     make -j 16 && \
     ctest -T test --output-on-failure
 
+FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-10.0.0 AS clang10
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
+
 FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-11.0.0 AS clang11
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,102 +1,88 @@
 FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-7.3.0 AS gcc7
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && \
-    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
 
 FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc8
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && \
-    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-9.4.0 AS gcc9
+FROM ghcr.io/rse-ops/gcc-ubuntu-18.04:gcc-9.4.0 AS gcc9
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && \
-    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-11.2.0 AS gcc
+FROM ghcr.io/rse-ops/gcc-ubuntu-18.04:gcc-11.2.0 AS gcc11
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && \
-    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
     make -j 16 && \
     ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11
+FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-11.0.0 AS clang11
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-13.0.0 AS clang
+FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-12.0.0 AS clang12
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-13.0.0 AS clang13
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
 
 FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10
 ENV GTEST_COLOR=1
-COPY . /home/axom/workspace
-WORKDIR /home/axom/workspace
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    mkdir build && cd build && \
     cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
     make -j 16
 
-FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc
+FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11
 ENV GTEST_COLOR=1
-COPY . /home/axom/workspace
-WORKDIR /home/axom/workspace
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    mkdir build && cd build && \
-    cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
-    make -j 16
-
-FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11-debug
-ENV GTEST_COLOR=1
-COPY . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    mkdir build && cd build && \
-    cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
-    make -j 16
-
-FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc
-ENV GTEST_COLOR=1
-COPY . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    mkdir build && cd build && \
     cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
     make -j 16
 
 FROM axom/compilers:rocm AS hip
 ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
 ENV HCC_AMDGPU_TARGET=gfx900
-RUN mkdir build && cd build && cmake -DROCM_ROOT_DIR=/opt/rocm/include -DHIP_RUNTIME_INCLUDE_DIRS="/opt/rocm/include;/opt/rocm/hip/include" -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DENABLE_HIP=On ..
-RUN cd build && make -j 16
+RUN cmake -DROCM_ROOT_DIR=/opt/rocm/include -DHIP_RUNTIME_INCLUDE_DIRS="/opt/rocm/include;/opt/rocm/hip/include" -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DENABLE_HIP=On .. && \
+    make -j 16
 
 FROM ghcr.io/rse-ops/intel-ubuntu-20.04:intel-2021.2.0 AS sycl
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
-WORKDIR /home/axom/workspace
-RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh && mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=dpcpp -DENABLE_WARNINGS_AS_ERRORS=Off -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DUMPIRE_ENABLE_SYCL=On .."
-RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh && cd build && make -j 16"
+WORKDIR /home/umpire/workspace/build
+RUN /bin/bash -c "source /opt/view/setvars.sh && \
+    cmake -DCMAKE_CXX_COMPILER=dpcpp -DENABLE_WARNINGS_AS_ERRORS=Off -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DUMPIRE_ENABLE_SYCL=On .. && \
+    make -j 16"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,81 @@
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc
+FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-7.3.0 AS gcc7
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace
-RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++  ..
-RUN cd build && make -j 16
-RUN cd build && ctest -T test --output-on-failure
+RUN mkdir build && \
+    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang
+FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc8
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace
+RUN mkdir build && \
+    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-9.4.0 AS gcc9
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace
+RUN mkdir build && \
+    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-11.2.0 AS gcc
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace
+RUN mkdir build && \
+    cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ .. && \
+    make -j 16 && \
+    ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace
 RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
 RUN cd build && make -j 16
 RUN cd build && ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-13.0.0 AS clang
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace
+RUN mkdir build && cd build && cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ ..
+RUN cd build && make -j 16
+RUN cd build && ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10
+ENV GTEST_COLOR=1
+COPY . /home/axom/workspace
+WORKDIR /home/axom/workspace
+RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+    mkdir build && cd build && \
+    cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
+    make -j 16
+
+FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc
+ENV GTEST_COLOR=1
+COPY . /home/axom/workspace
+WORKDIR /home/axom/workspace
+RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+    mkdir build && cd build && \
+    cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
+    make -j 16
+
+FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11-debug
+ENV GTEST_COLOR=1
+COPY . /home/axom/workspace
+WORKDIR /home/axom/workspace
+RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+    mkdir build && cd build && \
+    cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On .. && \
+    make -j 16
 
 FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc
 ENV GTEST_COLOR=1
@@ -37,10 +100,3 @@ COPY . /home/umpire/workspace
 WORKDIR /home/axom/workspace
 RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh && mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=dpcpp -DENABLE_WARNINGS_AS_ERRORS=Off -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DUMPIRE_ENABLE_SYCL=On .."
 RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh && cd build && make -j 16"
-
-FROM axom/compilers:clang-10 AS check
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN mkdir build && cd build && cmake -DENABLE_DEVELOPER_DEFAULTS=On -DENABLE_CLANGQUERY=Off -DENABLE_CLANGTIDY=Off -DENABLE_CPPCHECK=Off -DCMAKE_CXX_COMPILER=clang++ ..
-RUN cd build && make check

--- a/Makefile
+++ b/Makefile
@@ -1,51 +1,41 @@
-gcc:
 ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target gcc --no-cache --progress plain .
+	DebugArgs=--progress plain
 else
-	DOCKER_BUILDKIT=1 docker build --target gcc --no-cache .
+	DebugArgs=
 endif
 
-clang:
-ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target clang --no-cache --progress plain .
-else
-	DOCKER_BUILDKIT=1 docker build --target clang --no-cache .
-endif
+gcc7:
+	DOCKER_BUILDKIT=1 docker build --target gcc7 --no-cache $(DebugArgs) .
 
-nvcc:
-ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target nvcc --no-cache --progress plain .
-else
-	DOCKER_BUILDKIT=1 docker build --target nvcc --no-cache .
-endif
+gcc8:
+	DOCKER_BUILDKIT=1 docker build --target gcc8 --no-cache $(DebugArgs) .
 
-hcc:
-ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target hcc --no-cache --progress plain .
-else
-	DOCKER_BUILDKIT=1 docker build --target hcc --no-cache .
-endif
+gcc9:
+	DOCKER_BUILDKIT=1 docker build --target gcc9 --no-cache $(DebugArgs) .
+
+gcc11:
+	DOCKER_BUILDKIT=1 docker build --target gcc11 --no-cache $(DebugArgs) .
+
+clang11:
+	DOCKER_BUILDKIT=1 docker build --target clang11 --no-cache $(DebugArgs) .
+
+clang12:
+	DOCKER_BUILDKIT=1 docker build --target clang12 --no-cache $(DebugArgs) .
+
+clang13:
+	DOCKER_BUILDKIT=1 docker build --target clang13 --no-cache $(DebugArgs) .
+
+nvcc10:
+	DOCKER_BUILDKIT=1 docker build --target nvcc10 --no-cache $(DebugArgs) .
+
+nvcc11:
+	DOCKER_BUILDKIT=1 docker build --target nvcc11 --no-cache $(DebugArgs) .
 
 hip:
-ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target hip --no-cache --progress plain .
-else
-	DOCKER_BUILDKIT=1 docker build --target hip --no-cache .
-endif
+	DOCKER_BUILDKIT=1 docker build --target hip --no-cache $(DebugArgs) .
 
 sycl:
-ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target sycl --no-cache --progress plain .
-else
-	DOCKER_BUILDKIT=1 docker build --target sycl --no-cache .
-endif
-
-check:
-ifeq ($(DEBUG),1)
-	DOCKER_BUILDKIT=1 docker build --target check --no-cache --progress plain .
-else
-	DOCKER_BUILDKIT=1 docker build --target check --no-cache .
-endif
+	DOCKER_BUILDKIT=1 docker build --target sycl --no-cache $(DebugArgs) .
 
 style:
 	scripts/docker/apply-style.sh
@@ -56,10 +46,9 @@ help:
 	@echo 'Build Umpire using Docker!'
 	@echo ''
 	@echo 'target:'
-	@echo '    gcc                            build with GCC 8'
-	@echo '    clang                          build with clang 6'
-	@echo '    nvcc                           build with CUDA 9'
-	@echo '    hcc                            build with hcc'
+	@echo '    gccN                           build with GCC N'
+	@echo '    clangN                         build with clang N'
+	@echo '    nvccN                          build with CUDA N'
 	@echo '    hip                            build with HIP'
 	@echo ''
 	@echo 'variable:'
@@ -67,6 +56,6 @@ help:
 	@echo ''
 	@echo 'For example'
 	@echo ''
-	@echo '    make DEBUG=1 nvcc'
+	@echo '    make DEBUG=1 nvcc11'
 	@echo ''
-	@echo 'builds with the nvcc Docker image and displays all output.'
+	@echo 'builds with the nvcc Docker image for nvcc 11.1.1 and displays all output.'

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ gcc9:
 gcc11:
 	DOCKER_BUILDKIT=1 docker build --target gcc11 --no-cache $(DebugArgs) .
 
+clang10:
+	DOCKER_BUILDKIT=1 docker build --target clang10 --no-cache $(DebugArgs) .
+
 clang11:
 	DOCKER_BUILDKIT=1 docker build --target clang11 --no-cache $(DebugArgs) .
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,16 +46,12 @@ jobs:
         docker_target: gcc8
       gcc9:
         docker_target: gcc9
-      gcc13:
-        docker_target: gcc
       clang11:
         docker_target: clang11
-      clang13:
-        docker_target: clang
       nvcc10:
         docker_target: nvcc10
       nvcc11:
-        docker_target: nvcc
+        docker_target: nvcc11
       hip:
         docker_target: hip
       sycl:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,10 @@ jobs:
         docker_target: clang10
       clang11:
         docker_target: clang11
+      clang12:
+        docker_target: clang12
+      clang13:
+        docker_target: clang13
       nvcc10:
         docker_target: nvcc10
       nvcc11:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,8 @@ jobs:
         docker_target: gcc8
       gcc9:
         docker_target: gcc9
+      clang10:
+        docker_target: clang10
       clang11:
         docker_target: clang11
       nvcc10:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,10 +40,6 @@ jobs:
 - job: Docker
   strategy:
     matrix: 
-      gcc5: 
-        docker_target: gcc5
-      gcc6:
-        docker_target: gcc6
       gcc7:
         docker_target: gcc7
       gcc8:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,14 +43,18 @@ jobs:
       gcc7:
         docker_target: gcc7
       gcc8:
+        docker_target: gcc8
+      gcc9:
+        docker_target: gcc9
+      gcc13:
         docker_target: gcc
-      clang4:
-        docker_target: clang4
-      clang5:
-        docker_target: clang5
-      clang6:
+      clang11:
+        docker_target: clang11
+      clang13:
         docker_target: clang
-      nvcc:
+      nvcc10:
+        docker_target: nvcc10
+      nvcc11:
         docker_target: nvcc
       hip:
         docker_target: hip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,8 +52,6 @@ jobs:
         docker_target: clang11
       clang12:
         docker_target: clang12
-      clang13:
-        docker_target: clang13
       nvcc10:
         docker_target: nvcc10
       nvcc11:

--- a/src/umpire/util/AllocationMap.hpp
+++ b/src/umpire/util/AllocationMap.hpp
@@ -45,7 +45,6 @@ class AllocationMap {
       ConstIterator();
       ConstIterator(const RecordList* list, iterator_begin);
       ConstIterator(const RecordList* list, iterator_end);
-      ConstIterator(const ConstIterator&) = default;
 
       const AllocationRecord& operator*();
       const AllocationRecord* operator->();

--- a/tests/integration/io/CMakeLists.txt
+++ b/tests/integration/io/CMakeLists.txt
@@ -10,33 +10,33 @@ blt_add_executable(
   DEPENDS_ON umpire)
 
 if (NOT C_COMPILER_FAMILY_IS_PGI)
-  include(FindPythonInterp)
+  find_package(Python3)
 
-  if (PYTHON_EXECUTABLE)
+  if (Python3_FOUND)
     umpire_add_test_with_mpi(
       NAME io_tests_with_basename_logging_replay
       NUM_MPI_TASKS 1
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +logging +replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +logging +replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
     umpire_add_test_with_mpi(
       NAME io_tests_with_basename_directory
       NUM_MPI_TASKS 1
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory -logging -replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory -logging -replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
     umpire_add_test_with_mpi(
       NAME io_tests_with_basename_directory_logging
       NUM_MPI_TASKS 1
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory +logging -replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory +logging -replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
     umpire_add_test_with_mpi(
       NAME io_tests_with_basename_directory_replay
       NUM_MPI_TASKS 1
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory -logging +replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory -logging +replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
     umpire_add_test_with_mpi(
       NAME io_tests_with_basename_directory_logging_replay
       NUM_MPI_TASKS 1
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory +logging +replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/io_tests_runner.py "Basename +Directory +logging +replay" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
   endif ()
 endif ()

--- a/tests/integration/io/io_tests_runner.py
+++ b/tests/integration/io/io_tests_runner.py
@@ -75,7 +75,8 @@ def run_io_test(test_env, file_uid, expect_logging, expect_replay):
             env=dict(os.environ, **test_env),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            shell=False)
+            shell=False,
+            text=True)
     pid = test_program.pid
     ecode = test_program.wait()
 

--- a/tests/integration/io/io_tests_runner.py
+++ b/tests/integration/io/io_tests_runner.py
@@ -75,8 +75,7 @@ def run_io_test(test_env, file_uid, expect_logging, expect_replay):
             env=dict(os.environ, **test_env),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            shell=False,
-            text=True)
+            shell=False)
     pid = test_program.pid
     ecode = test_program.wait()
 
@@ -87,7 +86,7 @@ def run_io_test(test_env, file_uid, expect_logging, expect_replay):
         print("{RED}[   ERROR]{END} Unexpected exit code {ecode} from io_test".format(ecode=ecode, **formatters))
         errors = 1
     else:
-        check_output('stderr', error, 'testing error stream')
+        check_output('stderr', error, b'testing error stream')
 
         output_filename = 'umpire_io_tests.{pid}.{uid}.log'.format(uid=file_uid, pid=pid)
         replay_filename = 'umpire_io_tests.{pid}.{uid}.replay'.format(uid=file_uid, pid=pid)
@@ -98,15 +97,15 @@ def run_io_test(test_env, file_uid, expect_logging, expect_replay):
 
         if expect_logging:
             check_file_exists(output_filename)
-            with open(output_filename) as output_file:
-                check_output(output_filename, output_file, 'testing log stream')
+            with open(output_filename, 'rb') as output_file:
+                check_output(output_filename, output_file, b'testing log stream')
         else:
             check_file_not_exists(output_filename)
 
         if expect_replay:
             check_file_exists(replay_filename)
-            with open(replay_filename) as replay_file:
-                check_output(replay_filename, replay_file, 'testing replay stream')
+            with open(replay_filename, 'rb') as replay_file:
+                check_output(replay_filename, replay_file, b'testing replay stream')
         else:
             check_file_not_exists(replay_filename)
 


### PR DESCRIPTION
The CI containers were updated to allow for gcc{7,8,9}, clang{11,12}, and nvcc{10,11}.