### PR TITLE
shared ci improved

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,20 +36,26 @@ stages:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
         ref: main
-        file: '${CI_JOB_NAME}.yml'
-      - local: '.gitlab/${CI_JOB_NAME}-extra.yml'
+        file: '${CI_MACHINE}-build-and-test.yml'
+      - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend
     forward:
       pipeline_variables: true
 
 # Trigger a pipeline for ruby, corona and lassen
 ruby-build-and-test:
+  variables:
+    CI_MACHINE: "ruby"
   extends: [.build-and-test]
 
 corona-build-and-test:
+  variables:
+    CI_MACHINE: "corona"
   extends: [.build-and-test]
 
 lassen-build-and-test:
+  variables:
+    CI_MACHINE: "lassen"
   extends: [.build-and-test]
 
 # If testing develop branch, trigger CHAI pipeline with this version of Umpire.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,45 +28,29 @@ stages:
   - multi-project # unused so far
   - radiuss-spack-testing # unused so far
 
-# Trigger sub-pipelines:
-ruby-build-and-test:
+# Template for jobs triggering a build-and-test  sub-pipelines:
+.build-and-test:
   stage: build-and-test
   trigger:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
         ref: main
-        file: 'ruby-build-and-test.yml'
-      - local: '.gitlab/ruby-build-and-test-extra.yml'
+        file: '${CI_JOB_NAME}.yml'
+      - local: '.gitlab/${CI_JOB_NAME}-extra.yml'
     strategy: depend
     forward:
       pipeline_variables: true
+
+# Trigger a pipeline for ruby, corona and lassen
+ruby-build-and-test:
+  extends: [.build-and-test]
 
 corona-build-and-test:
-  stage: build-and-test
-  trigger:
-    include:
-      - local: '.gitlab/custom-jobs.yml'
-      - project: 'radiuss/radiuss-shared-ci'
-        ref: main
-        file: 'corona-build-and-test.yml'
-      - local: '.gitlab/corona-build-and-test-extra.yml'
-    strategy: depend
-    forward:
-      pipeline_variables: true
+  extends: [.build-and-test]
 
 lassen-build-and-test:
-  stage: build-and-test
-  trigger:
-    include:
-      - local: '.gitlab/custom-jobs.yml'
-      - project: 'radiuss/radiuss-shared-ci'
-        ref: main
-        file: 'lassen-build-and-test.yml'
-      - local: '.gitlab/lassen-build-and-test-extra.yml'
-    strategy: depend
-    forward:
-      pipeline_variables: true
+  extends: [.build-and-test]
 
 # If testing develop branch, trigger CHAI pipeline with this version of Umpire.
 # TODO: Once Spack allows to clone a specific commit on demand, then point to the exact commit.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,30 +5,32 @@
 # SPDX-License-Identifier: (MIT)
 ###############################################################################
 
+# DESCRIPTION:
 ###############################################################################
 # General GitLab pipelines configurations for supercomputers and Linux clusters
 # at Lawrence Livermore National Laboratory (LLNL).
-#
 # This entire pipeline is LLNL-specific
-# #############################################################################
+#
+# Important note: This file is a copy of the template provided by
+# llnl/radiuss-shared-ci. It should not require any change from the project.
+#
+# Instead, each project should provide:
+# - .gitlab/custom-variables.yml
+# - .gitlab/custom-pipelines.yml
+# - .gitlab/custom-jobs.yml
+# - .gitlab/${MACHINE}-build-and-test-extra.yml
+###############################################################################
 
-# We organize the CI on Gitlab in sub-pipelines. Each sub-pipeline correspond
-# to a test phase on a given machine. This design is simpler and more scalable
-# than doing the same with stages.
+# We organize the CI on Gitlab in sub-pipelines. Each sub-pipeline corresponds
+# to a test phase on a given machine.
 
-# We start with custom configuration, local to the project.
-include:
-  - local: .gitlab/custom-variables.yml
-
-# The stages in the top-level pipeline described here correspond to high level
-# steps in the testing workflow.
-# TODO: rehabilitate multi-project and branch radiuss-spack-testing.
+# High level stages
 stages:
   - build-and-test
-  - multi-project # unused so far
-  - radiuss-spack-testing # unused so far
+  - multi-project #TODO unused so far
+  - radiuss-spack-testing #TODO unused so far
 
-# Template for jobs triggering a build-and-test  sub-pipelines:
+# Template for jobs triggering a build-and-test sub-pipelines:
 .build-and-test:
   stage: build-and-test
   trigger:
@@ -42,32 +44,7 @@ stages:
     forward:
       pipeline_variables: true
 
-# Trigger a pipeline for ruby, corona and lassen
-ruby-build-and-test:
-  variables:
-    CI_MACHINE: "ruby"
-  extends: [.build-and-test]
-
-corona-build-and-test:
-  variables:
-    CI_MACHINE: "corona"
-  extends: [.build-and-test]
-
-lassen-build-and-test:
-  variables:
-    CI_MACHINE: "lassen"
-  extends: [.build-and-test]
-
-# If testing develop branch, trigger CHAI pipeline with this version of Umpire.
-# TODO: Once Spack allows to clone a specific commit on demand, then point to the exact commit.
-#       This will prevent from sticking to a branch (here develop).
-# trigger-chai:
-#  stage: multi-project
-#  rules:
-#    - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"' #run only if ...
-#  variables:
-#    UPDATE_UMPIRE: develop
-#  trigger:
-#    project: radiuss/chai
-#    branch: develop
-#    strategy: depend
+# Import parameters and pipelines defined by the project
+include:
+  - local: .gitlab/custom-variables.yml
+  - local: .gitlab/custom-pipelines.yml

--- a/.gitlab/custom-pipelines.yml
+++ b/.gitlab/custom-pipelines.yml
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2022, Lawrence Livermore National Security, LLC and RADIUSS
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+###############################################################################
+
+# Trigger a build-and-test pipeline for ruby, corona and lassen
+ruby-build-and-test:
+  variables:
+    CI_MACHINE: "ruby"
+  extends: [.build-and-test]
+
+corona-build-and-test:
+  variables:
+    CI_MACHINE: "corona"
+  extends: [.build-and-test]
+
+lassen-build-and-test:
+  variables:
+    CI_MACHINE: "lassen"
+  extends: [.build-and-test]
+
+## If testing develop branch, trigger CHAI pipeline with this version of Umpire.
+## TODO: Once Spack allows to clone a specific commit on demand, then point to
+## the exact commit. This will prevent from sticking to a branch (here develop).
+# trigger-chai:
+#  stage: multi-project
+#  rules:
+#    - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"' #run only if ...
+#  variables:
+#    UPDATE_UMPIRE: develop
+#  trigger:
+#    project: radiuss/chai
+#    branch: develop
+#    strategy: depend


### PR DESCRIPTION
Suggested slight reformatting of the CI.

Makes `.gitlab-ci.yml` a generic, shareable file, and gathers all the configuration/customization in `.gitlab`. 

@davidbeckingsale since we are close to merging #749 (shared CI) I did not want to confuse you by changing things at the last minute.

Still, this is ready to be merge in shared CI before we merge shared CI in develop.

Just need your approval.