### PR TITLE
Prefix UMPIRE_ to ENABLE_MPI and ENABLE_IPC_SHARED_MEMORY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,10 @@ cmake_dependent_option( UMPIRE_ENABLE_OPENMP "Build Umpire with OpenMP" On
                        "ENABLE_OPENMP" Off )
 cmake_dependent_option( UMPIRE_ENABLE_MPI "Build Umpire with MPI" On
                        "ENABLE_MPI" Off )
-cmake_dependent_option( ENABLE_IPC_SHARED_MEMORY "Enable Host Shared Memory Resource" ${ENABLE_MPI}
+#
+# NOTE: The following option depends upon UMPIRE_ENABLE_MPI being defined first
+#
+cmake_dependent_option( UMPIRE_ENABLE_IPC_SHARED_MEMORY "Enable Host Shared Memory Resource" ${UMPIRE_ENABLE_MPI}
                        "NOT WIN32;NOT APPLE" Off )
 
 

--- a/cmake/UmpireMacros.cmake
+++ b/cmake/UmpireMacros.cmake
@@ -43,7 +43,7 @@ macro(umpire_add_test_with_mpi)
     cmake_parse_arguments(arg
      "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-   if (ENABLE_MPI)
+    if (UMPIRE_ENABLE_MPI)
       blt_add_test( NAME           ${arg_NAME}
                     COMMAND        ${arg_COMMAND}
                     NUM_MPI_TASKS  ${arg_NUM_MPI_TASKS})

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -14,28 +14,28 @@ argument is a boolean option, and  can be turned on or off:
 
 Here is a summary of the configuration options, their default value, and meaning:
 
-    ====================================== ==========  ===========================================================================
-    Variable                               Default     Meaning
-    ====================================== ==========  ===========================================================================
-    ``ENABLE_BENCHMARKS``                  On          Build benchmark programs
-    ``ENABLE_CUDA``                        Off         Enable CUDA support
-    ``ENABLE_DOCS``                        Off         Build documentation (requires Sphinx and/or Doxygen)
-    ``ENABLE_FORTRAN``                     Off         Build the Fortran API
-    ``ENABLE_HIP``                         Off         Enable HIP support
-    ``ENABLE_TESTS``                       On          Build test executables
-    ``UMPIRE_DISABLE_ALLOCATIONMAP_DEBUG`` Off         Disable verbose output from AllocationMap when a pointer cannot be found
-    ``UMPIRE_ENABLE_ASAN``                 Off         Enable ASAN support
-    ``UMPIRE_ENABLE_BACKTRACE_SYMBOLS``    Off         Enable symbol lookup for backtraces
-    ``UMPIRE_ENABLE_BACKTRACE``            Off         Enable backtraces for allocations
-    ``UMPIRE_ENABLE_C``                    Off         Build the C API
-    ``UMPIRE_ENABLE_FILE_RESOURCE``        Off         Enable FILE support      
-    ``UMPIRE_ENABLE_IPC_SHARED_MEMORY``    ENABLE_MPI  Enable Shared Memory support
-    ``UMPIRE_ENABLE_LOGGING``              On          Enable Logging within Umpire
-    ``UMPIRE_ENABLE_NUMA``                 Off         Enable NUMA support
-    ``UMPIRE_ENABLE_PERFORMANCE_TESTS``    Off         Build and run performance tests
-    ``UMPIRE_ENABLE_SLIC``                 Off         Enable SLIC logging
-    ``UMPIRE_ENABLE_TOOLS``                Off         Enable tools like replay
-    ====================================== ==========  ===========================================================================
+    ====================================== ==========         ===========================================================================
+    Variable                               Default            Meaning
+    ====================================== ==========         ===========================================================================
+    ``ENABLE_BENCHMARKS``                  On                 Build benchmark programs
+    ``ENABLE_CUDA``                        Off                Enable CUDA support
+    ``ENABLE_DOCS``                        Off                Build documentation (requires Sphinx and/or Doxygen)
+    ``ENABLE_FORTRAN``                     Off                Build the Fortran API
+    ``ENABLE_HIP``                         Off                Enable HIP support
+    ``ENABLE_TESTS``                       On                 Build test executables
+    ``UMPIRE_DISABLE_ALLOCATIONMAP_DEBUG`` Off                Disable verbose output from AllocationMap when a pointer cannot be found
+    ``UMPIRE_ENABLE_ASAN``                 Off                Enable ASAN support
+    ``UMPIRE_ENABLE_BACKTRACE_SYMBOLS``    Off                Enable symbol lookup for backtraces
+    ``UMPIRE_ENABLE_BACKTRACE``            Off                Enable backtraces for allocations
+    ``UMPIRE_ENABLE_C``                    Off                Build the C API
+    ``UMPIRE_ENABLE_FILE_RESOURCE``        Off                Enable FILE support      
+    ``UMPIRE_ENABLE_IPC_SHARED_MEMORY``    UMPIRE_ENABLE_MPI  Enable Shared Memory support
+    ``UMPIRE_ENABLE_LOGGING``              On                 Enable Logging within Umpire
+    ``UMPIRE_ENABLE_NUMA``                 Off                Enable NUMA support
+    ``UMPIRE_ENABLE_PERFORMANCE_TESTS``    Off                Build and run performance tests
+    ``UMPIRE_ENABLE_SLIC``                 Off                Enable SLIC logging
+    ``UMPIRE_ENABLE_TOOLS``                Off                Enable tools like replay
+    ====================================== ==========         ===========================================================================
 
 These arguments are explained in more detail below:
 

--- a/scripts/spack_packages/umpire/package.py
+++ b/scripts/spack_packages/umpire/package.py
@@ -229,7 +229,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
 
         entries = super(Umpire, self).initconfig_mpi_entries()
-        entries.append(cmake_cache_option("UMPIRE_ENABLE_MPI", '+mpi' in spec))
+        entries.append(cmake_cache_option("ENABLE_MPI", '+mpi' in spec))
 
         return entries
 

--- a/scripts/spack_packages/umpire/package.py
+++ b/scripts/spack_packages/umpire/package.py
@@ -229,7 +229,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
 
         entries = super(Umpire, self).initconfig_mpi_entries()
-        entries.append(cmake_cache_option("ENABLE_MPI", '+mpi' in spec))
+        entries.append(cmake_cache_option("UMPIRE_ENABLE_MPI", '+mpi' in spec))
 
         return entries
 


### PR DESCRIPTION
This prefix was inconsistently applied ENABLE_MPI and
ENABLE_IPC_SHARED_MEMORY which caused some build confusion.

This is documented in https://rzlc.llnl.gov/jira/browse/UM-1016