### PR TITLE
Removing GCC compiler FMT note

### DIFF
--- a/.gitlab/lassen-build-and-test.yml
+++ b/.gitlab/lassen-build-and-test.yml
@@ -64,7 +64,7 @@ clang_10_0_1_cuda_mpi_shmem:
 
 gcc_8_3_1_cuda:
   variables:
-    SPEC: "+fortran+cuda+shared %gcc@8.3.1 ^cuda@10.1.168"
+    SPEC: "+fortran+cuda+shared+tools+backtrace %gcc@8.3.1 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 xl_16_1_1_10_cuda:

--- a/scripts/spack_packages/umpire/package.py
+++ b/scripts/spack_packages/umpire/package.py
@@ -61,6 +61,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     variant('libcpp', default=False, description='Uses libc++ instead of libstdc++')
     variant('tools', default=True, description='Enable tools')
+    variant('backtrace', default=False, description='Enable backtrace tools')
     variant('dev_benchmarks', default=False, description='Enable Developer Benchmarks')
     variant('device_alloc', default=False, description='Enable the DeviceAllocator')
     variant('werror', default=True, description='Enable warnings as errors')
@@ -238,6 +239,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("UMPIRE_ENABLE_DEVICE_ALLOCATOR", '+device_alloc' in spec))
         entries.append(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec))
         entries.append(cmake_cache_option("UMPIRE_ENABLE_TOOLS", '+tools' in spec))
+        entries.append(cmake_cache_option("UMPIRE_ENABLE_BACKTRACE", '+backtrace' in spec))
         entries.append(cmake_cache_option("ENABLE_WARNINGS_AS_ERRORS", '+werror' in spec))
         entries.append(cmake_cache_option("UMPIRE_ENABLE_ASAN", '+asan' in spec))
         entries.append(cmake_cache_option("BUILD_SHARED_LIBS", '+shared' in spec))

--- a/src/tpl/CMakeLists.txt
+++ b/src/tpl/CMakeLists.txt
@@ -165,6 +165,9 @@ endif ()
 # Avoid warnings from fmt (so we can still use -Werror)
 blt_patch_target(NAME umpire_tpl_fmt
   TREAT_INCLUDES_AS_SYSTEM ON)
+target_compile_options(umpire_tpl_fmt
+  INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-fcompare-debug-second>
+)
 
 install(TARGETS
   umpire_tpl_fmt

--- a/src/tpl/CMakeLists.txt
+++ b/src/tpl/CMakeLists.txt
@@ -165,9 +165,12 @@ endif ()
 # Avoid warnings from fmt (so we can still use -Werror)
 blt_patch_target(NAME umpire_tpl_fmt
   TREAT_INCLUDES_AS_SYSTEM ON)
-target_compile_options(umpire_tpl_fmt
-  INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-fcompare-debug-second>
-)
+
+if (C_COMPILER_FAMILY_IS_GNU)
+  target_compile_options(umpire_tpl_fmt
+    INTERFACE 
+    $<$<COMPILE_LANGUAGE:CXX>:-fcompare-debug-second>)
+endif ()
 
 install(TARGETS
   umpire_tpl_fmt


### PR DESCRIPTION
An unnecessary note gets printed out countless times during some builds using gcc. We thought we got rid of all of those occurrences, but when tools and backtrace is turned on, they showed up again. This PR is to remove that annoying note and then create a CI test that checks for +tools and +backtrace during a gcc + cuda build which was when this issue was first detected. 