### PR TITLE
Replace use of deprecated random_shuffle with shuffle for c++17

### DIFF
--- a/benchmarks/file_resource_benchmarks.cpp
+++ b/benchmarks/file_resource_benchmarks.cpp
@@ -10,11 +10,12 @@
 #include "umpire/ResourceManager.hpp"
 #include "umpire/Allocator.hpp"
 
-#include <omp.h>
-#include <vector>
-#include <unistd.h>
-#include <time.h>
 #include <algorithm>
+#include <chrono>
+#include <omp.h>
+#include <time.h>
+#include <unistd.h>
+#include <vector>
 
 int iterations;
 size_t Scalar = 5;
@@ -63,7 +64,9 @@ void Initialized(std::size_t* A, std::size_t* B, std::size_t* C){
             index[i] = i; 
     } 
 
-    std::random_shuffle(index.begin(), index.end());
+    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    std::shuffle(index.begin(), index.end(), std::default_random_engine(seed));
 
     #pragma omp parallel for
     for (int i = 0; i < index.size(); i++) {

--- a/tests/unit/resource/shared_memory_resource_tests.cpp
+++ b/tests/unit/resource/shared_memory_resource_tests.cpp
@@ -6,6 +6,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <random>
 #include <sstream>
@@ -211,7 +212,9 @@ TEST_F(SharedMemoryTest, UnitTests)
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    std::random_shuffle(allocs.begin(), allocs.end());
+    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    std::shuffle(allocs.begin(), allocs.end(), std::default_random_engine(seed));
     do_deallocations(allocs);
 
     MPI_Barrier(MPI_COMM_WORLD);


### PR DESCRIPTION
Update Umpire to use `std::shuffle` to address #809