### PR TITLE
Fixed coalescing call for blocks releasable heuristic

### DIFF
--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -122,7 +122,10 @@ bool DynamicPoolList::tracksMemoryUse() const noexcept
 void DynamicPoolList::coalesce() noexcept
 {
   UMPIRE_LOG(Debug, "()");
-  
+  umpire::event::record([&](auto& event) {
+    event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
+  });
+    
   std::size_t suggested_size{m_should_coalesce(*this)};
   if (0 != suggested_size) {
     UMPIRE_LOG(Debug,
@@ -136,14 +139,14 @@ void DynamicPoolList::coalesce() noexcept
 PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable(std::size_t nblocks)
 {
   return [=](const strategy::DynamicPoolList& pool) {
-    return pool.getReleasableBlocks() > nblocks ? pool.getActualSize() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getActualSize() : 0;
   };
 }
 
 PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable_hwm(std::size_t nblocks)
 {
   return [=](const strategy::DynamicPoolList& pool) {
-    return pool.getReleasableBlocks() > nblocks ? pool.getHighWatermark() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getHighWatermark() : 0;
   };
 }
 

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -125,7 +125,7 @@ void DynamicPoolList::coalesce() noexcept
   umpire::event::record([&](auto& event) {
     event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
   });
-    
+
   std::size_t suggested_size{m_should_coalesce(*this)};
   if (0 != suggested_size) {
     UMPIRE_LOG(Debug,

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -122,10 +122,15 @@ bool DynamicPoolList::tracksMemoryUse() const noexcept
 void DynamicPoolList::coalesce() noexcept
 {
   UMPIRE_LOG(Debug, "()");
-  umpire::event::record([&](auto& event) {
-    event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
-  });
-  dpa.coalesce(dpa.getActualSize());
+  
+  std::size_t suggested_size{m_should_coalesce(*this)};
+  if (0 != suggested_size) {
+    UMPIRE_LOG(Debug,
+               "Heuristic returned true, "
+               "performing coalesce operation for "
+                   << this << "\n");
+    dpa.coalesce(suggested_size);
+  }
 }
 
 PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable(std::size_t nblocks)

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -122,7 +122,7 @@ bool DynamicPoolList::tracksMemoryUse() const noexcept
 void DynamicPoolList::coalesce() noexcept
 {
   UMPIRE_LOG(Debug, "()");
-  
+
   std::size_t suggested_size{m_should_coalesce(*this)};
   if (0 != suggested_size) {
     UMPIRE_LOG(Debug,

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -125,13 +125,10 @@ void DynamicPoolList::coalesce() noexcept
   umpire::event::record([&](auto& event) {
     event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
   });
-    
+
   std::size_t suggested_size{m_should_coalesce(*this)};
   if (0 != suggested_size) {
-    UMPIRE_LOG(Debug,
-               "Heuristic returned true, "
-               "performing coalesce operation for "
-                   << this << "\n");
+    UMPIRE_LOG(Debug, "coalesce heuristic true, performing coalesce, suggested size is " << suggested_size);
     dpa.coalesce(suggested_size);
   }
 }

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -336,15 +336,15 @@ void QuickPool::do_coalesce(std::size_t suggested_size) noexcept
 
 PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable(std::size_t nblocks)
 {
-  return [=](const strategy::QuickPool& pool) {
-    return pool.getReleasableBlocks() > nblocks ? pool.getHighWatermark() : 0;
-  };
+  return
+      [=](const strategy::QuickPool& pool) { return pool.getReleasableBlocks() > nblocks ? pool.getActualSize() : 0; };
 }
 
 PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable_hwm(std::size_t nblocks)
 {
-  return
-      [=](const strategy::QuickPool& pool) { return pool.getReleasableBlocks() > nblocks ? pool.getActualSize() : 0; };
+  return [=](const strategy::QuickPool& pool) {
+    return pool.getReleasableBlocks() > nblocks ? pool.getHighWatermark() : 0;
+  };
 }
 
 PoolCoalesceHeuristic<QuickPool> QuickPool::percent_releasable(int percentage)

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -312,6 +312,10 @@ void QuickPool::coalesce() noexcept
 {
   UMPIRE_LOG(Debug, "()");
 
+  umpire::event::record([&](auto& event) {
+    event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
+  });
+
   std::size_t suggested_size{m_should_coalesce(*this)};
   if (0 != suggested_size) {
     UMPIRE_LOG(Debug, "coalesce heuristic true, performing coalesce.");
@@ -337,13 +341,13 @@ void QuickPool::do_coalesce(std::size_t suggested_size) noexcept
 PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable(std::size_t nblocks)
 {
   return
-      [=](const strategy::QuickPool& pool) { return pool.getReleasableBlocks() > nblocks ? pool.getActualSize() : 0; };
+      [=](const strategy::QuickPool& pool) { return pool.getReleasableBlocks() >= nblocks ? pool.getActualSize() : 0; };
 }
 
 PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable_hwm(std::size_t nblocks)
 {
   return [=](const strategy::QuickPool& pool) {
-    return pool.getReleasableBlocks() > nblocks ? pool.getHighWatermark() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getHighWatermark() : 0;
   };
 }
 

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -315,7 +315,7 @@ void QuickPool::coalesce() noexcept
 
   std::size_t suggested_size{m_should_coalesce(*this)};
   if (0 != suggested_size) {
-    UMPIRE_LOG(Debug, "coalesce heuristic true, performing coalesce.");
+    UMPIRE_LOG(Debug, "coalesce heuristic true, performing coalesce, suggested size is " << suggested_size);
     do_coalesce(suggested_size);
   }
 }

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -312,11 +312,11 @@ void QuickPool::coalesce() noexcept
 {
   UMPIRE_LOG(Debug, "()");
 
-  umpire::event::record([&](auto& event) {
-    event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
-  });
-
-  do_coalesce(getActualSize());
+  std::size_t suggested_size{m_should_coalesce(*this)};
+  if (0 != suggested_size) {
+    UMPIRE_LOG(Debug, "coalesce heuristic true, performing coalesce.");
+    do_coalesce(suggested_size);
+  }
 }
 
 void QuickPool::do_coalesce(std::size_t suggested_size) noexcept

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -110,12 +110,9 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasable)
 
   for (int i{max_blocks}; i > 0; i--) {
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i - 1]););
-
-    if (i % 2)
-      ASSERT_EQ(a.second->getReleasableBlocks(), 1);
-    else
-      ASSERT_EQ(a.second->getReleasableBlocks(), 2);
+    ASSERT_EQ(a.second->getReleasableBlocks(), 1);
   }
+
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
   ASSERT_EQ(a.second->getTotalBlocks(), 1);
 }
@@ -131,6 +128,7 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
 
   std::vector<void*> ptrs;
 
+  // allocate 64 bytes 23 times with first block being 1024 bytes and next_block 128 bytes
   for (int i{0}; i < 23; ++i) {
     ASSERT_NO_THROW(ptrs.push_back(a.first.allocate(64)));
     ASSERT_EQ(a.second->getReleasableBlocks(), 0);
@@ -140,11 +138,12 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
   ASSERT_EQ(a.second->getHighWatermark(), 1472);
   ASSERT_EQ(a.second->getTotalBlocks(), 5);
 
-  for (int i{22}; i > 16; --i) {
+  // deallocate 4 times so that two blocks are relesable and they will coalesce automatically
+  for (int i{22}; i > 18; --i) {
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
 
   ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
-  ASSERT_EQ(a.second->getTotalBlocks(), 3);
+  ASSERT_EQ(a.second->getTotalBlocks(), 4);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
-  }
+}

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -147,4 +147,4 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
   ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
   ASSERT_EQ(a.second->getTotalBlocks(), 3);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
-  }
+}

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -146,4 +146,11 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
   ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
   ASSERT_EQ(a.second->getTotalBlocks(), 4);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
+
+  for (int i{19}; i > 0; --i) {
+    ASSERT_NO_THROW(a.first.deallocate(ptrs[i - 1]););
+  }
+
+  ASSERT_EQ(a.second->getReleasableBlocks(), 1);
+  ASSERT_EQ(a.second->getTotalBlocks(), 1);
 }

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -142,7 +142,7 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
   for (int i{22}; i > 18; --i) {
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
-    
+
   ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
   ASSERT_EQ(a.second->getTotalBlocks(), 4);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -142,7 +142,7 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
   for (int i{22}; i > 18; --i) {
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
-
+    
   ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
   ASSERT_EQ(a.second->getTotalBlocks(), 4);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -119,3 +119,32 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasable)
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
   ASSERT_EQ(a.second->getTotalBlocks(), 1);
 }
+
+TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
+{
+  using myPoolType = typename TestFixture::myPoolType;
+  using TestAllocator = typename TestFixture::TestAllocator;
+  TestAllocator a;
+
+  ASSERT_NO_THROW(a = this->getAllocator(myPoolType::blocks_releasable_hwm(2)));
+  ASSERT_NE(a.second, nullptr);
+
+  std::vector<void*> ptrs;
+
+  for (int i{0}; i < 23; ++i) {
+    ASSERT_NO_THROW(ptrs.push_back(a.first.allocate(64)));
+    ASSERT_EQ(a.second->getReleasableBlocks(), 0);
+  }
+
+  ASSERT_EQ(a.second->getActualSize(), 1536);
+  ASSERT_EQ(a.second->getHighWatermark(), 1472);
+  ASSERT_EQ(a.second->getTotalBlocks(), 5);
+
+  for (int i{22}; i > 16; --i) {
+    ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
+  }
+
+  ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
+  ASSERT_EQ(a.second->getTotalBlocks(), 3);
+  ASSERT_EQ(a.second->getReleasableBlocks(), 1);
+  }

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -90,6 +90,46 @@ TYPED_TEST(PoolHeuristicsTest, PercentReleasable)
   ASSERT_EQ(a.second->getTotalBlocks(), 1);
 }
 
+TYPED_TEST(PoolHeuristicsTest, PercentReleasableHWM)
+{
+  using myPoolType = typename TestFixture::myPoolType;
+  using TestAllocator = typename TestFixture::TestAllocator;
+  TestAllocator a;
+
+  ASSERT_NO_THROW(a = this->getAllocator(myPoolType::percent_releasable_hwm(25)));
+  ASSERT_NE(a.second, nullptr);
+
+  std::vector<void*> ptrs;
+
+  // allocate 64 bytes 23 times with first block being 1024 bytes and next_block 128 bytes
+  for (int i{0}; i < 23; ++i) {
+    ASSERT_NO_THROW(ptrs.push_back(a.first.allocate(64)));
+    ASSERT_EQ(a.second->getReleasableBlocks(), 0);
+  }
+
+  ASSERT_EQ(a.second->getActualSize(), 1536);
+  ASSERT_EQ(a.second->getHighWatermark(), 1472);
+  ASSERT_EQ(a.second->getTotalBlocks(), 5);
+
+  // deallocate 7*64 = 448 bytes so that 25% of the pool is relesable and it will coalesce automatically
+  for (int i{22}; i > 15; --i) {
+    ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
+  }
+
+  ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
+  ASSERT_EQ(a.second->getTotalBlocks(), 2);
+  ASSERT_EQ(a.second->getReleasableBlocks(), 1);
+
+  ASSERT_NO_THROW(a.first.release());
+
+  for (int i{16}; i > 0; --i) {
+    ASSERT_NO_THROW(a.first.deallocate(ptrs[i - 1]););
+  }
+
+  ASSERT_EQ(a.second->getReleasableBlocks(), 1);
+  ASSERT_EQ(a.second->getTotalBlocks(), 1);
+}
+
 TYPED_TEST(PoolHeuristicsTest, BlocksReleasable)
 {
   using myPoolType = typename TestFixture::myPoolType;


### PR DESCRIPTION
The bodies of the two functions, `blocks_releasable(std::size_t nblocks)` and `blocks_releasable_hwm(std::size_t nblocks)`, were swapped so I switched the code of these two functions. Now `blocks_releasable` uses the actual size and `blocks_releasable_hwm` uses the high-watermark. In addition, I passed the right value into `blocks_releasable(std::size_t nblocks)` and `blocks_releasable_hwm(std::size_t nblocks)` by calling the heuristic before the coalesce call happens.