### PR TITLE
[Woptim] Fix allocations and update shared CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: woptim/overlap-as-inline-option
+        ref: woptim/custom-variants-and-deps
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: woptim/custom-variants-and-deps
+        ref: v2022.08.1
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: v2022.06.0
+        ref: woptim/overlap-as-inline-option
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -5,17 +5,12 @@
 # SPDX-License-Identifier: (MIT)
 ###############################################################################
 
-rocm_5.1.0_fortran_clang_13_0_0:
-  variables:
-    SPEC: "+rocm~tools amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.0"
-  extends: .build_and_test_on_corona
-
 ###
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still disable tools from being built.
 ###
-rocm_5.1.0_openmp_fortran_clang_13_0_0:
+rocm_5_1_1_openmp_fortran_clang_13_0_0:
   variables:
-    SPEC: "+rocm+openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.0"
+    SPEC: "+rocm +openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.1"
   extends: .build_and_test_on_corona
 

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -5,17 +5,17 @@
 # SPDX-License-Identifier: (MIT)
 ###############################################################################
 
-rocm_5.1.0_fortran_clang_13_0_0:
+rocm_5.1.1_fortran_clang_13_0_0:
   variables:
-    SPEC: "+rocm~tools amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.0"
+    SPEC: "+rocm~tools amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.1"
   extends: .build_and_test_on_corona
 
 ###
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still disable tools from being built.
 ###
-rocm_5.1.0_openmp_fortran_clang_13_0_0:
+rocm_5.1.1_openmp_fortran_clang_13_0_0:
   variables:
-    SPEC: "+rocm+openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.0"
+    SPEC: "+rocm+openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.1"
   extends: .build_and_test_on_corona
 

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -30,15 +30,15 @@ variables:
 
 # Ruby
 # Arguments for top level allocation
-  RUBY_BUILD_AND_TEST_SHARED_ALLOC: "--partition=pdebug --time=10 --nodes=1 --cpus-per-task=36"
+  RUBY_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --partition=pdebug --time=10 --nodes=1"
 # Arguments for job level allocation
   RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=10 --nodes=1"
 
 # Corona
 # Arguments for top level allocation
-  CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --partition=pdebug --time=10 --nodes=1 --cpus-per-task=36"
+  CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --partition=pdebug --time=10 --nodes=1"
 # Arguments for job level allocation
-  CORONA_BUILD_AND_TEST_JOB_ALLOC: "--partition=pdebug --time=10 --nodes=1"
+  CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time=10 --nodes=1"
 
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -32,13 +32,13 @@ variables:
 # Arguments for top level allocation
   RUBY_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --partition=pdebug --time=10 --nodes=1"
 # Arguments for job level allocation
-  RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=10 --nodes=1"
+  RUBY_BUILD_AND_TEST_JOB_ALLOC: "--overlap --time=10 --nodes=1"
 
 # Corona
 # Arguments for top level allocation
   CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --partition=pdebug --time=10 --nodes=1"
 # Arguments for job level allocation
-  CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time=10 --nodes=1"
+  CORONA_BUILD_AND_TEST_JOB_ALLOC: "--overlap --time=10 --nodes=1"
 
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Changed
+
+- unifies the naming of Corona jobs with other projects.
+- uses options instead of variables to create overlapping allocations with Slurm.
+- use Flux scheduler on Corona.
+- updates radiuss-shared-ci to benefit from latest improvements, including sub-pipeline reporting.
+
 ## [v2022.03.1 - 2022-04-12]
 
 - Fix reported build errors by setting UMPIRE_ENABLE_DOCS back to OFF by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Changed
 
-- unifies the naming of Corona jobs with other projects.
-- uses options instead of variables to create overlapping allocations with Slurm.
-- use Flux scheduler on Corona.
-- updates radiuss-shared-ci to benefit from latest improvements, including sub-pipeline reporting.
+- Unify the naming of Corona jobs with other projects.
+- Use options instead of variables to create overlapping allocations with Slurm.
+- Use Flux scheduler on Corona.
+- Update radiuss-shared-ci to benefit from latest improvements, including sub-pipeline reporting.
+
+### Fixed
+
+- Reference Radiuss-Shared-CI instead of Radiuss-CI in the documentation.
 
 ## [v2022.03.1 - 2022-04-12]
 

--- a/docs/sphinx/developer/ci.rst
+++ b/docs/sphinx/developer/ci.rst
@@ -9,10 +9,9 @@ Gitlab CI
 
 Umpire uses continuous integration to ensure that changes added to the
 repository are well integrated and tested for compatability with the rest
-of the existing code base. Our CI tests incude a variety of vetted 
+of the existing code base. Our CI tests incude a variety of vetted
 configurations that run on different LC machines.
 
-
 Umpire shares its Gitlab CI workflow with other projects. The documentation is
-therefore `shared <https://radiuss-ci.readthedocs.io/en/latest/uberenv.html#ci>`_.
+therefore `shared <https://radiuss-shared-ci.readthedocs.io/en/latest/>`_.
 


### PR DESCRIPTION
This branch:

- unifies the naming of corona jobs with other projects.
- uses options instead of variables to create overlapping allocations with Slurm.
- improves Flux allocation adding a time limit on corona.
- updates radiuss-shared-ci to benefit from latest improvements, including sub-pipeline reporting.