### PR TITLE
Update toolchains on tioga, lassen, ruby and poodle

### DIFF
--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -30,8 +30,8 @@
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still disable tools from being built.
 ###
-rocmcc_5_7_0_hip_openmp_device_alloc:
+rocmcc_5_7_1_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx906 %rocmcc@=5.7.0 ^hip@5.7.0"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx906 %rocmcc@=5.7.1 ^hip@5.7.1"
   extends: .job_on_corona
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -25,6 +25,13 @@ xl_2022_08_19_gcc_8_3_1_cuda_11_2_0:
     LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
   extends: .job_on_lassen
 
+xl_2023_06_28_gcc_11_2_1_cuda_11_8_0:
+  variables:
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.14.cuda.11.8.0.gcc.8.3.1 ^cuda@11.8.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    MODULE_LIST: "cuda/11.8.0"
+    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
+  extends: .job_on_lassen
+  allow_failure: true
 
 ############
 # Extra jobs
@@ -96,15 +103,33 @@ gcc_8_3_1_tpls:
     SPEC: "~shared +fortran +tools tests=basic %gcc@=8.3.1"
   extends: .job_on_lassen
 
+gcc_11_2_1_tpls:
+  variables:
+    SPEC: "~shared +fortran +tools tests=basic %gcc@=11.2.1"
+  extends: .job_on_lassen
+
 ibm_clang_14_0_5_gcc_8_3_1_cuda_11_7_0_tpls:
   variables:
     SPEC: "~shared +fortran +cuda +tools tests=basic %clang@=14.0.5.ibm.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers"
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 
+ibm_clang_16_0_6_gcc_11_2_1_cuda_11_8_tpls:
+  variables:
+    SPEC: "~shared +fortran +cuda +tools tests=basic %clang@=16.0.6.cuda.11.8.0.ibm.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers"
+    MODULE_LIST: "cuda/11.8.0"
+  extends: .job_on_lassen
+
 xl_2022_08_19_gcc_8_3_1_cuda_11_2_tpls:
   variables:
     SPEC: "~shared +fortran +cuda +tools tests=basic %xl@=16.1.1.12.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers"
     MODULE_LIST: "cuda/11.7.0"
+    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
+  extends: .job_on_lassen
+
+xl_2023_06_28_gcc_11_2_1_cuda_11_8_tpls:
+  variables:
+    SPEC: "~shared +fortran +cuda +tools tests=basic %xl@=16.1.1.14.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers"
+    MODULE_LIST: "cuda/11.8.0"
     LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
   extends: .job_on_lassen

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -27,11 +27,10 @@ xl_2022_08_19_gcc_8_3_1_cuda_11_2_0:
 
 xl_2023_06_28_gcc_11_2_1_cuda_11_8_0:
   variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.14.cuda.11.8.0.gcc.8.3.1 ^cuda@11.8.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.14.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
     MODULE_LIST: "cuda/11.8.0"
     LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
   extends: .job_on_lassen
-  allow_failure: true
 
 ############
 # Extra jobs
@@ -116,7 +115,7 @@ ibm_clang_14_0_5_gcc_8_3_1_cuda_11_7_0_tpls:
 
 ibm_clang_16_0_6_gcc_11_2_1_cuda_11_8_tpls:
   variables:
-    SPEC: "~shared +fortran +cuda +tools tests=basic %clang@=16.0.6.cuda.11.8.0.ibm.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers"
+    SPEC: "~shared +fortran +cuda +tools tests=basic %clang@=16.0.6.ibm.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers"
     MODULE_LIST: "cuda/11.8.0"
   extends: .job_on_lassen
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -17,20 +17,7 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
-# Overriden to increase allocation
-xl_2022_08_19_gcc_8_3_1_cuda_11_2_0:
-  variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.12.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
-    MODULE_LIST: "cuda/11.2.0"
-    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
-  extends: .job_on_lassen
-
-xl_2023_06_28_gcc_11_2_1_cuda_11_8_0:
-  variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.14.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
-    MODULE_LIST: "cuda/11.8.0"
-    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
-  extends: .job_on_lassen
+# No overridden jobs so far
 
 ############
 # Extra jobs
@@ -78,12 +65,6 @@ gcc_8_3_1_dev_benchmarks:
     SPEC: "~shared +dev_benchmarks +tools build_type=Release %gcc@=8.3.1"
   extends: .job_on_lassen
 
-xl_2022_08_19_default_omp_target:
-  variables:
-    SPEC: "~shared +tools +openmp +openmp_target tests=basic %xl@=16.1.1.12"
-  allow_failure: true
-  extends: .job_on_lassen
-
 gcc_8_3_1_numa:
   variables:
     SPEC: "~shared +fortran +numa +tools tests=basic %gcc@=8.3.1"
@@ -117,18 +98,4 @@ ibm_clang_16_0_6_gcc_11_2_1_cuda_11_8_tpls:
   variables:
     SPEC: "~shared +fortran +cuda +tools tests=basic %clang@=16.0.6.ibm.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers"
     MODULE_LIST: "cuda/11.8.0"
-  extends: .job_on_lassen
-
-xl_2022_08_19_gcc_8_3_1_cuda_11_2_tpls:
-  variables:
-    SPEC: "~shared +fortran +cuda +tools tests=basic %xl@=16.1.1.12.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers"
-    MODULE_LIST: "cuda/11.7.0"
-    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
-  extends: .job_on_lassen
-
-xl_2023_06_28_gcc_11_2_1_cuda_11_8_tpls:
-  variables:
-    SPEC: "~shared +fortran +cuda +tools tests=basic %xl@=16.1.1.14.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers"
-    MODULE_LIST: "cuda/11.8.0"
-    LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
   extends: .job_on_lassen

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -17,13 +17,6 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
-# Allow failure due to compiler internal error building wrapfumpire.f
-intel_2022_1_0:
-  variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
-  extends: .job_on_poodle
-  allow_failure: true
-
 ############
 # Extra jobs
 ############

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -17,13 +17,6 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
-# Allow failure due to compiler internal error building wrapfumpire.f
-intel_2022_1_0:
-  variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
-  extends: .job_on_ruby
-  allow_failure: true
-
 ############
 # Extra jobs
 ############

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -33,8 +33,8 @@ cce_18_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_6_1_2_hip_openmp_device_alloc:
+rocmcc_6_2_0_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %rocmcc@=6.1.2 ^hip@6.1.2"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %rocmcc@=6.2.0 ^hip@6.2.0"
   extends: .job_on_tioga
 

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -17,9 +17,9 @@
 # the comparison with the original job is easier.
 
 # We override the cce job because we can’t use +device-alloc with it
-cce_16_0_1:
+cce_18_0_0:
   variables:
-    SPEC: "~shared +fortran tests=basic %cce@=16.0.1"
+    SPEC: "~shared +fortran tests=basic %cce@=18.0.0"
   extends: .job_on_tioga
 
 ############
@@ -33,8 +33,8 @@ cce_16_0_1:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_6_1_1_hip_openmp_device_alloc:
+rocmcc_6_1_2_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %rocmcc@=6.1.1 ^hip@6.1.1"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %rocmcc@=6.1.2 ^hip@6.1.2"
   extends: .job_on_tioga
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -57,9 +57,7 @@ fi
 
 if [[ -n ${module_list} ]]
 then
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~~~~~ Modules to load: ${module_list}"
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    timed_message "Modules to load: ${module_list}"
     module load ${module_list}
 fi
 
@@ -79,7 +77,7 @@ then
     prefix="${prefix}-${job_unique_id}"
 else
     # We set the prefix in the parent directory so that spack dependencies are not installed inside the source tree.
-    prefix="$(pwd)/../spack-and-build-root"
+    prefix="${project_dir}/../spack-and-build-root"
 fi
 
 echo "Creating directory ${prefix}"


### PR DESCRIPTION
- [x] Remove Intel 19
- [x] Update to Intel 2023
- [x] ~~Update corona to ROCm 6.0.2~~ -> same error as with tioga, need ROCm 6.1.x , reverted to ROCm 5.7.1
- [x] Update tioga to ROCm 6.1.2
- [x] Remove CUDA 10 job (blueos system default is now 11.2.0)

## Errors

- xl 2023.06.28 + gcc 11.2.1 + cuda 11.8.0
```
[ 36%] Built target blt_fruit_smoke
In file included from /dev/shm/lassen408-2045932/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeho/xl-16.1.1.14.cuda.11.8.0.gcc.11.2.1/blt-0.6.2-5xez4qkndlusy5milwuuyfntex2wagep/thirdparty_builtin/googletest/googletest/src/gtest-all.cc:38:
In file included from /dev/shm/lassen408-2045932/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeho/xl-16.1.1.14.cuda.11.8.0.gcc.11.2.1/blt-0.6.2-5xez4qkndlusy5milwuuyfntex2wagep/thirdparty_builtin/googletest/googletest/include/gtest/gtest.h:54:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/iomanip:40:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/bits/ios_base.h:41:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/bits/locale_classes.h:40:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/string:41:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/bits/allocator.h:46:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/ppc64le-redhat-linux/bits/c++allocator.h:33:
In file included from /usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/ext/new_allocator.h:33:
/usr/tce/packages/gcc/gcc-11.2.1/rh/usr/bin/../lib/gcc/ppc64le-redhat-linux/11/../../../../include/c++/11/new:141:42: error: 1540-2990 The attribute " __attribute__((alloc_size(1, 0)))" is not supported.  The attribute is ignored.
  __attribute__((__externally_visible__, __alloc_size__ (1), __malloc__));
                                         ^
```