### PR TITLE
Removing Corona Stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,12 +72,12 @@ stages:
     reports:
       junit: junit.xml
 
-.build_toss_4_x86_64_ib_corona_script:
-  script:
-    - srun -p pbatch -t 30 -N 1 scripts/gitlab/build_and_test.sh
-  artifacts:
-    reports:
-      junit: junit.xml
+      #.build_toss_4_x86_64_ib_corona_script:
+      #script:
+      #- srun -p pbatch -t 30 -N 1 scripts/gitlab/build_and_test.sh
+      #artifacts:
+      #reports:
+      #junit: junit.xml
 
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.
@@ -111,5 +111,5 @@ include:
   - local: .gitlab/ruby-jobs.yml
   - local: .gitlab/lassen-templates.yml
   - local: .gitlab/lassen-jobs.yml
-  - local: .gitlab/corona-templates.yml
-  - local: .gitlab/corona-jobs.yml
+    #  - local: .gitlab/corona-templates.yml
+    #  - local: .gitlab/corona-jobs.yml


### PR DESCRIPTION
Until Corona starts working again and issues have been fixed (working with LC right now on this), disable Corona CI so that other PRs can pass through.