### PR TITLE
cmake: properly add Fortran module directories

### DIFF
--- a/src/umpire/interface/c_fortran/CMakeLists.txt
+++ b/src/umpire/interface/c_fortran/CMakeLists.txt
@@ -57,8 +57,8 @@ target_include_directories(
   PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
-  $<INSTALL_INTERFACE:include/umpire> # for Fortran module files
+  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:${CMAKE_Fortran_MODULE_DIRECTORY}>>
+  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:Fortran>:include/umpire>> # for Fortran module files
   $<INSTALL_INTERFACE:include>)
 
 install(FILES

--- a/src/umpire/interface/c_fortran/CMakeLists.txt
+++ b/src/umpire/interface/c_fortran/CMakeLists.txt
@@ -57,6 +57,8 @@ target_include_directories(
   PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+  $<INSTALL_INTERFACE:include/umpire> # for Fortran module files
   $<INSTALL_INTERFACE:include>)
 
 install(FILES


### PR DESCRIPTION
The fix in the INSTALL_INTERFACE is necessary so that a project that does

```
find_package(umpire)

[...]
target_link_libraries(my_fortran_exe PRIVATE umpire)
```

actually will find the `umpire_mod.mod` file, which gets installed into `include/umpire/`.

The change in the BUILD_INTERFACE is for the case where umpire is used in another cmake project via `add_subdirectory()`, which is probably not an offically supported case, but it can be quite useful.