### PR TITLE
Fix find_first_set() on Windows

### DIFF
--- a/src/umpire/strategy/FixedPool.cpp
+++ b/src/umpire/strategy/FixedPool.cpp
@@ -12,8 +12,8 @@
 #include <cstring>
 #include <sstream>
 
-#include "umpire/util/find_first_set.hpp"
 #include "umpire/util/Macros.hpp"
+#include "umpire/util/find_first_set.hpp"
 
 #if !defined(_MSC_VER)
 #define _XOPEN_SOURCE_EXTENDED 1

--- a/src/umpire/strategy/FixedPool.cpp
+++ b/src/umpire/strategy/FixedPool.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <sstream>
 
+#include "umpire/util/find_first_set.hpp"
 #include "umpire/util/Macros.hpp"
 
 #if !defined(_MSC_VER)
@@ -21,18 +22,6 @@
 
 namespace umpire {
 namespace strategy {
-
-inline int find_first_set(int i)
-{
-#if defined(_MSC_VER)
-  unsigned long bit;
-  unsigned long i_l = static_cast<unsigned long>(i);
-  _BitScanForward(&bit, i_l);
-  return static_cast<int>(bit);
-#else
-  return ffs(i);
-#endif
-}
 
 static constexpr std::size_t bits_per_int = sizeof(int) * 8;
 
@@ -116,7 +105,7 @@ void* FixedPool::allocInPool(Pool& p)
 
   for (unsigned int int_index = 0; int_index < m_avail_bytes; ++int_index) {
     // Return the index of the first 1 bit
-    const int bit_index = find_first_set(p.avail[int_index]) - 1;
+    const int bit_index = util::find_first_set(p.avail[int_index]) - 1;
     if (bit_index >= 0) {
       const std::size_t index = int_index * bits_per_int + bit_index;
       if (index < m_obj_per_pool) {

--- a/src/umpire/strategy/FixedSizePool.hpp
+++ b/src/umpire/strategy/FixedSizePool.hpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include "StdAllocator.hpp"
+#include "umpire/util/find_first_set.hpp"
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -20,18 +21,6 @@
 #pragma warning(disable : 4245)
 #pragma warning(disable : 4267)
 #endif
-
-inline int find_first_set(int i)
-{
-#if defined(_MSC_VER)
-  unsigned long bit;
-  unsigned long i_l = static_cast<unsigned long>(i);
-  _BitScanForward(&bit, i_l);
-  return static_cast<int>(bit);
-#else
-  return ffs(i);
-#endif
-}
 
 template <class T, class MA, class IA = StdAllocator, int NP = (1 << 6)>
 class FixedSizePool {
@@ -69,7 +58,7 @@ class FixedSizePool {
       return NULL;
 
     for (int i = 0; i < NP; i++) {
-      const int bit = find_first_set(p->avail[i]) - 1;
+      const int bit = umpire::util::find_first_set(p->avail[i]) - 1;
       if (bit >= 0) {
         p->avail[i] ^= 1 << bit;
         p->numAvail--;

--- a/src/umpire/util/CMakeLists.txt
+++ b/src/umpire/util/CMakeLists.txt
@@ -12,6 +12,7 @@ set (umpire_util_headers
   backtrace.hpp
   backtrace.inl
   Exception.hpp
+  find_first_set.hpp
   FixedMallocPool.hpp
   io.hpp
   Logger.hpp

--- a/src/umpire/util/find_first_set.hpp
+++ b/src/umpire/util/find_first_set.hpp
@@ -21,10 +21,13 @@ namespace util {
 inline int find_first_set(int i)
 {
 #if defined(_MSC_VER)
-  unsigned long bit;
+  unsigned long index;
   unsigned long i_l = static_cast<unsigned long>(i);
-  _BitScanForward(&bit, i_l);
-  return static_cast<int>(bit);
+  int bit = 0;
+  if (_BitScanForward(&index, i_l)) {
+    bit = static_cast<int>(index) + 1;
+  }
+  return bit;
 #else
   return ffs(i);
 #endif

--- a/src/umpire/util/find_first_set.hpp
+++ b/src/umpire/util/find_first_set.hpp
@@ -1,0 +1,36 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-22, Lawrence Livermore National Security, LLC and Umpire
+// project contributors. See the COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (MIT)
+//////////////////////////////////////////////////////////////////////////////
+#ifndef UMPIRE_find_first_set_HPP
+#define UMPIRE_find_first_set_HPP
+
+namespace umpire {
+namespace util {
+
+/*!
+ * \brief Find the first (least significant) bit set in \p i.
+ *
+ * \param i Bits.
+ *
+ * \return Index of the first bit set. Bits are numbered starting at 1, the
+ * least significant bit. A return value of 0 means that no bits were set.
+ */
+inline int find_first_set(int i)
+{
+#if defined(_MSC_VER)
+  unsigned long bit;
+  unsigned long i_l = static_cast<unsigned long>(i);
+  _BitScanForward(&bit, i_l);
+  return static_cast<int>(bit);
+#else
+  return ffs(i);
+#endif
+}
+
+} // end of namespace util
+} // end of namespace umpire
+
+#endif // UMPIRE_find_first_set_HPP

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -54,3 +54,12 @@ blt_add_executable(
 blt_add_test(
   NAME memory_map_tests
   COMMAND memory_map_tests)
+
+blt_add_executable(
+  NAME find_first_set_tests
+  SOURCES find_first_set_tests.cpp
+  DEPENDS_ON umpire gtest)
+
+blt_add_test(
+  NAME find_first_set_tests
+  COMMAND find_first_set_tests)

--- a/tests/unit/util/find_first_set_tests.cpp
+++ b/tests/unit/util/find_first_set_tests.cpp
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-22, Lawrence Livermore National Security, LLC and Umpire
+// project contributors. See the COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (MIT)
+//////////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>
+#include <limits>
+#include <random>
+
+#include "gtest/gtest.h"
+#include "umpire/util/find_first_set.hpp"
+
+using umpire::util::find_first_set;
+
+TEST(FindFirstSet, ZeroBits)
+{
+  const auto bit = find_first_set(0);
+  EXPECT_EQ(bit, 0);
+}
+
+TEST(FindFirstSet, OneBit)
+{
+  // include sign bit
+  constexpr int n_bits = std::numeric_limits<int>::digits + 1;
+
+  for (int index = 0; index < n_bits; ++index) {
+    const int mask = 1 << index;
+    const auto bit = find_first_set(mask);
+    EXPECT_EQ(bit, index + 1);
+  }
+}
+
+TEST(FindFirstSet, MultipleBits)
+{
+  // include sign bit
+  constexpr int n_bits = std::numeric_limits<int>::digits + 1;
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dist(0, n_bits - 1);
+
+  constexpr int n_iter = 4;
+  auto min_index = n_bits;
+  int mask = 0;
+
+  for (int iter = 0; iter < n_iter; ++iter) {
+    const auto index = dist(gen);
+    const int m = 1 << index;
+    mask |= m;
+    min_index = std::min(min_index, index);
+  }
+
+  const auto bit = find_first_set(mask);
+  EXPECT_EQ(bit, min_index + 1);
+}


### PR DESCRIPTION
I encountered a bug when running the tutorials on dynamic pools (`tut_dynamic_pool_1` and `tut_dynamic_pool_2`). Both tutorials would crash on my machine (Windows 10, Visual Studio 2019) after encountering a stack overflow in `FixedSizePool<T, MA, IA, NP>::allocate()`.

I traced the bug to where `allocate()` calls `allocInPool()`. The "search" (`for` loop) in `allocInPool()` would always fail, and a null pointer was returned. `allocate()` would then continue, passing the call to `newPool()`, and then recursing into `allocate()`.

The "search" in `allocInPool()` was always failing because the Windows implementation of `find_first_set()` was incorrect. This appeared in two places, so I refactored the code (and added a unit test) before I fixed it.