### PR TITLE
Fix high water mark coalescing in memory pools

### DIFF
--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -83,6 +83,16 @@ std::size_t DynamicPoolList::getActualHighwaterMark() const noexcept
   return dpa.getActualHighwaterMark();
 }
 
+std::size_t DynamicPoolList::getAlignedSize() const noexcept
+{
+  return dpa.getAlignedSize();
+}
+
+std::size_t DynamicPoolList::getAlignedHighwaterMark() const noexcept
+{
+  return dpa.getAlignedHighwaterMark();
+}
+
 std::size_t DynamicPoolList::getReleasableSize() const noexcept
 {
   std::size_t SparseBlockSize = dpa.getReleasableSize();

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -186,7 +186,7 @@ PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::percent_releasable_hwm(i
     return [=](const strategy::DynamicPoolList& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() >= threshold ? pool.getActualHighwaterMark() : 0;
+      return pool.getReleasableSize() > threshold ? pool.getActualHighwaterMark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -143,7 +143,7 @@ PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable(std::s
 PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable_hwm(std::size_t nblocks)
 {
   return [=](const strategy::DynamicPoolList& pool) {
-    return pool.getReleasableBlocks() >= nblocks ? pool.getHighWatermark() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getActualHighwaterMark() : 0;
   };
 }
 
@@ -178,14 +178,15 @@ PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::percent_releasable_hwm(i
   if (percentage == 0) {
     return [=](const DynamicPoolList& UMPIRE_UNUSED_ARG(pool)) { return 0; };
   } else if (percentage == 100) {
-    return
-        [=](const strategy::DynamicPoolList& pool) { return pool.getCurrentSize() == 0 ? pool.getHighWatermark() : 0; };
+    return [=](const strategy::DynamicPoolList& pool) {
+      return pool.getCurrentSize() == 0 ? pool.getActualHighwaterMark() : 0;
+    };
   } else {
     float f = (float)((float)percentage / (float)100.0);
     return [=](const strategy::DynamicPoolList& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() >= threshold ? pool.getHighWatermark() : 0;
+      return pool.getReleasableSize() >= threshold ? pool.getActualHighwaterMark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -64,13 +64,6 @@ std::size_t DynamicPoolList::getTotalBlocks() const noexcept
   return dpa.getTotalBlocks();
 }
 
-std::size_t DynamicPoolList::getCurrentSize() const noexcept
-{
-  std::size_t CurrentSize = dpa.getCurrentSize();
-  UMPIRE_LOG(Debug, "() returning " << CurrentSize);
-  return CurrentSize;
-}
-
 std::size_t DynamicPoolList::getActualSize() const noexcept
 {
   std::size_t ActualSize = dpa.getActualSize();

--- a/src/umpire/strategy/DynamicPoolList.cpp
+++ b/src/umpire/strategy/DynamicPoolList.cpp
@@ -153,7 +153,7 @@ PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable(std::s
 PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::blocks_releasable_hwm(std::size_t nblocks)
 {
   return [=](const strategy::DynamicPoolList& pool) {
-    return pool.getReleasableBlocks() >= nblocks ? pool.getActualHighwaterMark() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getAlignedHighwaterMark() : 0;
   };
 }
 
@@ -189,14 +189,14 @@ PoolCoalesceHeuristic<DynamicPoolList> DynamicPoolList::percent_releasable_hwm(i
     return [=](const DynamicPoolList& UMPIRE_UNUSED_ARG(pool)) { return 0; };
   } else if (percentage == 100) {
     return [=](const strategy::DynamicPoolList& pool) {
-      return pool.getCurrentSize() == 0 ? pool.getActualHighwaterMark() : 0;
+      return pool.getCurrentSize() == 0 ? pool.getAlignedHighwaterMark() : 0;
     };
   } else {
     float f = (float)((float)percentage / (float)100.0);
     return [=](const strategy::DynamicPoolList& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() > threshold ? pool.getActualHighwaterMark() : 0;
+      return pool.getReleasableSize() >= threshold ? pool.getAlignedHighwaterMark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/DynamicPoolList.hpp
+++ b/src/umpire/strategy/DynamicPoolList.hpp
@@ -78,6 +78,8 @@ class DynamicPoolList : public AllocationStrategy {
   std::size_t getActualSize() const noexcept override;
   std::size_t getCurrentSize() const noexcept override;
   std::size_t getActualHighwaterMark() const noexcept;
+  std::size_t getAlignedSize() const noexcept;
+  std::size_t getAlignedHighwaterMark() const noexcept;
 
   Platform getPlatform() noexcept override;
 

--- a/src/umpire/strategy/DynamicPoolList.hpp
+++ b/src/umpire/strategy/DynamicPoolList.hpp
@@ -76,7 +76,6 @@ class DynamicPoolList : public AllocationStrategy {
   std::size_t getTotalBlocks() const noexcept;
 
   std::size_t getActualSize() const noexcept override;
-  std::size_t getCurrentSize() const noexcept override;
   std::size_t getActualHighwaterMark() const noexcept;
   std::size_t getAlignedSize() const noexcept;
   std::size_t getAlignedHighwaterMark() const noexcept;

--- a/src/umpire/strategy/DynamicSizePool.hpp
+++ b/src/umpire/strategy/DynamicSizePool.hpp
@@ -372,13 +372,6 @@ class DynamicSizePool : private umpire::strategy::mixins::AlignedAllocation {
     return m_actual_bytes;
   }
 
-  // TODO: Keep old behaviour with m_aligned_bytes or remove and use definition
-  // from AllocationStrategy which returns m_current_size?
-  std::size_t getCurrentSize() const
-  {
-    return m_aligned_bytes;
-  }
-
   std::size_t getActualHighwaterMark() const noexcept
   {
     return m_actual_highwatermark;

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -361,7 +361,7 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable(std::size_t nblock
 PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable_hwm(std::size_t nblocks)
 {
   return [=](const strategy::QuickPool& pool) {
-    return pool.getReleasableBlocks() >= nblocks ? pool.getActualHighwaterMark() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getAlignedHighwaterMark() : 0;
   };
 }
 
@@ -397,14 +397,14 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::percent_releasable_hwm(int percentag
     return [=](const QuickPool& UMPIRE_UNUSED_ARG(pool)) { return 0; };
   } else if (percentage == 100) {
     return [=](const strategy::QuickPool& pool) {
-      return pool.getActualSize() == pool.getReleasableSize() ? pool.getActualHighwaterMark() : 0;
+      return pool.getActualSize() == pool.getReleasableSize() ? pool.getAlignedHighwaterMark() : 0;
     };
   } else {
     float f = (float)((float)percentage / (float)100.0);
     return [=](const strategy::QuickPool& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() > threshold ? pool.getActualHighwaterMark() : 0;
+      return pool.getReleasableSize() >= threshold ? pool.getAlignedHighwaterMark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -265,13 +265,6 @@ std::size_t QuickPool::getActualSize() const noexcept
   return m_actual_bytes;
 }
 
-// TODO: Keep old behaviour with m_aligned_bytes or remove and use definition
-// from AllocationStrategy which returns m_current_size?
-std::size_t QuickPool::getCurrentSize() const noexcept
-{
-  return m_aligned_bytes;
-}
-
 std::size_t QuickPool::getReleasableSize() const noexcept
 {
   return m_releasable_bytes;

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -346,7 +346,7 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable(std::size_t nblock
 PoolCoalesceHeuristic<QuickPool> QuickPool::blocks_releasable_hwm(std::size_t nblocks)
 {
   return [=](const strategy::QuickPool& pool) {
-    return pool.getReleasableBlocks() >= nblocks ? pool.getHighWatermark() : 0;
+    return pool.getReleasableBlocks() >= nblocks ? pool.getActualHighwaterMark() : 0;
   };
 }
 
@@ -382,14 +382,14 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::percent_releasable_hwm(int percentag
     return [=](const QuickPool& UMPIRE_UNUSED_ARG(pool)) { return 0; };
   } else if (percentage == 100) {
     return [=](const strategy::QuickPool& pool) {
-      return pool.getActualSize() == pool.getReleasableSize() ? pool.getHighWatermark() : 0;
+      return pool.getActualSize() == pool.getReleasableSize() ? pool.getActualHighwaterMark() : 0;
     };
   } else {
     float f = (float)((float)percentage / (float)100.0);
     return [=](const strategy::QuickPool& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() >= threshold ? pool.getHighWatermark() : 0;
+      return pool.getReleasableSize() >= threshold ? pool.getActualHighwaterMark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/QuickPool.cpp
+++ b/src/umpire/strategy/QuickPool.cpp
@@ -389,7 +389,7 @@ PoolCoalesceHeuristic<QuickPool> QuickPool::percent_releasable_hwm(int percentag
     return [=](const strategy::QuickPool& pool) {
       // Calculate threshold in bytes from the percentage
       const std::size_t threshold = static_cast<std::size_t>(f * pool.getActualSize());
-      return pool.getReleasableSize() >= threshold ? pool.getActualHighwaterMark() : 0;
+      return pool.getReleasableSize() > threshold ? pool.getActualHighwaterMark() : 0;
     };
   }
 }

--- a/src/umpire/strategy/QuickPool.hpp
+++ b/src/umpire/strategy/QuickPool.hpp
@@ -73,6 +73,8 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
   std::size_t getCurrentSize() const noexcept override;
   std::size_t getReleasableSize() const noexcept;
   std::size_t getActualHighwaterMark() const noexcept;
+  std::size_t getAlignedSize() const noexcept;
+  std::size_t getAlignedHighwaterMark() const noexcept;
 
   Platform getPlatform() noexcept override;
 
@@ -163,8 +165,9 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
 
   std::size_t m_total_blocks{0};
   std::size_t m_releasable_blocks{0};
+  std::size_t m_aligned_bytes{0};
+  std::size_t m_aligned_highwatermark{0};
   std::size_t m_actual_bytes{0};
-  std::size_t m_current_bytes{0};
   std::size_t m_releasable_bytes{0};
   std::size_t m_actual_highwatermark{0};
   bool m_is_destructing{false};

--- a/src/umpire/strategy/QuickPool.hpp
+++ b/src/umpire/strategy/QuickPool.hpp
@@ -70,7 +70,6 @@ class QuickPool : public AllocationStrategy, private mixins::AlignedAllocation {
   void release() override;
 
   std::size_t getActualSize() const noexcept override;
-  std::size_t getCurrentSize() const noexcept override;
   std::size_t getReleasableSize() const noexcept;
   std::size_t getActualHighwaterMark() const noexcept;
   std::size_t getAlignedSize() const noexcept;

--- a/tests/integration/primary_pool_tests.cpp
+++ b/tests/integration/primary_pool_tests.cpp
@@ -254,8 +254,7 @@ TYPED_TEST(PrimaryPoolTest, Works)
     this->m_allocator->deallocate(ptr_two);
   });
 
-  // NOTE: Size is 64 since it's rounded up
-  ASSERT_EQ(this->m_allocator->getCurrentSize(), 64);
+  ASSERT_EQ(this->m_allocator->getCurrentSize(), 62);
   EXPECT_NO_THROW(this->m_allocator->release());
 
   ASSERT_LE(this->m_allocator->getActualSize(), this->m_initial_pool_size);

--- a/tests/integration/primary_pool_tests.cpp
+++ b/tests/integration/primary_pool_tests.cpp
@@ -358,7 +358,7 @@ TYPED_TEST(PrimaryPoolTest, coalesce)
   ASSERT_EQ(pool->getBlocksInPool(), 1);
 
   ASSERT_EQ(this->m_allocator->getCurrentSize(), 0);
-  ASSERT_LT(pool->getActualSize(), old_actual_size);
+  ASSERT_LE(pool->getActualSize(), old_actual_size);
   ASSERT_EQ(this->m_allocator->getHighWatermark(), 1 + this->m_initial_pool_size);
 }
 
@@ -579,7 +579,7 @@ TYPED_TEST(PrimaryPoolTest, heuristic_75_percent_hwm)
   ASSERT_NO_THROW({ alloc.deallocate(a[2]); }); // 50% releasable
   ASSERT_EQ(pool->getBlocksInPool(), 4);
   ASSERT_NO_THROW({ alloc.deallocate(a[1]); }); // 75% releasable
-  ASSERT_EQ(pool->getBlocksInPool(), 2);        // Collapse happened
+  ASSERT_EQ(pool->getBlocksInPool(), 4);
   ASSERT_NO_THROW({ alloc.deallocate(a[0]); }); // 100% releasable
   ASSERT_EQ(pool->getBlocksInPool(), 1);        // Collapse happened
 }

--- a/tests/integration/primary_pool_tests.cpp
+++ b/tests/integration/primary_pool_tests.cpp
@@ -358,7 +358,7 @@ TYPED_TEST(PrimaryPoolTest, coalesce)
   ASSERT_EQ(pool->getBlocksInPool(), 1);
 
   ASSERT_EQ(this->m_allocator->getCurrentSize(), 0);
-  ASSERT_LE(pool->getActualSize(), old_actual_size);
+  ASSERT_LT(pool->getActualSize(), old_actual_size);
   ASSERT_EQ(this->m_allocator->getHighWatermark(), 1 + this->m_initial_pool_size);
 }
 
@@ -579,7 +579,7 @@ TYPED_TEST(PrimaryPoolTest, heuristic_75_percent_hwm)
   ASSERT_NO_THROW({ alloc.deallocate(a[2]); }); // 50% releasable
   ASSERT_EQ(pool->getBlocksInPool(), 4);
   ASSERT_NO_THROW({ alloc.deallocate(a[1]); }); // 75% releasable
-  ASSERT_EQ(pool->getBlocksInPool(), 4);
+  ASSERT_EQ(pool->getBlocksInPool(), 2);        // Collapse happened
   ASSERT_NO_THROW({ alloc.deallocate(a[0]); }); // 100% releasable
   ASSERT_EQ(pool->getBlocksInPool(), 1);        // Collapse happened
 }

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -116,7 +116,7 @@ TYPED_TEST(PoolHeuristicsTest, PercentReleasableHWM)
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
 
-  ASSERT_EQ(a.second->getActualSize(), a.second->getActualHighwaterMark());
+  ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
   ASSERT_EQ(a.second->getTotalBlocks(), 2);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
 
@@ -183,7 +183,7 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
 
-  ASSERT_EQ(a.second->getActualSize(), a.second->getActualHighwaterMark());
+  ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
   ASSERT_EQ(a.second->getTotalBlocks(), 4);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
 

--- a/tests/unit/strategy/pool_heuristics_tests.cpp
+++ b/tests/unit/strategy/pool_heuristics_tests.cpp
@@ -116,7 +116,7 @@ TYPED_TEST(PoolHeuristicsTest, PercentReleasableHWM)
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
 
-  ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
+  ASSERT_EQ(a.second->getActualSize(), a.second->getActualHighwaterMark());
   ASSERT_EQ(a.second->getTotalBlocks(), 2);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
 
@@ -183,7 +183,7 @@ TYPED_TEST(PoolHeuristicsTest, BlocksReleasableHWM)
     ASSERT_NO_THROW(a.first.deallocate(ptrs[i]););
   }
 
-  ASSERT_EQ(a.second->getActualSize(), a.second->getHighWatermark());
+  ASSERT_EQ(a.second->getActualSize(), a.second->getActualHighwaterMark());
   ASSERT_EQ(a.second->getTotalBlocks(), 4);
   ASSERT_EQ(a.second->getReleasableBlocks(), 1);
 


### PR DESCRIPTION
Fixes #906.

This adds two methods, `getAlignedSize` and `getAlignedHighwaterMark` to `QuickPool` and `DynamicPoolList`. The `m_current_bytes`/`m_current_size` members have been renamed `m_aligned_bytes`.

`getAlignedHighwaterMark` is now used instead of `getHighWatermark` in the `hwm` coalescing heuristics.