### PR TITLE
Make fmt header-only by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,13 @@ FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-12.0.0 AS clang12
 ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace/build
-RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ .. && \
+RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/home/umpire/workspace/install .. && \
     make -j 16 && \
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd /home/umpire/workspace/install/examples/umpire/using-with-cmake && \
+    mkdir build && cd build && \
+    cmake -C ../host-config.cmake .. && \
+    make
 
 FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-11.0.0 AS umap_build
 ENV GTEST_COLOR=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV GTEST_COLOR=1
 COPY . /home/umpire/workspace
 WORKDIR /home/umpire/workspace/build
 RUN cmake -DUMPIRE_ENABLE_DEVELOPER_DEFAULTS=On -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/home/umpire/workspace/install .. && \
-    make -j 16 && \
+    make -j 16 && make install && \
     ctest -T test --output-on-failure && \
     cd /home/umpire/workspace/install/examples/umpire/using-with-cmake && \
     mkdir build && cd build && \

--- a/cmake/SetupUmpireOptions.cmake
+++ b/cmake/SetupUmpireOptions.cmake
@@ -39,7 +39,7 @@ option(UMPIRE_ENABLE_SANITIZER_TESTS "Enable address sanitizer tests" Off)
 option(UMPIRE_ENABLE_DEVICE_ALLOCATOR "Enable Device Allocator" Off)
 option(UMPIRE_ENABLE_SQLITE_EXPERIMENTAL "Build with sqlite event integration (experimental)" Off)
 option(UMPIRE_DISABLE_ALLOCATIONMAP_DEBUG "Disable verbose output from AllocationMap during debug builds" Off)
-set(UMPIRE_FMT_TARGET fmt::fmt CACHE STRING "Name of fmt target to use") 
+set(UMPIRE_FMT_TARGET fmt::fmt-header-only CACHE STRING "Name of fmt target to use") 
 
 if (UMPIRE_ENABLE_INACCESSIBILITY_TESTS)
   set(ENABLE_GTEST_DEATH_TESTS On CACHE BOOL "Enable tests asserting failure.")

--- a/cmake/SetupUmpireOptions.cmake
+++ b/cmake/SetupUmpireOptions.cmake
@@ -39,6 +39,7 @@ option(UMPIRE_ENABLE_SANITIZER_TESTS "Enable address sanitizer tests" Off)
 option(UMPIRE_ENABLE_DEVICE_ALLOCATOR "Enable Device Allocator" Off)
 option(UMPIRE_ENABLE_SQLITE_EXPERIMENTAL "Build with sqlite event integration (experimental)" Off)
 option(UMPIRE_DISABLE_ALLOCATIONMAP_DEBUG "Disable verbose output from AllocationMap during debug builds" Off)
+set(UMPIRE_FMT_TARGET fmt::fmt CACHE STRING "Name of fmt target to use") 
 
 if (UMPIRE_ENABLE_INACCESSIBILITY_TESTS)
   set(ENABLE_GTEST_DEATH_TESTS On CACHE BOOL "Enable tests asserting failure.")

--- a/src/tpl/CMakeLists.txt
+++ b/src/tpl/CMakeLists.txt
@@ -143,8 +143,8 @@ if (NOT TARGET ${UMPIRE_FMT_TARGET})
         ${fmt_DIR}
         ${fmt_DIR}/lib64/cmake/fmt)
 
-    set_target_properties(fmt::fmt PROPERTIES IMPORTED_GLOBAL TRUE)
-    blt_convert_to_system_includes(TARGET fmt::fmt)
+    set_target_properties(${UMPIRE_FMT_TARGET} PROPERTIES IMPORTED_GLOBAL TRUE)
+    blt_convert_to_system_includes(TARGET ${UMPIRE_FMT_TARGET}
   else ()
     if (NOT EXISTS ${PROJECT_SOURCE_DIR}/src/tpl/umpire/fmt/CMakeLists.txt)
       message(FATAL_ERROR "fmt submodule not initialized. Run 'git submodule update --init --recursive' in the git repository or set fmt_DIR to use an external build of fmt.")
@@ -153,7 +153,6 @@ if (NOT TARGET ${UMPIRE_FMT_TARGET})
       set(fmt_DIR ${CMAKE_INSTALL_PREFIX} CACHE PATH "")
       set(FMT_INSTALL ON)
       set(FMT_SYSTEM_HEADERS ON)
-      set(UMPIRE_FMT_TARGET fmt::fmt-header-only CACHE STRING "" FORCE)
       add_subdirectory(umpire/fmt)
     endif ()
   endif ()

--- a/src/tpl/CMakeLists.txt
+++ b/src/tpl/CMakeLists.txt
@@ -144,7 +144,7 @@ if (NOT TARGET ${UMPIRE_FMT_TARGET})
         ${fmt_DIR}/lib64/cmake/fmt)
 
     set_target_properties(${UMPIRE_FMT_TARGET} PROPERTIES IMPORTED_GLOBAL TRUE)
-    blt_convert_to_system_includes(TARGET ${UMPIRE_FMT_TARGET}
+    blt_convert_to_system_includes(TARGET ${UMPIRE_FMT_TARGET})
   else ()
     if (NOT EXISTS ${PROJECT_SOURCE_DIR}/src/tpl/umpire/fmt/CMakeLists.txt)
       message(FATAL_ERROR "fmt submodule not initialized. Run 'git submodule update --init --recursive' in the git repository or set fmt_DIR to use an external build of fmt.")

--- a/src/tpl/CMakeLists.txt
+++ b/src/tpl/CMakeLists.txt
@@ -135,7 +135,7 @@ if (NOT TARGET camp)
   endif()
 endif ()
 
-if (NOT TARGET fmt::fmt)
+if (NOT TARGET ${UMPIRE_FMT_TARGET})
   if (DEFINED fmt_DIR)
     find_package(fmt REQUIRED
       NO_DEFAULT_PATH
@@ -153,6 +153,7 @@ if (NOT TARGET fmt::fmt)
       set(fmt_DIR ${CMAKE_INSTALL_PREFIX} CACHE PATH "")
       set(FMT_INSTALL ON)
       set(FMT_SYSTEM_HEADERS ON)
+      set(UMPIRE_FMT_TARGET fmt::fmt-header-only CACHE STRING "" FORCE)
       add_subdirectory(umpire/fmt)
     endif ()
   endif ()

--- a/src/umpire/event/CMakeLists.txt
+++ b/src/umpire/event/CMakeLists.txt
@@ -17,7 +17,7 @@ set (umpire_event_sources
   json_file_store.cpp
   recorder_factory.cpp)
 
-set (umpire_event_depends fmt::fmt umpire_tpl_json camp)
+set (umpire_event_depends ${UMPIRE_FMT_TARGET} umpire_tpl_json camp)
 
 if (UMPIRE_ENABLE_CUDA)
   set(umpire_event_depends

--- a/src/umpire/resource/CMakeLists.txt
+++ b/src/umpire/resource/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-set(umpire_resource_depends umpire_util camp fmt::fmt)
+set(umpire_resource_depends umpire_util camp ${UMPIRE_FMT_TARGET})
 
 set (umpire_resource_headers
   DefaultMemoryResource.hpp

--- a/src/umpire/util/CMakeLists.txt
+++ b/src/umpire/util/CMakeLists.txt
@@ -52,7 +52,7 @@ if (UMPIRE_ENABLE_NUMA)
     numa.cpp)
 endif ()
 
-set (umpire_util_depends camp umpire_event umpire_tpl_judy fmt::fmt)
+set (umpire_util_depends camp umpire_event umpire_tpl_judy ${UMPIRE_FMT_TARGET})
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set (umpire_util_depends

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -40,7 +40,7 @@ if (@UMPIRE_ENABLE_IPC_SHARED_MEMORY@)
   find_dependency(Threads)
 endif ()
 
-if (NOT TARGET fmt::fmt)
+if (NOT TARGET @UMPIRE_FMT_TARGET@)
   set(UMPIRE_FMT_DIR "@fmt_DIR@")
   if(NOT fmt_DIR)
     set(fmt_DIR ${UMPIRE_FMT_DIR})


### PR DESCRIPTION
Allows user to define preferred fmt target using `UMPIRE_FMT_TARGET` variable.