### PR TITLE
Fix usage of CAMP_EXPAND to accommode new API

### DIFF
--- a/src/umpire/event/event.hpp
+++ b/src/umpire/event/event.hpp
@@ -146,7 +146,7 @@ class builder {
   template <typename... Ts, std::size_t... N>
   builder& args_impl(std::index_sequence<N...>, Ts... as)
   {
-    UMPIRE_USE_VAR(CAMP_EXPAND(arg("arg" + std::to_string(N), as)));
+    CAMP_EXPAND(arg("arg" + std::to_string(N), as));
     return *this;
   }
 


### PR DESCRIPTION
The Camp macro CAMP_EXPAND has been fixed to no longer warn.  But it was also changed such that it declares a named array instead of an unnamed array which caused Umpire's compiles to break when using UMPIRE_USE_VAR.