### PR TITLE
Properly set ID for device allocator

### DIFF
--- a/src/umpire/resource/MemoryResourceTypes.hpp
+++ b/src/umpire/resource/MemoryResourceTypes.hpp
@@ -10,7 +10,16 @@
 #include <cstddef>
 #include <string>
 
+#include "umpire/config.hpp"
 #include "umpire/util/error.hpp"
+
+#if defined(UMPIRE_ENABLE_CUDA)
+#include <cuda_runtime_api.h>
+#endif /* UMPIRE_ENABLE_CUDA */
+
+#if defined(UMPIRE_ENABLE_HIP)
+#include <hip/hip_runtime.h>
+#endif /* UMPIRE_ENABLE_HIP */
 
 namespace umpire {
 namespace resource {
@@ -99,6 +108,16 @@ inline int resource_to_device_id(const std::string& resource)
   int device_id{0};
   if (resource.find("::") != std::string::npos) {
     device_id = std::stoi(resource.substr(resource.find("::") + 2));
+  }
+  else {
+    // get the device bound to the current process
+    #if defined(UMPIRE_ENABLE_CUDA)
+      cudaGetDevice(&device_id);
+    #endif /* UMPIRE_ENABLE_CUDA */
+
+    #if defined(UMPIRE_ENABLE_HIP)
+      hipGetDevice(&device_id);
+    #endif /* UMPIRE_ENABLE_HIP */
   }
   return device_id;
 }


### PR DESCRIPTION
# Summary 

The ``umpire::resource::resource_to_device_id()`` method has logic to detect the device ID based on the name of the memory resource. However, if the calling code has set a particular GPU to the process, e.g., via calling ``cudaSetDevice()`` or ``hipSetDevice()``, the default device allocator that Umpire provides may have the wrong device ID. Consequently, all memory allocations/operations would be directed to the wrong GPU on the system.

This commit fixes this issue by adding logic to query the CUDA or HIP runtime for the correct device ID to use if the caller has not encoded the device ID to the name of the memory resource.

Resolves #798