### PR TITLE
Add ASAN CI to azure pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,16 @@ RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DU
     make -j 16 && \
     ctest -T test --output-on-failure
 
+FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-10.0.0 AS asan
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang \
+          -DUMPIRE_ENABLE_C=On -DCMAKE_CXX_FLAGS="-fsanitize=address" -DENABLE_TESTS=On -DUMPIRE_ENABLE_TOOLS=On \
+          -DUMPIRE_ENABLE_ASAN=On -DUMPIRE_ENABLE_SANITIZER_TESTS=On .. && \
+    make -j && \
+    ctest -T test --output-on-failure
+
 FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-10.0.0 AS clang10
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,16 +30,6 @@ RUN cmake -DUMPIRE_ENABLE_C=On -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug -DU
     make -j 16 && \
     ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-10.0.0 AS asan
-ENV GTEST_COLOR=1
-COPY . /home/umpire/workspace
-WORKDIR /home/umpire/workspace/build
-RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang \
-          -DUMPIRE_ENABLE_C=On -DCMAKE_CXX_FLAGS="-fsanitize=address" -DENABLE_TESTS=On -DUMPIRE_ENABLE_TOOLS=On \
-          -DUMPIRE_ENABLE_ASAN=On -DUMPIRE_ENABLE_SANITIZER_TESTS=On .. && \
-    make -j && \
-    ctest -T test --output-on-failure
-
 FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-10.0.0 AS clang10
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
@@ -70,6 +60,16 @@ COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace/build
 RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ .. && \
     make -j 16 && \
+    ctest -T test --output-on-failure
+
+FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-12.0.0 AS asan
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang \
+          -DUMPIRE_ENABLE_C=On -DCMAKE_CXX_FLAGS="-fsanitize=address" -DENABLE_TESTS=On -DUMPIRE_ENABLE_TOOLS=On \
+          -DUMPIRE_ENABLE_ASAN=On -DUMPIRE_ENABLE_SANITIZER_TESTS=On .. && \
+    make -j && \
     ctest -T test --output-on-failure
 
 FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DC
           -DUMPIRE_ENABLE_C=On -DCMAKE_CXX_FLAGS="-fsanitize=address" -DENABLE_TESTS=On -DUMPIRE_ENABLE_TOOLS=On \
           -DUMPIRE_ENABLE_ASAN=On -DUMPIRE_ENABLE_SANITIZER_TESTS=On .. && \
     make -j && \
-    ctest -T test --output-on-failure
+    ctest -T test -E operation_tests --output-on-failure
 
 FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10
 ENV GTEST_COLOR=1

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 	DebugArgs=
 endif
 
-targets = clang10 clang11 clang12 clang13 gcc11 gcc7 gcc8 gcc9 hip hip.debug nvcc10 nvcc11 sycl
+targets = asan clang10 clang11 clang12 clang13 gcc11 gcc7 gcc8 gcc9 hip hip.debug nvcc10 nvcc11 sycl
 
 $(targets):
 	DOCKER_BUILDKIT=1 docker build --target $@ --no-cache $(DebugArgs) .
@@ -18,6 +18,7 @@ help:
 	@echo 'Build Umpire using Docker!'
 	@echo ''
 	@echo 'target:'
+	@echo '    asan                           build with clang sanitizer'
 	@echo '    gccN                           build with GCC N'
 	@echo '    clangN                         build with clang N'
 	@echo '    nvccN                          build with CUDA N'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,8 @@ jobs:
         docker_target: gcc8
       gcc9:
         docker_target: gcc9
+      asan:
+        docker_target: asan
       clang10:
         docker_target: clang10
       clang11:

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -141,21 +141,23 @@ blt_add_test(
   NAME strategy_tests
   COMMAND strategy_tests)
 
-blt_add_executable(
-  NAME operation_tests
-  SOURCES operation_tests.cpp
-  DEPENDS_ON ${integration_tests_depends})
+if (NOT UMPIRE_ENABLE_SANITIZER_TESTS)
+  blt_add_executable(
+    NAME operation_tests
+    SOURCES operation_tests.cpp
+    DEPENDS_ON ${integration_tests_depends})
 
-set_source_files_properties(operation_tests.cpp PROPERTIES COMPILE_FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
+  set_source_files_properties(operation_tests.cpp PROPERTIES COMPILE_FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
 
-target_include_directories(
-  operation_tests
-  PRIVATE
-  ${PROJECT_BINARY_DIR}/include)
+  target_include_directories(
+    operation_tests
+    PRIVATE
+    ${PROJECT_BINARY_DIR}/include)
 
-blt_add_test(
-  NAME operation_tests
-  COMMAND operation_tests)
+  blt_add_test(
+    NAME operation_tests
+    COMMAND operation_tests)
+endif()
 
 blt_add_executable(
   NAME reallocate_tests
@@ -252,9 +254,13 @@ add_subdirectory(io)
 blt_add_target_compile_flags(
   TO strategy_tests
   FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
-blt_add_target_compile_flags(
-  TO operation_tests
-  FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
+
+if (NOT UMPIRE_ENABLE_SANITIZER_TESTS)
+  blt_add_target_compile_flags(
+    TO operation_tests
+    FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
+endif()
+
 blt_add_target_compile_flags(
   TO primary_pool_tests
   FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -141,23 +141,21 @@ blt_add_test(
   NAME strategy_tests
   COMMAND strategy_tests)
 
-if (NOT UMPIRE_ENABLE_SANITIZER_TESTS)
-  blt_add_executable(
-    NAME operation_tests
-    SOURCES operation_tests.cpp
-    DEPENDS_ON ${integration_tests_depends})
+blt_add_executable(
+  NAME operation_tests
+  SOURCES operation_tests.cpp
+  DEPENDS_ON ${integration_tests_depends})
 
-  set_source_files_properties(operation_tests.cpp PROPERTIES COMPILE_FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
+set_source_files_properties(operation_tests.cpp PROPERTIES COMPILE_FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
 
-  target_include_directories(
-    operation_tests
-    PRIVATE
-    ${PROJECT_BINARY_DIR}/include)
+target_include_directories(
+  operation_tests
+  PRIVATE
+  ${PROJECT_BINARY_DIR}/include)
 
-  blt_add_test(
-    NAME operation_tests
-    COMMAND operation_tests)
-endif()
+blt_add_test(
+  NAME operation_tests
+  COMMAND operation_tests)
 
 blt_add_executable(
   NAME reallocate_tests
@@ -254,13 +252,9 @@ add_subdirectory(io)
 blt_add_target_compile_flags(
   TO strategy_tests
   FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
-
-if (NOT UMPIRE_ENABLE_SANITIZER_TESTS)
-  blt_add_target_compile_flags(
-    TO operation_tests
-    FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
-endif()
-
+blt_add_target_compile_flags(
+  TO operation_tests
+  FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})
 blt_add_target_compile_flags(
   TO primary_pool_tests
   FLAGS ${UMPIRE_DISABLE_DEPRECATED_WARNINGS_FLAG})


### PR DESCRIPTION
CI tests with ASAN have been enabled for azure pipelines with the exception of the operation_tests which were causing an OOM due to the default container resource limit and the size of the test.  CI tests for the operation_tests are still done via gitlab CI which runs on physical LC compute nodes.