### PR TITLE
[WIP] [Woptim] RADIUSS Spack Configs update

### DIFF
--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -51,14 +51,14 @@ ibm_clang_14_0_5_gcc_8_3_1_cuda_11_7_0_mpi_shmem:
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 
-clang_14_0_5_libcpp:
+clang_12_0_1_libcpp:
   variables:
-    SPEC: "~shared +tools tests=basic %clang@=14.0.5 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
+    SPEC: "~shared +tools tests=basic %clang@=12.0.1 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
   extends: .job_on_lassen
 
-clang_14_0_5_gcc_8_3_1_memleak:
+clang_12_0_1_gcc_8_3_1_memleak:
   variables:
-    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=14.0.5.gcc.8.3.1 cxxflags==-fsanitize=address"
+    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=12.0.1.gcc.8.3.1 cxxflags==-fsanitize=address"
     ASAN_OPTIONS: "detect_leaks=1"
   extends: .job_on_lassen
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -51,14 +51,14 @@ ibm_clang_14_0_5_gcc_8_3_1_cuda_11_7_0_mpi_shmem:
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 
-clang_16_0_6_libcpp:
+clang_14_0_5_libcpp:
   variables:
-    SPEC: "~shared +tools tests=basic %clang@=16.0.6 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
+    SPEC: "~shared +tools tests=basic %clang@=14.0.5 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
   extends: .job_on_lassen
 
-clang_16_0_6_gcc_8_3_1_memleak:
+clang_14_0_5_gcc_8_3_1_memleak:
   variables:
-    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=16.0.6.gcc.8.3.1 cxxflags==-fsanitize=address"
+    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=14.0.5.gcc.8.3.1 cxxflags==-fsanitize=address"
     ASAN_OPTIONS: "detect_leaks=1"
   extends: .job_on_lassen
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -51,14 +51,14 @@ ibm_clang_14_0_5_gcc_8_3_1_cuda_11_7_0_mpi_shmem:
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 
-clang_12_0_1_libcpp:
+clang_16_0_6_libcpp:
   variables:
-    SPEC: "~shared +tools tests=basic %clang@=12.0.1 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
+    SPEC: "~shared +tools tests=basic %clang@=16.0.6 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
   extends: .job_on_lassen
 
-clang_12_0_1_gcc_8_3_1_memleak:
+clang_16_0_6_gcc_8_3_1_memleak:
   variables:
-    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=12.0.1.gcc.8.3.1 cxxflags==-fsanitize=address"
+    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=16.0.6.gcc.8.3.1 cxxflags==-fsanitize=address"
     ASAN_OPTIONS: "detect_leaks=1"
   extends: .job_on_lassen
 


### PR DESCRIPTION
# Summary

- This PR updates the submodule RADIUSS Spack Configs

## Purpose

In RADIUSS Spack Configs:
- The compilers (wrappers) on Lassen have been updated to better support the use of gcc 8.3.1 toolchain.
- The local spack packages have been updated to be as close as possible to what we are pushing in https://github.com/spack/spack/pull/41375.

## Notes

Packages in RADIUSS Spack Configs still have some specific changes compared to the PR mentioned above.

Supersedes https://github.com/LLNL/Umpire/pull/876