### PR TITLE
is_device_allocator now returns false if no DeviceAllocator exists yet

### DIFF
--- a/src/umpire/device_allocator_helper.cpp
+++ b/src/umpire/device_allocator_helper.cpp
@@ -42,13 +42,23 @@ __host__ __device__ inline int convert_to_array_index(int neg_id)
 __host__ __device__ inline int get_index(const char* name)
 {
   int index{-1};
+
 #if !defined(__CUDA_ARCH__)
+  if (UMPIRE_DEV_ALLOCS_h == nullptr) {
+    UMPIRE_LOG(Warning, "No DeviceAllocators have been created yet.");
+    return index;   
+  }
+
   for (int i = 0; i < UMPIRE_TOTAL_DEV_ALLOCS; i++) {
     if (strcmp(UMPIRE_DEV_ALLOCS_h[i].getName(), name) == 0) {
       index = i;
     }
   }
 #else
+  if (UMPIRE_DEV_ALLOCS == nullptr) {
+    return index;   
+  }
+
   for (int i = 0; i < UMPIRE_TOTAL_DEV_ALLOCS; i++) {
     const char* temp = UMPIRE_DEV_ALLOCS[i].getName();
     int curr = 0;

--- a/src/umpire/device_allocator_helper.cpp
+++ b/src/umpire/device_allocator_helper.cpp
@@ -46,7 +46,7 @@ __host__ __device__ inline int get_index(const char* name)
 #if !defined(__CUDA_ARCH__)
   if (UMPIRE_DEV_ALLOCS_h == nullptr) {
     UMPIRE_LOG(Warning, "No DeviceAllocators have been created yet.");
-    return index;   
+    return index;
   }
 
   for (int i = 0; i < UMPIRE_TOTAL_DEV_ALLOCS; i++) {
@@ -56,7 +56,7 @@ __host__ __device__ inline int get_index(const char* name)
   }
 #else
   if (UMPIRE_DEV_ALLOCS == nullptr) {
-    return index;   
+    return index;
   }
 
   for (int i = 0; i < UMPIRE_TOTAL_DEV_ALLOCS; i++) {

--- a/tests/integration/device_allocator.cpp
+++ b/tests/integration/device_allocator.cpp
@@ -37,6 +37,8 @@ TEST_P(DeviceAllocator, CreateAndAllocate)
   auto allocator = rm.getAllocator("UM");
   size_t size = 1 * sizeof(double);
 
+  ASSERT_FALSE(umpire::is_device_allocator("No_DeviceAllocator_created_yet"));
+
   umpire::DeviceAllocator da = umpire::make_device_allocator(allocator, size, GetParam());
   ASSERT_THROW((umpire::make_device_allocator(allocator, 0, "bad_da")), umpire::runtime_error);
 


### PR DESCRIPTION
If no DeviceAllocator has been created yet and a user calls is_device_allocator, it will now return false instead of throwing an error. There is also a check added to the DeviceAllocator test for this.