### PR TITLE
fixed getReleasableSize()

### DIFF
--- a/src/umpire/strategy/DynamicSizePool.hpp
+++ b/src/umpire/strategy/DynamicSizePool.hpp
@@ -404,12 +404,10 @@ class DynamicSizePool : private umpire::strategy::mixins::AlignedAllocation {
 
   std::size_t getReleasableSize() const
   {
-    std::size_t nblocks = 0;
     std::size_t nbytes = 0;
     for (struct Block *temp = freeBlocks; temp; temp = temp->next) {
       if (temp->size == temp->blockSize) {
         nbytes += temp->blockSize;
-        nblocks++;
       }
     }
     return nbytes;

--- a/src/umpire/strategy/DynamicSizePool.hpp
+++ b/src/umpire/strategy/DynamicSizePool.hpp
@@ -412,7 +412,7 @@ class DynamicSizePool : private umpire::strategy::mixins::AlignedAllocation {
         nblocks++;
       }
     }
-    return nblocks > 1 ? nbytes : 0;
+    return nbytes;
   }
 
   std::size_t getFreeBlocks() const

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -318,7 +318,7 @@ void QuickPool::coalesce() noexcept
 
 void QuickPool::do_coalesce(std::size_t suggested_size) noexcept
 {
-  if (m_size_map.size() > 1)  {
+  if (m_size_map.size() > 1) {
     UMPIRE_LOG(Debug, "()");
     release();
     std::size_t size_post{getActualSize()};

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -267,12 +267,17 @@ std::size_t QuickPool::getCurrentSize() const noexcept
   return m_current_bytes;
 }
 
-std::size_t QuickPool::getReleasableSize() const noexcept
+std::size_t QuickPool::getReleasableSizeCoalescing() const noexcept
 {
   if (m_size_map.size() > 1)
     return m_releasable_bytes;
   else
     return 0;
+}
+
+std::size_t QuickPool::getReleasableSize() const noexcept
+{
+  return m_releasable_bytes;
 }
 
 std::size_t QuickPool::getActualHighwaterMark() const noexcept
@@ -358,14 +363,14 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::percent_releasable(int percentage)
     return [=](const QuickPool& UMPIRE_UNUSED_ARG(pool)) { return 0; };
   } else if (percentage == 100) {
     return [=](const strategy::QuickPool& pool) {
-      return pool.getActualSize() == pool.getReleasableSize() ? pool.getActualSize() : 0;
+      return pool.getActualSize() == pool.getReleasableSizeCoalescing() ? pool.getActualSize() : 0;
     };
   } else {
     float f = (float)((float)percentage / (float)100.0);
     return [=](const strategy::QuickPool& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() >= threshold ? pool.getActualSize() : 0;
+      return pool.getReleasableSizeCoalescing() >= threshold ? pool.getActualSize() : 0;
     };
   }
 }
@@ -381,14 +386,14 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::percent_releasable_hwm(int percentag
     return [=](const QuickPool& UMPIRE_UNUSED_ARG(pool)) { return 0; };
   } else if (percentage == 100) {
     return [=](const strategy::QuickPool& pool) {
-      return pool.getActualSize() == pool.getReleasableSize() ? pool.getHighWatermark() : 0;
+      return pool.getActualSize() == pool.getReleasableSizeCoalescing() ? pool.getHighWatermark() : 0;
     };
   } else {
     float f = (float)((float)percentage / (float)100.0);
     return [=](const strategy::QuickPool& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() >= threshold ? pool.getHighWatermark() : 0;
+      return pool.getReleasableSizeCoalescing() >= threshold ? pool.getHighWatermark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/QuickPool.hpp
+++ b/src/umpire/strategy/QuickPool.hpp
@@ -72,7 +72,6 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
   std::size_t getActualSize() const noexcept override;
   std::size_t getCurrentSize() const noexcept override;
   std::size_t getReleasableSize() const noexcept;
-  std::size_t getReleasableSizeCoalescing() const noexcept;
   std::size_t getActualHighwaterMark() const noexcept;
 
   Platform getPlatform() noexcept override;

--- a/src/umpire/strategy/QuickPool.hpp
+++ b/src/umpire/strategy/QuickPool.hpp
@@ -72,6 +72,7 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
   std::size_t getActualSize() const noexcept override;
   std::size_t getCurrentSize() const noexcept override;
   std::size_t getReleasableSize() const noexcept;
+  std::size_t getReleasableSizeCoalescing() const noexcept;
   std::size_t getActualHighwaterMark() const noexcept;
 
   Platform getPlatform() noexcept override;

--- a/tests/integration/primary_pool_tests.cpp
+++ b/tests/integration/primary_pool_tests.cpp
@@ -654,6 +654,35 @@ TYPED_TEST(PrimaryPoolTest, heuristic_100_percent)
   ASSERT_EQ(pool->getBlocksInPool(), 1);        // Collapse happened
 }
 
+TYPED_TEST(PrimaryPoolTest, ReleasableSizeCheck)
+{
+  using Pool = typename TestFixture::Pool;
+  auto pool = umpire::util::unwrap_allocator<Pool>(*this->m_allocator);
+
+  ASSERT_NE(pool, nullptr);
+
+  const std::size_t iterations{8};
+  void* allocs[iterations];
+
+  ASSERT_EQ(pool->getReleasableSize(), 0);
+
+  // 8 Blocks (0 free, 8 allocated)
+  for (int i{0}; i < 8; ++i) {
+    ASSERT_NO_THROW(allocs[i] = this->m_allocator->allocate(this->m_initial_pool_size););
+    ASSERT_EQ(pool->getReleasableSize(), 0);
+  }
+
+  // 8 blocks (8 free, 0 allocated)
+  for (int i{0}; i < 8; ++i) {
+    ASSERT_NO_THROW(this->m_allocator->deallocate(allocs[i]););
+    ASSERT_EQ(pool->getReleasableSize(), this->m_initial_pool_size * (i + 1));
+  }
+
+  pool->release();
+
+  ASSERT_EQ(pool->getReleasableSize(), 0);
+}
+
 #if defined(UMPIRE_ENABLE_CONST)
 using ConstResourceTypes = camp::list<device_const_resource_tag>;
 using ConstPoolTypes = camp::list<umpire::strategy::DynamicPoolList, umpire::strategy::QuickPool>;


### PR DESCRIPTION
In order to fix the getReleasableSize() function for both `QuickPool.cpp` and `DynamicSizePool.hpp` I wrapped the coalescing function with a conditional that checks if there is more than a single block in the pool. 