### PR TITLE
Temporarily disable CI on Corona

### DIFF
--- a/.gitlab/corona-jobs.yml
+++ b/.gitlab/corona-jobs.yml
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-rocm_4_1_fortran_gcc_8_1_0 (build and test on corona):
-  variables:
-    SPEC: "+fortran+rocm~tools amdgpu_target=gfx906 %gcc@8.1.0 ^blt@develop ^hip@4.1.0"
-  extends: .build_and_test_on_corona
+# rocm_4_1_fortran_gcc_8_1_0 (build and test on corona):
+# variables:
+#   SPEC: "+fortran+rocm~tools amdgpu_target=gfx906 %gcc@8.1.0 ^blt@develop ^hip@4.1.0"
+# extends: .build_and_test_on_corona
 
-rocm_4_2_fortran_gcc_8_1_0 (build and test on corona):
-  variables:
-    SPEC: "+fortran+rocm amdgpu_target=gfx906 %gcc@8.1.0 ^blt@develop ^hip@4.2.0"
-  extends: .build_and_test_on_corona
+# rocm_4_2_fortran_gcc_8_1_0 (build and test on corona):
+# variables:
+#   SPEC: "+fortran+rocm amdgpu_target=gfx906 %gcc@8.1.0 ^blt@develop ^hip@4.2.0"
+# extends: .build_and_test_on_corona


### PR DESCRIPTION
This will be enabled again once CI support is brought back online.