### PR TITLE
Use GitLab container registry as a Spack build cache

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -70,3 +70,15 @@ variables:
   artifacts:
     reports:
       junit: junit.xml
+
+.reproducer_vars:
+  script:
+    - |
+      echo -e "
+      # Required variables \n
+      export MODULE_LIST=\"${MODULE_LIST}\" \n
+      export SPEC=\"${SPEC//\"/\\\"}\" \n
+      # Allow to set job script for debugging (only this differs from CI) \n
+      export DEBUG_MODE=true \n
+      # Using the CI build cache is optional and requires a token. Set it like so: \n
+      # export REGISTRY_TOKEN=\"<your token here>\" \n"

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -56,7 +56,7 @@ variables:
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.
 # Arguments for job level allocation
-  LASSEN_JOB_ALLOC: "1 -W 10 -q pci"
+  LASSEN_JOB_ALLOC: "1 -W 12 -q pci"
 # Project specific variants for lassen
   PROJECT_LASSEN_VARIANTS: "~shared +fortran +tools tests=basic "
 # Project specific deps for lassen

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -56,7 +56,7 @@ variables:
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.
 # Arguments for job level allocation
-  LASSEN_JOB_ALLOC: "1 -W 12 -q pci"
+  LASSEN_JOB_ALLOC: "1 -W 10 -q pci"
 # Project specific variants for lassen
   PROJECT_LASSEN_VARIANTS: "~shared +fortran +tools tests=basic "
 # Project specific deps for lassen

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -9,8 +9,13 @@
 .corona_reproducer_vars:
   script:
     - |
+      echo -e "# Mandatory variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+      echo -e "# Allow to set job script for debugging (only this differs from CI)"
+      echo -e "export DEBUG_MODE=true"
+      echo -e "# Using the CI build cache is optional (requires a token)"
+      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -14,8 +14,8 @@
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"
       echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional (requires a token)"
-      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
+      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
+      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -9,7 +9,7 @@
 .corona_reproducer_vars:
   script:
     - |
-      echo -e "# Mandatory variables"
+      echo -e "# Required variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -8,14 +8,7 @@
 # Override reproducer section to define Umpire specific variables.
 .corona_reproducer_vars:
   script:
-    - |
-      echo -e "# Required variables"
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
-      echo -e "# Allow to set job script for debugging (only this differs from CI)"
-      echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
-      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -9,8 +9,13 @@
 .lassen_reproducer_vars:
   script:
     - |
+      echo -e "# Mandatory variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+      echo -e "# Allow to set job script for debugging (only this differs from CI)"
+      echo -e "export DEBUG_MODE=true"
+      echo -e "# Using the CI build cache is optional (requires a token)"
+      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -8,14 +8,7 @@
 # Override reproducer section to define Umpire specific variables.
 .lassen_reproducer_vars:
   script:
-    - |
-      echo -e "# Required variables"
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
-      echo -e "# Allow to set job script for debugging (only this differs from CI)"
-      echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
-      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -65,6 +65,7 @@ clang_12_0_1_gcc_8_3_1_memleak:
   variables:
     SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=12.0.1.gcc.8.3.1 cxxflags==-fsanitize=address"
     ASAN_OPTIONS: "detect_leaks=1"
+    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
   extends: .job_on_lassen
 
 # clang_9_0_0_datarace (build and test on lassen):

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -14,8 +14,8 @@
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"
       echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional (requires a token)"
-      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
+      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
+      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -9,7 +9,7 @@
 .lassen_reproducer_vars:
   script:
     - |
-      echo -e "# Mandatory variables"
+      echo -e "# Required variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -9,7 +9,7 @@
 .poodle_reproducer_vars:
   script:
     - |
-      echo -e "# Mandatory variables"
+      echo -e "# Required variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -14,8 +14,8 @@
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"
       echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional (requires a token)"
-      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
+      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
+      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -9,8 +9,13 @@
 .poodle_reproducer_vars:
   script:
     - |
+      echo -e "# Mandatory variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+      echo -e "# Allow to set job script for debugging (only this differs from CI)"
+      echo -e "export DEBUG_MODE=true"
+      echo -e "# Using the CI build cache is optional (requires a token)"
+      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -8,14 +8,7 @@
 # Override reproducer section to define Umpire specific variables.
 .poodle_reproducer_vars:
   script:
-    - |
-      echo -e "# Required variables"
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
-      echo -e "# Allow to set job script for debugging (only this differs from CI)"
-      echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
-      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -9,7 +9,7 @@
 .ruby_reproducer_vars:
   script:
     - |
-      echo -e "# Mandatory variables"
+      echo -e "# Required variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -14,8 +14,8 @@
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"
       echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional (requires a token)"
-      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
+      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
+      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -9,8 +9,13 @@
 .ruby_reproducer_vars:
   script:
     - |
+      echo -e "# Mandatory variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+      echo -e "# Allow to set job script for debugging (only this differs from CI)"
+      echo -e "export DEBUG_MODE=true"
+      echo -e "# Using the CI build cache is optional (requires a token)"
+      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -8,14 +8,7 @@
 # Override reproducer section to define UMPIRE specific variables.
 .ruby_reproducer_vars:
   script:
-    - |
-      echo -e "# Required variables"
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
-      echo -e "# Allow to set job script for debugging (only this differs from CI)"
-      echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
-      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -12,49 +12,49 @@
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
 
-########################
-# Overridden shared jobs
-########################
-# We duplicate the shared jobs description and add necessary changes for RAJA.
-# We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
-# the comparison with the original job is easier.
-
-# Allow failure due to compiler internal error building wrapfumpire.f
-intel_2022_1_0:
-  variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
-  extends: .job_on_ruby
-  allow_failure: true
-
-############
-# Extra jobs
-############
-# We do not recommend using ${PROJECT_<MACHINE>_VARIANTS} and
-# ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is not reason not to fully
-# describe the spec here.
-
-gcc_10_3_1_numa:
-  variables:
-    SPEC: "~shared +fortran +numa +tools tests=basic %gcc@=10.3.1"
-  extends: .job_on_ruby
-
-clang_14_0_6_gcc_10_3_1_sqlite_experimental:
-  variables:
-    SPEC: "~shared +sqlite_experimental +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
-  extends: .job_on_ruby
-
-# Develop builds against specific tpl version.
-clang_14_0_6_gcc_10_3_1_tpls:
-  variables:
-    SPEC: "~shared +fortran +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
-  extends: .job_on_ruby
+#########################
+## Overridden shared jobs
+#########################
+## We duplicate the shared jobs description and add necessary changes for RAJA.
+## We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
+## the comparison with the original job is easier.
+#
+## Allow failure due to compiler internal error building wrapfumpire.f
+#intel_2022_1_0:
+#  variables:
+#    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
+#  extends: .job_on_ruby
+#  allow_failure: true
+#
+#############
+## Extra jobs
+#############
+## We do not recommend using ${PROJECT_<MACHINE>_VARIANTS} and
+## ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is not reason not to fully
+## describe the spec here.
+#
+#gcc_10_3_1_numa:
+#  variables:
+#    SPEC: "~shared +fortran +numa +tools tests=basic %gcc@=10.3.1"
+#  extends: .job_on_ruby
+#
+#clang_14_0_6_gcc_10_3_1_sqlite_experimental:
+#  variables:
+#    SPEC: "~shared +sqlite_experimental +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
+#  extends: .job_on_ruby
+#
+## Develop builds against specific tpl version.
+#clang_14_0_6_gcc_10_3_1_tpls:
+#  variables:
+#    SPEC: "~shared +fortran +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
+#  extends: .job_on_ruby
 
 gcc_10_3_1_tpls:
   variables:
     SPEC: "~shared +fortran +tools tests=basic %gcc@=10.3.1"
   extends: .job_on_ruby
 
-gcc_10_3_1_ipc_no_mpi:
-  variables:
-    SPEC: "~shared +ipc_shmem tests=basic %gcc@=10.3.1"
-  extends: .job_on_ruby
+#gcc_10_3_1_ipc_no_mpi:
+#  variables:
+#    SPEC: "~shared +ipc_shmem tests=basic %gcc@=10.3.1"
+#  extends: .job_on_ruby

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -12,49 +12,49 @@
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
 
-#########################
-## Overridden shared jobs
-#########################
-## We duplicate the shared jobs description and add necessary changes for RAJA.
-## We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
-## the comparison with the original job is easier.
-#
-## Allow failure due to compiler internal error building wrapfumpire.f
-#intel_2022_1_0:
-#  variables:
-#    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
-#  extends: .job_on_ruby
-#  allow_failure: true
-#
-#############
-## Extra jobs
-#############
-## We do not recommend using ${PROJECT_<MACHINE>_VARIANTS} and
-## ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is not reason not to fully
-## describe the spec here.
-#
-#gcc_10_3_1_numa:
-#  variables:
-#    SPEC: "~shared +fortran +numa +tools tests=basic %gcc@=10.3.1"
-#  extends: .job_on_ruby
-#
-#clang_14_0_6_gcc_10_3_1_sqlite_experimental:
-#  variables:
-#    SPEC: "~shared +sqlite_experimental +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
-#  extends: .job_on_ruby
-#
-## Develop builds against specific tpl version.
-#clang_14_0_6_gcc_10_3_1_tpls:
-#  variables:
-#    SPEC: "~shared +fortran +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
-#  extends: .job_on_ruby
+########################
+# Overridden shared jobs
+########################
+# We duplicate the shared jobs description and add necessary changes for RAJA.
+# We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
+# the comparison with the original job is easier.
+
+# Allow failure due to compiler internal error building wrapfumpire.f
+intel_2022_1_0:
+  variables:
+    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
+  extends: .job_on_ruby
+  allow_failure: true
+
+############
+# Extra jobs
+############
+# We do not recommend using ${PROJECT_<MACHINE>_VARIANTS} and
+# ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is not reason not to fully
+# describe the spec here.
+
+gcc_10_3_1_numa:
+  variables:
+    SPEC: "~shared +fortran +numa +tools tests=basic %gcc@=10.3.1"
+  extends: .job_on_ruby
+
+clang_14_0_6_gcc_10_3_1_sqlite_experimental:
+  variables:
+    SPEC: "~shared +sqlite_experimental +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
+  extends: .job_on_ruby
+
+# Develop builds against specific tpl version.
+clang_14_0_6_gcc_10_3_1_tpls:
+  variables:
+    SPEC: "~shared +fortran +tools tests=basic %clang@=14.0.6.gcc.10.3.1"
+  extends: .job_on_ruby
 
 gcc_10_3_1_tpls:
   variables:
     SPEC: "~shared +fortran +tools tests=basic %gcc@=10.3.1"
   extends: .job_on_ruby
 
-#gcc_10_3_1_ipc_no_mpi:
-#  variables:
-#    SPEC: "~shared +ipc_shmem tests=basic %gcc@=10.3.1"
-#  extends: .job_on_ruby
+gcc_10_3_1_ipc_no_mpi:
+  variables:
+    SPEC: "~shared +ipc_shmem tests=basic %gcc@=10.3.1"
+  extends: .job_on_ruby

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -8,14 +8,7 @@
 # Override reproducer section to define Umpire specific variables.
 .tioga_reproducer_vars:
   script:
-    - |
-      echo -e "# Required variables"
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
-      echo -e "# Allow to set job script for debugging (only this differs from CI)"
-      echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
-      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
+    - !reference [.reproducer_vars, script]
 
 # Overridden shared jobs
 ########################

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -9,7 +9,7 @@
 .tioga_reproducer_vars:
   script:
     - |
-      echo -e "# Mandatory variables"
+      echo -e "# Required variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -9,8 +9,13 @@
 .tioga_reproducer_vars:
   script:
     - |
+      echo -e "# Mandatory variables"
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+      echo -e "# Allow to set job script for debugging (only this differs from CI)"
+      echo -e "export DEBUG_MODE=true"
+      echo -e "# Using the CI build cache is optional (requires a token)"
+      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -14,10 +14,9 @@
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
       echo -e "# Allow to set job script for debugging (only this differs from CI)"
       echo -e "export DEBUG_MODE=true"
-      echo -e "# Using the CI build cache is optional (requires a token)"
-      echo -e "read REGISTRY_TOKEN -p \"To use the Spack build cache, please enter a GitLab token with read access to the container registry, otherwise just press ENTER.\""
+      echo -e "# Using the CI build cache is optional and requires a token. Set it like so:"
+      echo -e "# export REGISTRY_TOKEN=\"<your token here>\""
 
-########################
 # Overridden shared jobs
 ########################
 # We duplicate the shared jobs description and add necessary changes for RAJA.

--- a/.gitlab/subscribed-pipelines.yml
+++ b/.gitlab/subscribed-pipelines.yml
@@ -37,8 +37,7 @@ generate-job-lists:
     RADIUSS_JOBS_PATH: "scripts/radiuss-spack-configs/gitlab/radiuss-jobs"
     LOCAL_JOBS_PATH: ".gitlab/jobs"
   script:
-    #- cat ${RADIUSS_JOBS_PATH}/ruby.yml ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
-    - cat ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
+    - cat ${RADIUSS_JOBS_PATH}/ruby.yml ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/poodle.yml ${LOCAL_JOBS_PATH}/poodle.yml > poodle-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/lassen.yml ${LOCAL_JOBS_PATH}/lassen.yml > lassen-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/corona.yml ${LOCAL_JOBS_PATH}/corona.yml > corona-jobs.yml
@@ -63,65 +62,65 @@ ruby-build-and-test:
   needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
-## POODLE
-#poodle-up-check:
+# POODLE
+poodle-up-check:
+  variables:
+    CI_MACHINE: "poodle"
+  extends: [.machine-check]
+
+poodle-build-and-test:
+  variables:
+    CI_MACHINE: "poodle"
+  needs: [poodle-up-check, generate-job-lists]
+  extends: [.build-and-test]
+
+# CORONA
+corona-up-check:
+  variables:
+    CI_MACHINE: "corona"
+  extends: [.machine-check]
+
+corona-build-and-test:
+  variables:
+    CI_MACHINE: "corona"
+  needs: [corona-up-check, generate-job-lists]
+  extends: [.build-and-test]
+
+# TIOGA
+tioga-up-check:
+  variables:
+    CI_MACHINE: "tioga"
+  extends: [.machine-check]
+
+tioga-build-and-test:
+  variables:
+    CI_MACHINE: "tioga"
+  needs: [tioga-up-check, generate-job-lists]
+  extends: [.build-and-test]
+
+# LASSEN
+lassen-up-check:
+  variables:
+    CI_MACHINE: "lassen"
+  extends: [.machine-check]
+
+lassen-build-and-test:
+  variables:
+    CI_MACHINE: "lassen"
+  needs: [lassen-up-check, generate-job-lists]
+  extends: [.build-and-test]
+
+
+## If testing develop branch, trigger CHAI pipeline with this version of Umpire.
+## TODO: Once Spack allows to clone a specific commit on demand, then point to
+## the exact commit. This will prevent from sticking to a branch (here develop).
+# trigger-chai:
+#  stage: multi-project
+#  rules:
+#    - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"' #run only if ...
 #  variables:
-#    CI_MACHINE: "poodle"
-#  extends: [.machine-check]
-#
-#poodle-build-and-test:
-#  variables:
-#    CI_MACHINE: "poodle"
-#  needs: [poodle-up-check, generate-job-lists]
-#  extends: [.build-and-test]
-#
-## CORONA
-#corona-up-check:
-#  variables:
-#    CI_MACHINE: "corona"
-#  extends: [.machine-check]
-#
-#corona-build-and-test:
-#  variables:
-#    CI_MACHINE: "corona"
-#  needs: [corona-up-check, generate-job-lists]
-#  extends: [.build-and-test]
-#
-## TIOGA
-#tioga-up-check:
-#  variables:
-#    CI_MACHINE: "tioga"
-#  extends: [.machine-check]
-#
-#tioga-build-and-test:
-#  variables:
-#    CI_MACHINE: "tioga"
-#  needs: [tioga-up-check, generate-job-lists]
-#  extends: [.build-and-test]
-#
-## LASSEN
-#lassen-up-check:
-#  variables:
-#    CI_MACHINE: "lassen"
-#  extends: [.machine-check]
-#
-#lassen-build-and-test:
-#  variables:
-#    CI_MACHINE: "lassen"
-#  needs: [lassen-up-check, generate-job-lists]
-#  extends: [.build-and-test]
-#
-#
-### If testing develop branch, trigger CHAI pipeline with this version of Umpire.
-### TODO: Once Spack allows to clone a specific commit on demand, then point to
-### the exact commit. This will prevent from sticking to a branch (here develop).
-## trigger-chai:
-##  stage: multi-project
-##  rules:
-##    - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"' #run only if ...
-##  variables:
-##    UPDATE_UMPIRE: develop
-##  trigger:
-##    project: radiuss/chai
-##    branch: develop
-##    strategy: depend
+#    UPDATE_UMPIRE: develop
+#  trigger:
+#    project: radiuss/chai
+#    branch: develop
+#    strategy: depend

--- a/.gitlab/subscribed-pipelines.yml
+++ b/.gitlab/subscribed-pipelines.yml
@@ -62,65 +62,65 @@ ruby-build-and-test:
   needs: [ruby-up-check, generate-job-lists]
   extends: [.build-and-test]
 
-# POODLE
-poodle-up-check:
-  variables:
-    CI_MACHINE: "poodle"
-  extends: [.machine-check]
-
-poodle-build-and-test:
-  variables:
-    CI_MACHINE: "poodle"
-  needs: [poodle-up-check, generate-job-lists]
-  extends: [.build-and-test]
-
-# CORONA
-corona-up-check:
-  variables:
-    CI_MACHINE: "corona"
-  extends: [.machine-check]
-
-corona-build-and-test:
-  variables:
-    CI_MACHINE: "corona"
-  needs: [corona-up-check, generate-job-lists]
-  extends: [.build-and-test]
-
-# TIOGA
-tioga-up-check:
-  variables:
-    CI_MACHINE: "tioga"
-  extends: [.machine-check]
-
-tioga-build-and-test:
-  variables:
-    CI_MACHINE: "tioga"
-  needs: [tioga-up-check, generate-job-lists]
-  extends: [.build-and-test]
-
-# LASSEN
-lassen-up-check:
-  variables:
-    CI_MACHINE: "lassen"
-  extends: [.machine-check]
-
-lassen-build-and-test:
-  variables:
-    CI_MACHINE: "lassen"
-  needs: [lassen-up-check, generate-job-lists]
-  extends: [.build-and-test]
-
-
-## If testing develop branch, trigger CHAI pipeline with this version of Umpire.
-## TODO: Once Spack allows to clone a specific commit on demand, then point to
-## the exact commit. This will prevent from sticking to a branch (here develop).
-# trigger-chai:
-#  stage: multi-project
-#  rules:
-#    - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"' #run only if ...
+## POODLE
+#poodle-up-check:
 #  variables:
-#    UPDATE_UMPIRE: develop
-#  trigger:
-#    project: radiuss/chai
-#    branch: develop
-#    strategy: depend
+#    CI_MACHINE: "poodle"
+#  extends: [.machine-check]
+#
+#poodle-build-and-test:
+#  variables:
+#    CI_MACHINE: "poodle"
+#  needs: [poodle-up-check, generate-job-lists]
+#  extends: [.build-and-test]
+#
+## CORONA
+#corona-up-check:
+#  variables:
+#    CI_MACHINE: "corona"
+#  extends: [.machine-check]
+#
+#corona-build-and-test:
+#  variables:
+#    CI_MACHINE: "corona"
+#  needs: [corona-up-check, generate-job-lists]
+#  extends: [.build-and-test]
+#
+## TIOGA
+#tioga-up-check:
+#  variables:
+#    CI_MACHINE: "tioga"
+#  extends: [.machine-check]
+#
+#tioga-build-and-test:
+#  variables:
+#    CI_MACHINE: "tioga"
+#  needs: [tioga-up-check, generate-job-lists]
+#  extends: [.build-and-test]
+#
+## LASSEN
+#lassen-up-check:
+#  variables:
+#    CI_MACHINE: "lassen"
+#  extends: [.machine-check]
+#
+#lassen-build-and-test:
+#  variables:
+#    CI_MACHINE: "lassen"
+#  needs: [lassen-up-check, generate-job-lists]
+#  extends: [.build-and-test]
+#
+#
+### If testing develop branch, trigger CHAI pipeline with this version of Umpire.
+### TODO: Once Spack allows to clone a specific commit on demand, then point to
+### the exact commit. This will prevent from sticking to a branch (here develop).
+## trigger-chai:
+##  stage: multi-project
+##  rules:
+##    - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"' #run only if ...
+##  variables:
+##    UPDATE_UMPIRE: develop
+##  trigger:
+##    project: radiuss/chai
+##    branch: develop
+##    strategy: depend

--- a/.gitlab/subscribed-pipelines.yml
+++ b/.gitlab/subscribed-pipelines.yml
@@ -37,7 +37,8 @@ generate-job-lists:
     RADIUSS_JOBS_PATH: "scripts/radiuss-spack-configs/gitlab/radiuss-jobs"
     LOCAL_JOBS_PATH: ".gitlab/jobs"
   script:
-    - cat ${RADIUSS_JOBS_PATH}/ruby.yml ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
+    #- cat ${RADIUSS_JOBS_PATH}/ruby.yml ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
+    - cat ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/poodle.yml ${LOCAL_JOBS_PATH}/poodle.yml > poodle-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/lassen.yml ${LOCAL_JOBS_PATH}/lassen.yml > lassen-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/corona.yml ${LOCAL_JOBS_PATH}/corona.yml > corona-jobs.yml

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "bugfix/invalid-compiler-warning",
+"spack_branch": "develop-2024-05-26",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-05-05",
+"spack_branch": "bugfix/invalid-compiler-warning",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "woptim/buildcache-autopush-ignore-externals",
+"spack_branch": "develop",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-04-28",
+"spack_branch": "woptim/buildcache-autopush-ignore-externals",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-02-18",
+"spack_branch": "develop-2024-04-28",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop",
+"spack_branch": "develop-2024-05-05",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -85,7 +85,7 @@ then
 
     ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only
 
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci ${OCI_REGISTRY}
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY}
 
     ./scripts/uberenv/uberenv.py --spack-debug --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -94,7 +94,7 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~~~~~ Building Dependencies"
+    echo "~~~~~ Building dependencies"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     if [[ -z ${spec} ]]
@@ -141,7 +141,7 @@ then
 
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-  echo "~~~~~ Dependencies Built"
+  echo "~~~~~ Dependencies built"
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 date
 
@@ -220,14 +220,15 @@ then
       ${cmake_options} \
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
-    if ! $cmake_exe --build . -j; then
-      echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      echo "Compilation failed, running make VERBOSE=1"
-      echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      $cmake_exe --build . --verbose -j 1
+    if ! $cmake_exe --build . -j
+    then
+        echo "[Error]: compilation failed, building with verbose output..."
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        echo "~~~~~ Running make VERBOSE=1"
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        $cmake_exe --build . --verbose -j 1
     else
-      # todo this should use cmake --install once we use CMake 3.15+ everywhere
-      make install
+        $cmake_exe --install .
     fi
     date
 
@@ -246,7 +247,7 @@ then
 
     if [[ ! -d ${build_dir} ]]
     then
-        echo "ERROR: Build directory not found : ${build_dir}" && exit 1
+        echo "[Error]: Build directory not found : ${build_dir}" && exit 1
     fi
 
     cd ${build_dir}
@@ -266,7 +267,7 @@ then
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
     then
-        echo "ERROR: No tests were found" && exit 1
+        echo "[Error]: No tests were found" && exit 1
     fi
 
     echo "Copying Testing xml reports for export"
@@ -276,26 +277,26 @@ then
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        echo "ERROR: failure(s) while running CTest" && exit 1
+        echo "[Error]: failure(s) while running CTest" && exit 1
     fi
 
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
-        echo "WARNING: No install test with HIP"
+        echo "[Warning]: not testing install with HIP"
     else
         if [[ ! -d ${install_dir} ]]
         then
-            echo "ERROR: install directory not found : ${install_dir}" && exit 1
+            echo "[Error]: install directory not found : ${install_dir}" && exit 1
         fi
 
         cd ${install_dir}/examples/umpire/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then
-        echo "ERROR: running $cmake_exe for using-with-cmake test" && exit 1
+        echo "[Error]: running $cmake_exe for using-with-cmake test" && exit 1
         fi
 
         if ! make; then
-        echo "ERROR: running make for using-with-cmake test" && exit 1
+        echo "[Error]: running make for using-with-cmake test" && exit 1
         fi
     fi
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -85,7 +85,7 @@ then
 
     ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
 
     ./scripts/uberenv/uberenv.py --spack-debug --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -82,8 +82,8 @@ spack_env_path="${prefix}/spack_env"
 uberenv_cmd="./scripts/uberenv/uberenv.py"
 if [[ ${spack_debug} ]]
 then
-    spack_cmd="${spack_opt} --debug --stacktrace"
-    uberenv_cmd="${uberenv_opt} --spack-debug"
+    spack_cmd="${spack_cmd} --debug --stacktrace"
+    uberenv_cmd="${uberenv_cmd} --spack-debug"
 fi
 
 # Dependencies

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -85,6 +85,8 @@ then
 
     ./scripts/uberenv/uberenv.py --spack-debug --spec="${spec}" ${prefix_opt}
 
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY}
+
     ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 
 fi

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -85,7 +85,7 @@ then
 
     ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY}
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
 
     ./scripts/uberenv/uberenv.py --spack-debug --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,13 +83,13 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only --spec="${spec}" ${prefix_opt}
+    ./scripts/uberenv/uberenv.py --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
+    ${prefix}/spack/bin/spack -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --skip-setup-and-env --spec="${spec}" ${prefix_opt}
+    ./scripts/uberenv/uberenv.py --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
+    ${prefix}/spack/bin/spack -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -253,7 +253,7 @@ then
         echo "[Error]: No tests were found" && exit 1
     fi
 
-    timed_message "Preparing tests xml reports for export"
+    timed_message "Preparing testing xml reports for export"
     tree Testing
     xsltproc -o junit.xml ${project_dir}/blt/tests/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -80,7 +80,7 @@ fi
 spack_cmd="${prefix}/spack/bin/spack"
 spack_env_path="${prefix}/spack_env"
 uberenv_cmd="./scripts/uberenv/uberenv.py"
-if [[ ${spack_debug} ]]
+if [[ ${spack_debug} == true ]]
 then
     spack_cmd="${spack_cmd} --debug --stacktrace"
     uberenv_cmd="${uberenv_cmd} --spack-debug"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,9 +83,9 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
+    ./scripts/uberenv/uberenv.py --spack-debug --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,7 +83,7 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only
+    ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
     ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY}
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,10 +83,6 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --setup-only ${prefix_opt}
-
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY}
-
     ./scripts/uberenv/uberenv.py --spack-debug --spec="${spec}" ${prefix_opt}
 
     ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -203,7 +203,6 @@ then
         cmake_options="-DBLT_MPI_COMMAND_APPEND:STRING=--overlap"
     fi
 
-    date
     if [[ "${truehostname}" == "corona" || "${truehostname}" == "tioga" ]]
     then
         module unload rocm

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,7 +83,7 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --setup-only
+    ./scripts/uberenv/uberenv.py --spack-debug --setup-only ${prefix_opt}
 
     ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY}
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -29,9 +29,8 @@ use_dev_shm=${USE_DEV_SHM:-true}
 spack_debug=${SPACK_DEBUG:-false}
 debug_mode=${DEBUG_MODE:-false}
 
-if [[ ${debug_mode} ]]
+if [[ ${debug_mode} == true ]]
 then
-    echo "Debug mode: spack debug and deactivated shared memory, do not push to buildcache"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "~~~~~ Debug mode:"
     echo "~~~~~ - Spack debug mode."
@@ -132,7 +131,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
-    if [[ -n ${ci_registry_token} && ! ${debug_mode} ]]
+    if [[ -n ${ci_registry_token} && ${debug_mode} == false ]]
     then
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         echo "~~~~~ Push dependencies to Build Cache "

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -85,7 +85,7 @@ then
 
     ./scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
 
-    ${prefix_opt}/spack/bin/spack -D ${prefix_opt}/spack_env buildcache push --only dependencies gitlab_ci
+    ${prefix}/spack/bin/spack -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,7 +83,11 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --spec="${spec}" ${prefix_opt}
+    ./scripts/uberenv/uberenv.py --spack-debug --setup-and-env-only
+
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci ${OCI_REGISTRY}
+
+    ./scripts/uberenv/uberenv.py --spack-debug --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
     ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -222,7 +222,7 @@ then
       ${project_dir}
     if ! $cmake_exe --build . -j
     then
-        echo "[Error]: compilation failed, building with verbose output..."
+        echo "[Error]: Compilation failed, building with verbose output..."
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         echo "~~~~~ Running make VERBOSE=1"
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -277,26 +277,26 @@ then
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        echo "[Error]: failure(s) while running CTest" && exit 1
+        echo "[Error]: Failure(s) while running CTest" && exit 1
     fi
 
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
-        echo "[Warning]: not testing install with HIP"
+        echo "[Warning]: Not testing install with HIP"
     else
         if [[ ! -d ${install_dir} ]]
         then
-            echo "[Error]: install directory not found : ${install_dir}" && exit 1
+            echo "[Error]: Install directory not found : ${install_dir}" && exit 1
         fi
 
         cd ${install_dir}/examples/umpire/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then
-        echo "[Error]: running $cmake_exe for using-with-cmake test" && exit 1
+            echo "[Error]: Running $cmake_exe for using-with-cmake test" && exit 1
         fi
 
         if ! make; then
-        echo "[Error]: running make for using-with-cmake test" && exit 1
+            echo "[Error]: Running make for using-with-cmake test" && exit 1
         fi
     fi
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -85,6 +85,8 @@ then
 
     ./scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
 
+    ${prefix_opt}/spack/bin/spack -D ${prefix_opt}/spack_env buildcache push --only dependencies gitlab_ci
+
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   echo "~~~~~ Dependencies Built"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -43,7 +43,7 @@ fi
 
 # REGISTRY_TOKEN allows you to provide your own personal access token to the CI
 # registry. Be sure to set the token with at least read access to the registry.
-registry_token=${REGISTRY_TOKEN:""}
+registry_token=${REGISTRY_TOKEN:-""}
 ci_registry_user=${CI_REGISTRY_USER:-"${USER}"}
 ci_registry_image=${CI_REGISTRY_IMAGE:-"czregistry.llnl.gov:5050/radiuss/umpire"}
 ci_registry_token=${CI_JOB_TOKEN:-"${registry_token}"}

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,9 +83,11 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spack-debug --spec="${spec}" ${prefix_opt}
+    ./scripts/uberenv/uberenv.py --spack-debug --setup-only
 
-    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY}
+    ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${SPACK_TOKEN} gitlab_ci oci://${CI_REGISTRY}
+
+    ./scripts/uberenv/uberenv.py --spack-debug --spec="${spec}" ${prefix_opt}
 
     ${prefix}/spack/bin/spack --debug --stacktrace -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -26,6 +26,28 @@ spec=${SPEC:-""}
 module_list=${MODULE_LIST:-""}
 job_unique_id=${CI_JOB_ID:-""}
 use_dev_shm=${USE_DEV_SHM:-true}
+spack_debug=${SPACK_DEBUG:-false}
+debug_mode=${DEBUG_MODE:-false}
+
+if [[ ${debug_mode} ]]
+then
+    echo "Debug mode: spack debug and deactivated shared memory, do not push to buildcache"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ Debug mode:"
+    echo "~~~~~ - Spack debug mode."
+    echo "~~~~~ - Deactivated shared memory."
+    echo "~~~~~ - Do not push to buildcache."
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    use_dev_shm=false
+    spack_debug=true
+fi
+
+# REGISTRY_TOKEN allows you to provide your own personal access token to the CI
+# registry. Be sure to set the token with at least read access to the registry.
+registry_token=${REGISTRY_TOKEN:""}
+ci_registry_user=${CI_REGISTRY_USER:-"${USER}"}
+ci_registry_image=${CI_REGISTRY_IMAGE:-"czregistry.llnl.gov:5050/radiuss/umpire"}
+ci_registry_token=${CI_JOB_TOKEN:-"${registry_token}"}
 
 if [[ -n ${module_list} ]]
 then
@@ -56,6 +78,15 @@ else
     mkdir -p ${prefix}
 fi
 
+spack_cmd="${prefix}/spack/bin/spack"
+spack_env_path="${prefix}/spack_env"
+uberenv_cmd="./scripts/uberenv/uberenv.py"
+if [[ ${spack_debug} ]]
+then
+    spack_cmd="${spack_opt} --debug --stacktrace"
+    uberenv_cmd="${uberenv_opt} --spack-debug"
+fi
+
 # Dependencies
 date
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -83,13 +114,31 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --setup-and-env-only --spec="${spec}" ${prefix_opt}
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ Spack setup and environment "
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
+    if [[ -n ${ci_registry_token} ]]
+    then
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        echo "~~~~~ GitLab registry as Spack Build Cache "
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username ${ci_registry_user} --oci-password ${ci_registry_token} gitlab_ci oci://${ci_registry_image}
+    fi
 
-    ./scripts/uberenv/uberenv.py --skip-setup-and-env --spec="${spec}" ${prefix_opt}
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ Spack build of dependencies "
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
-    ${prefix}/spack/bin/spack -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
+    if [[ -n ${ci_registry_token} && ! ${debug_mode} ]]
+    then
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        echo "~~~~~ Push dependencies to Build Cache "
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
+    fi
 
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"


### PR DESCRIPTION
In this PR, we set the GitLab CI to push Spack built binaries (Umpire dependencies) to the builtin OCI container registry.

This required an update of Spack, RADIUSS Spack Configs and Uberenv.
