### PR TITLE
Soon required update of readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,6 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
- python:
-   install:
-   - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,22 @@
-python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+ python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Today is a brownout, temporarily enforcing future deprecation of readthedocs configuration file for 24 hours: 00:01 PST to 23:59 PST (midnight)

This PR updates the readthedocs configuration file. If the docs builds with this changes, then it’s ready for the upcoming requirement changes in readthedocs.

@davidbeckingsale I suggest you activate this version on readthedocs.org so that we know it’s building.