### PR TITLE
Disable ASAN CI on azure pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,13 @@ WORKDIR /home/umpire/workspace/build
 RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang \
           -DUMPIRE_ENABLE_C=On -DCMAKE_CXX_FLAGS="-fsanitize=address" -DENABLE_TESTS=On -DUMPIRE_ENABLE_TOOLS=On \
           -DUMPIRE_ENABLE_ASAN=On -DUMPIRE_ENABLE_SANITIZER_TESTS=On .. && \
-    make -j && \
+    make -j 2 && \
     ctest -T test -E operation_tests --output-on-failure
+
+FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-12.0.0 AS asan.debug
+ENV GTEST_COLOR=1
+COPY . /home/umpire/workspace
+WORKDIR /home/umpire/workspace/build
 
 FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10
 ENV GTEST_COLOR=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,8 +46,6 @@ jobs:
         docker_target: gcc8
       gcc9:
         docker_target: gcc9
-      asan:
-        docker_target: asan
       clang10:
         docker_target: clang10
       clang11:


### PR DESCRIPTION
Until we are able fix https://rzlc.llnl.gov/jira/browse/UM-994, this
test will be disabled.  Note: ASAN CI is still running on LC gitlab
machines.