### PR TITLE
Make allocate API threadsafe when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 	DebugArgs=
 endif
 
-targets = asan clang10 clang11 clang12 clang13 gcc11 gcc7 gcc8 gcc9 hip hip.debug nvcc10 nvcc11 sycl umap_build
+targets = asan clang10 clang11 clang12 clang13 gcc11 gcc7 gcc8 gcc9 hip hip.debug nvcc10 sycl umap_build
 
 $(targets):
 	DOCKER_BUILDKIT=1 docker build --target $@ --no-cache $(DebugArgs) .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,8 +56,6 @@ jobs:
         docker_target: clang12
       nvcc10:
         docker_target: nvcc10
-      nvcc11:
-        docker_target: nvcc11
       sycl:
         docker_target: sycl
       hip:

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -22,7 +22,7 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
   // we create a mutex to be used during allocation operations
   //
   if (dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr) {
-    m_mutex = new std::mutex; // Management of pointer TBD
+    m_mutex = std::shared_ptr<std::mutex>(new std::mutex);
   } else {
     m_mutex = nullptr;
   }

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -7,6 +7,7 @@
 #include "umpire/Allocator.hpp"
 
 #include "umpire/ResourceManager.hpp"
+#include "umpire/strategy/ThreadSafeAllocator.hpp"
 #include "umpire/util/Macros.hpp"
 
 namespace umpire {
@@ -17,6 +18,15 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
       m_allocator{allocator},
       m_tracking{allocator->isTracked()}
 {
+  // Hack: If the strategy for this allocator requires thread safety,
+  // we create a mutex to be used during allocation operations
+  //
+  if (dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr) {
+    m_mutex = new std::mutex; // Management of pointer TBD
+  }
+  else {
+    m_mutex = nullptr;
+  }
 }
 
 void Allocator::release()

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -30,24 +30,6 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
   }
 }
 
-void* Allocator::thread_safe_allocate(std::size_t bytes)
-{
-  std::lock_guard<std::mutex> lock(*m_thread_safe_mutex);
-  return do_allocate(bytes);
-}
-
-void* Allocator::thread_safe_named_allocate(const std::string& name, std::size_t bytes)
-{
-  std::lock_guard<std::mutex> lock(*m_thread_safe_mutex);
-  return do_named_allocate(name, bytes);
-}
-
-void Allocator::thread_safe_deallocate(void* ptr)
-{
-  std::lock_guard<std::mutex> lock(*m_thread_safe_mutex);
-  return do_deallocate(ptr);
-}
-
 void Allocator::release()
 {
   umpire::event::record([&](auto& event) {

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -15,7 +15,10 @@
 namespace umpire {
 
 Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
-    : strategy::mixins::Inspector{}, strategy::mixins::AllocateNull{}, m_tracking{allocator->isTracked()}, m_threadsafe{( dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr )}
+    : strategy::mixins::Inspector{},
+      strategy::mixins::AllocateNull{},
+      m_tracking{allocator->isTracked()},
+      m_threadsafe{(dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr)}
 {
 }
 

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -20,12 +20,12 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
       m_allocator{allocator},
       m_tracking{allocator->isTracked()}
 {
-  umpire::strategy::ThreadSafeAllocator* thread_safe_allocator = dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator);
+  umpire::strategy::ThreadSafeAllocator* thread_safe_allocator =
+      dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator);
 
   if (thread_safe_allocator != nullptr) {
     m_thread_safe_mutex = thread_safe_allocator->get_mutex();
-  }
-  else {
+  } else {
     m_thread_safe_mutex = nullptr;
   }
 }

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -18,16 +18,10 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
     : strategy::mixins::Inspector{},
       strategy::mixins::AllocateNull{},
       m_allocator{allocator},
-      m_tracking{allocator->isTracked()}
+      m_tracking{allocator->isTracked()},
+      m_thread_safe{(dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr)}
 {
-  umpire::strategy::ThreadSafeAllocator* thread_safe_allocator =
-      dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator);
-
-  if (thread_safe_allocator != nullptr) {
-    m_thread_safe_mutex = thread_safe_allocator->get_mutex();
-  } else {
-    m_thread_safe_mutex = nullptr;
-  }
+  m_thread_safe_mutex = m_thread_safe ? dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(m_allocator)->get_mutex() : nullptr;
 }
 
 void Allocator::release()

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -6,19 +6,18 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "umpire/Allocator.hpp"
 
+#include <mutex>
+
 #include "umpire/ResourceManager.hpp"
 #include "umpire/strategy/ThreadSafeAllocator.hpp"
 #include "umpire/util/Macros.hpp"
-#include <mutex>
 
 namespace umpire {
 
 Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
-    : strategy::mixins::Inspector{},
-      strategy::mixins::AllocateNull{},
-      m_tracking{allocator->isTracked()}
+    : strategy::mixins::Inspector{}, strategy::mixins::AllocateNull{}, m_tracking{allocator->isTracked()}
 {
-  m_threadsafe = ( dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr );
+  m_threadsafe = (dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr);
 }
 
 void* Allocator::thread_safe_allocate(std::size_t bytes)

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -15,9 +15,8 @@
 namespace umpire {
 
 Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
-    : strategy::mixins::Inspector{}, strategy::mixins::AllocateNull{}, m_tracking{allocator->isTracked()}
+    : strategy::mixins::Inspector{}, strategy::mixins::AllocateNull{}, m_tracking{allocator->isTracked()}, m_threadsafe{( dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr )}
 {
-  m_threadsafe = (dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr);
 }
 
 void* Allocator::thread_safe_allocate(std::size_t bytes)

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -23,8 +23,7 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
   //
   if (dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr) {
     m_mutex = new std::mutex; // Management of pointer TBD
-  }
-  else {
+  } else {
     m_mutex = nullptr;
   }
 }

--- a/src/umpire/Allocator.cpp
+++ b/src/umpire/Allocator.cpp
@@ -21,7 +21,8 @@ Allocator::Allocator(strategy::AllocationStrategy* allocator) noexcept
       m_tracking{allocator->isTracked()},
       m_thread_safe{(dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(allocator) != nullptr)}
 {
-  m_thread_safe_mutex = m_thread_safe ? dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(m_allocator)->get_mutex() : nullptr;
+  m_thread_safe_mutex =
+      m_thread_safe ? dynamic_cast<umpire::strategy::ThreadSafeAllocator*>(m_allocator)->get_mutex() : nullptr;
 }
 
 void Allocator::release()

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -194,9 +194,9 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
    */
   Allocator(strategy::AllocationStrategy* allocator) noexcept;
 
-  void* thread_safe_allocate(std::size_t bytes);
-  void* thread_safe_named_allocate(const std::string& name, std::size_t bytes);
-  void thread_safe_deallocate(void* ptr);
+  inline void* thread_safe_allocate(std::size_t bytes);
+  inline void* thread_safe_named_allocate(const std::string& name, std::size_t bytes);
+  inline void thread_safe_deallocate(void* ptr);
 
   inline void* do_allocate(std::size_t bytes);
   inline void* do_named_allocate(const std::string& name, std::size_t bytes);

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -9,7 +9,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <mutex>
 #include <ostream>
 #include <string>
 
@@ -194,18 +193,21 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
    */
   Allocator(strategy::AllocationStrategy* allocator) noexcept;
 
+  void* thread_safe_allocate(std::size_t bytes);
+  void* thread_safe_named_allocate(const std::string& name, std::size_t bytes);
+  void thread_safe_deallocate(void* ptr);
+
+  inline void* do_allocate(std::size_t bytes);
+  inline void* do_named_allocate(const std::string& name, std::size_t bytes);
+  inline void do_deallocate(void* ptr);
+
   /*!
    * \brief Pointer to the AllocationStrategy used by this Allocator.
    */
   umpire::strategy::AllocationStrategy* m_allocator;
 
   bool m_tracking{true};
-
-  /*!
-   * \brief Mutex to be used for AllocationStrategys that
-   * require thread safety
-   */
-  std::shared_ptr<std::mutex> m_mutex;
+  bool m_threadsafe{false};
 };
 
 inline std::string to_string(const Allocator& a)

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <ostream>
 #include <string>
 
@@ -199,6 +200,12 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
   umpire::strategy::AllocationStrategy* m_allocator;
 
   bool m_tracking{true};
+
+  /*!
+   * \brief Mutex to be used for AllocationStrategys that
+   * require thread safety
+   */
+  std::mutex* m_mutex;
 };
 
 inline std::string to_string(const Allocator& a)

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -208,6 +208,7 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
   umpire::strategy::AllocationStrategy* m_allocator;
 
   bool m_tracking{true};
+  bool m_thread_safe{false};
   std::mutex* m_thread_safe_mutex{nullptr};
 };
 

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -207,7 +207,7 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
   umpire::strategy::AllocationStrategy* m_allocator;
 
   bool m_tracking{true};
-  bool m_threadsafe{false};
+  bool m_threadsafe;
 };
 
 inline std::string to_string(const Allocator& a)

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <ostream>
 #include <string>
 
@@ -207,7 +208,7 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
   umpire::strategy::AllocationStrategy* m_allocator;
 
   bool m_tracking{true};
-  bool m_threadsafe;
+  std::mutex* m_thread_safe_mutex{nullptr};
 };
 
 inline std::string to_string(const Allocator& a)

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -205,7 +205,7 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
    * \brief Mutex to be used for AllocationStrategys that
    * require thread safety
    */
-  std::mutex* m_mutex;
+  std::shared_ptr<std::mutex> m_mutex;
 };
 
 inline std::string to_string(const Allocator& a)

--- a/src/umpire/Allocator.hpp
+++ b/src/umpire/Allocator.hpp
@@ -194,6 +194,23 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
    */
   Allocator(strategy::AllocationStrategy* allocator) noexcept;
 
+  /*!
+   * \brief Pointer to the AllocationStrategy used by this Allocator.
+   */
+  umpire::strategy::AllocationStrategy* m_allocator;
+
+  bool m_tracking{true};
+
+  /*!
+   * \brief Implementation to conditionally make Allocator thread-safe
+   *
+   * Make allocations thread-safe by syncronizing access to the entire
+   * allocation sequence including zero-byte-allocation check, allocation,
+   * and tracking bookkeeping.
+   *
+   * TODO: This is a temporary workaround until we update the Allocator API to
+   * automatically do this based upon type and/or policy information.
+   */
   inline void* thread_safe_allocate(std::size_t bytes);
   inline void* thread_safe_named_allocate(const std::string& name, std::size_t bytes);
   inline void thread_safe_deallocate(void* ptr);
@@ -202,12 +219,6 @@ class Allocator : private strategy::mixins::Inspector, strategy::mixins::Allocat
   inline void* do_named_allocate(const std::string& name, std::size_t bytes);
   inline void do_deallocate(void* ptr);
 
-  /*!
-   * \brief Pointer to the AllocationStrategy used by this Allocator.
-   */
-  umpire::strategy::AllocationStrategy* m_allocator;
-
-  bool m_tracking{true};
   bool m_thread_safe{false};
   std::mutex* m_thread_safe_mutex{nullptr};
 };

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -8,10 +8,10 @@
 #define UMPIRE_Allocator_INL
 
 #include "umpire/Allocator.hpp"
-#include "umpire/strategy/ThreadSafeAllocator.hpp"
 #include "umpire/config.hpp"
 #include "umpire/event/event.hpp"
 #include "umpire/event/recorder_factory.hpp"
+#include "umpire/strategy/ThreadSafeAllocator.hpp"
 #include "umpire/util/Macros.hpp"
 #include "umpire/util/error.hpp"
 

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -113,29 +113,17 @@ inline void Allocator::do_deallocate(void* ptr)
 
 inline void* Allocator::allocate(std::size_t bytes)
 {
-  if (m_thread_safe_mutex != nullptr) {
-    return thread_safe_allocate(bytes);
-  } else {
-    return do_allocate(bytes);
-  }
+  return m_thread_safe ? thread_safe_allocate(bytes) : do_allocate(bytes);
 }
 
 inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
 {
-  if (m_thread_safe_mutex != nullptr) {
-    return thread_safe_named_allocate(name, bytes);
-  } else {
-    return do_named_allocate(name, bytes);
-  }
+  return m_thread_safe ? thread_safe_named_allocate(name, bytes) : do_named_allocate(name, bytes);
 }
 
 inline void Allocator::deallocate(void* ptr)
 {
-  if (m_thread_safe_mutex != nullptr) {
-    thread_safe_deallocate(ptr);
-  } else {
-    do_deallocate(ptr);
-  }
+  m_thread_safe ? thread_safe_deallocate(ptr) : do_deallocate(ptr);
 }
 
 } // end of namespace umpire

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -64,7 +64,7 @@ inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
 
   if (m_mutex != nullptr)
     m_mutex->lock();
-  
+
   if (0 == bytes) {
     ret = allocateNull();
   } else {

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -24,6 +24,9 @@ inline void* Allocator::allocate(std::size_t bytes)
 
   UMPIRE_LOG(Debug, "(" << bytes << ")");
 
+  if (m_mutex != nullptr)
+    m_mutex->lock();
+
   if (0 == bytes) {
     ret = allocateNull();
   } else {
@@ -32,6 +35,8 @@ inline void* Allocator::allocate(std::size_t bytes)
     } catch (umpire::out_of_memory_error& e) {
       e.set_allocator_id(this->getId());
       e.set_requested_size(bytes);
+      if (m_mutex != nullptr)
+        m_mutex->unlock();
       throw;
     }
   }
@@ -39,6 +44,9 @@ inline void* Allocator::allocate(std::size_t bytes)
   if (m_tracking) {
     registerAllocation(ret, bytes, m_allocator);
   }
+
+  if (m_mutex != nullptr)
+    m_mutex->unlock();
 
   umpire::event::record<umpire::event::allocate>(
       [&](auto& event) { event.size(bytes).ref((void*)m_allocator).ptr(ret); });
@@ -54,6 +62,9 @@ inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
 
   UMPIRE_LOG(Debug, "(" << bytes << ")");
 
+  if (m_mutex != nullptr)
+    m_mutex->lock();
+  
   if (0 == bytes) {
     ret = allocateNull();
   } else {
@@ -63,6 +74,9 @@ inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
   if (m_tracking) {
     registerAllocation(ret, bytes, m_allocator, name);
   }
+
+  if (m_mutex != nullptr)
+    m_mutex->unlock();
 
   umpire::event::record<umpire::event::named_allocate>(
       [&](auto& event) { event.name(name).size(bytes).ref((void*)m_allocator).ptr(ret); });
@@ -79,6 +93,8 @@ inline void Allocator::deallocate(void* ptr)
     UMPIRE_LOG(Info, "Deallocating a null pointer (This behavior is intentionally allowed and ignored)");
     return;
   } else {
+    if (m_mutex != nullptr)
+      m_mutex->lock();
     if (m_tracking) {
       auto record = deregisterAllocation(ptr, m_allocator);
       if (!deallocateNull(ptr)) {
@@ -89,6 +105,8 @@ inline void Allocator::deallocate(void* ptr)
         m_allocator->deallocate(ptr);
       }
     }
+    if (m_mutex != nullptr)
+      m_mutex->unlock();
   }
 }
 

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -95,7 +95,7 @@ inline void Allocator::do_deallocate(void* ptr)
 
 inline void* Allocator::allocate(std::size_t bytes)
 {
-  if (m_threadsafe) {
+  if (m_thread_safe_mutex != nullptr) {
     return thread_safe_allocate(bytes);
   } else {
     return do_allocate(bytes);
@@ -104,7 +104,7 @@ inline void* Allocator::allocate(std::size_t bytes)
 
 inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
 {
-  if (m_threadsafe) {
+  if (m_thread_safe_mutex != nullptr) {
     return thread_safe_named_allocate(name, bytes);
   } else {
     return do_named_allocate(name, bytes);
@@ -113,7 +113,7 @@ inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
 
 inline void Allocator::deallocate(void* ptr)
 {
-  if (m_threadsafe) {
+  if (m_thread_safe_mutex != nullptr) {
     thread_safe_deallocate(ptr);
   } else {
     do_deallocate(ptr);

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -24,29 +24,25 @@ inline void* Allocator::allocate(std::size_t bytes)
 
   UMPIRE_LOG(Debug, "(" << bytes << ")");
 
-  if (m_mutex != nullptr)
-    m_mutex->lock();
+  {
+    const std::lock_guard<std::mutex> lock(m_mutex);
 
-  if (0 == bytes) {
-    ret = allocateNull();
-  } else {
-    try {
-      ret = m_allocator->allocate(bytes);
-    } catch (umpire::out_of_memory_error& e) {
-      e.set_allocator_id(this->getId());
-      e.set_requested_size(bytes);
-      if (m_mutex != nullptr)
-        m_mutex->unlock();
-      throw;
+    if (0 == bytes) {
+      ret = allocateNull();
+    } else {
+      try {
+        ret = m_allocator->allocate(bytes);
+      } catch (umpire::out_of_memory_error& e) {
+        e.set_allocator_id(this->getId());
+        e.set_requested_size(bytes);
+        throw;
+      }
+    }
+
+    if (m_tracking) {
+      registerAllocation(ret, bytes, m_allocator);
     }
   }
-
-  if (m_tracking) {
-    registerAllocation(ret, bytes, m_allocator);
-  }
-
-  if (m_mutex != nullptr)
-    m_mutex->unlock();
 
   umpire::event::record<umpire::event::allocate>(
       [&](auto& event) { event.size(bytes).ref((void*)m_allocator).ptr(ret); });
@@ -62,21 +58,19 @@ inline void* Allocator::allocate(const std::string& name, std::size_t bytes)
 
   UMPIRE_LOG(Debug, "(" << bytes << ")");
 
-  if (m_mutex != nullptr)
-    m_mutex->lock();
+  {
+    const std::lock_guard<std::mutex> lock(m_mutex);
 
-  if (0 == bytes) {
-    ret = allocateNull();
-  } else {
-    ret = m_allocator->allocate_named(name, bytes);
+    if (0 == bytes) {
+      ret = allocateNull();
+    } else {
+      ret = m_allocator->allocate_named(name, bytes);
+    }
+
+    if (m_tracking) {
+      registerAllocation(ret, bytes, m_allocator, name);
+    }
   }
-
-  if (m_tracking) {
-    registerAllocation(ret, bytes, m_allocator, name);
-  }
-
-  if (m_mutex != nullptr)
-    m_mutex->unlock();
 
   umpire::event::record<umpire::event::named_allocate>(
       [&](auto& event) { event.name(name).size(bytes).ref((void*)m_allocator).ptr(ret); });
@@ -93,8 +87,8 @@ inline void Allocator::deallocate(void* ptr)
     UMPIRE_LOG(Info, "Deallocating a null pointer (This behavior is intentionally allowed and ignored)");
     return;
   } else {
-    if (m_mutex != nullptr)
-      m_mutex->lock();
+    const std::lock_guard<std::mutex> lock(m_mutex);
+
     if (m_tracking) {
       auto record = deregisterAllocation(ptr, m_allocator);
       if (!deallocateNull(ptr)) {
@@ -105,8 +99,6 @@ inline void Allocator::deallocate(void* ptr)
         m_allocator->deallocate(ptr);
       }
     }
-    if (m_mutex != nullptr)
-      m_mutex->unlock();
   }
 }
 

--- a/src/umpire/Allocator.inl
+++ b/src/umpire/Allocator.inl
@@ -47,6 +47,24 @@ inline void* Allocator::do_allocate(std::size_t bytes)
   return ret;
 }
 
+inline void* Allocator::thread_safe_allocate(std::size_t bytes)
+{
+  std::lock_guard<std::mutex> lock(*m_thread_safe_mutex);
+  return do_allocate(bytes);
+}
+
+inline void* Allocator::thread_safe_named_allocate(const std::string& name, std::size_t bytes)
+{
+  std::lock_guard<std::mutex> lock(*m_thread_safe_mutex);
+  return do_named_allocate(name, bytes);
+}
+
+inline void Allocator::thread_safe_deallocate(void* ptr)
+{
+  std::lock_guard<std::mutex> lock(*m_thread_safe_mutex);
+  return do_deallocate(ptr);
+}
+
 inline void* Allocator::do_named_allocate(const std::string& name, std::size_t bytes)
 {
   void* ret = nullptr;

--- a/src/umpire/config.hpp.in
+++ b/src/umpire/config.hpp.in
@@ -54,7 +54,7 @@
 #define UMPIRE_EXPORT
 #endif
 
-#define UMPIRE_VERSION_SYM  umpire_ver_@Umpire_VERSION_MAJOR@_found
+#define UMPIRE_VERSION_SYM  umpire_ver_@Umpire_VERSION_MAJOR@_@Umpire_VERSION_MINOR@_found
 UMPIRE_EXPORT extern int    UMPIRE_VERSION_SYM;
 #define UMPIRE_VERSION_OK() UMPIRE_VERSION_SYM == 0
 

--- a/src/umpire/strategy/ThreadSafeAllocator.cpp
+++ b/src/umpire/strategy/ThreadSafeAllocator.cpp
@@ -22,14 +22,12 @@ ThreadSafeAllocator::ThreadSafeAllocator(const std::string& name, int id, Alloca
 
 void* ThreadSafeAllocator::allocate(std::size_t bytes)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
   void* ret = m_allocator->allocate_internal(bytes);
   return ret;
 }
 
 void ThreadSafeAllocator::deallocate(void* ptr, std::size_t size)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
   m_allocator->deallocate_internal(ptr, size);
 }
 
@@ -41,6 +39,11 @@ Platform ThreadSafeAllocator::getPlatform() noexcept
 MemoryResourceTraits ThreadSafeAllocator::getTraits() const noexcept
 {
   return m_allocator->getTraits();
+}
+
+std::mutex& ThreadSafeAllocator::get_mutex()
+{
+  return m_mutex;
 }
 
 } // end of namespace strategy

--- a/src/umpire/strategy/ThreadSafeAllocator.cpp
+++ b/src/umpire/strategy/ThreadSafeAllocator.cpp
@@ -22,8 +22,7 @@ ThreadSafeAllocator::ThreadSafeAllocator(const std::string& name, int id, Alloca
 
 void* ThreadSafeAllocator::allocate(std::size_t bytes)
 {
-  void* ret = m_allocator->allocate_internal(bytes);
-  return ret;
+  return m_allocator->allocate_internal(bytes);
 }
 
 void ThreadSafeAllocator::deallocate(void* ptr, std::size_t size)
@@ -41,9 +40,9 @@ MemoryResourceTraits ThreadSafeAllocator::getTraits() const noexcept
   return m_allocator->getTraits();
 }
 
-std::mutex& ThreadSafeAllocator::get_mutex()
+std::mutex* ThreadSafeAllocator::get_mutex()
 {
-  return m_mutex;
+  return &m_mutex;
 }
 
 } // end of namespace strategy

--- a/src/umpire/strategy/ThreadSafeAllocator.hpp
+++ b/src/umpire/strategy/ThreadSafeAllocator.hpp
@@ -33,7 +33,7 @@ class ThreadSafeAllocator : public AllocationStrategy {
 
   MemoryResourceTraits getTraits() const noexcept override;
 
-  std::mutex& get_mutex();
+  std::mutex* get_mutex();
 
  protected:
   strategy::AllocationStrategy* m_allocator;

--- a/src/umpire/strategy/ThreadSafeAllocator.hpp
+++ b/src/umpire/strategy/ThreadSafeAllocator.hpp
@@ -33,6 +33,8 @@ class ThreadSafeAllocator : public AllocationStrategy {
 
   MemoryResourceTraits getTraits() const noexcept override;
 
+  std::mutex& get_mutex();
+
  protected:
   strategy::AllocationStrategy* m_allocator;
 


### PR DESCRIPTION
The `ThreadSafeAllocator` strategy was only placing a mutex around the allocate and deallocate calls and tracking and zero-byte-allocation calls were left unprotected since they were being performed out of scope from the `ThreadSafeAllocator` strategy.

The fix was to move the mutex usage up to the `Allocator` API level where the zero-byte-allocation, tracking, and allocate/deallocate calls were being made.