### PR TITLE
[Woptim] update to xl 16 1 1 11, match raja config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: v2022.08.1
+        ref: woptim/update-to-xl_16_1_1_11
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend


### PR DESCRIPTION
In order to match RAJA CI configuration, we update xl@16.1.1.10 to xl@16.1.1.11.
We don’t expect any change in the CI results.