### PR TITLE
Switch to a tag as ref in radiuss-shared-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: main
+        ref: v2022.06.0
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend


### PR DESCRIPTION
Stop using `main` as reference to point to `radiuss-shared-ci` as it is a moving target.
Instead, I added a tag in that project to point to.