### PR TITLE
Update README and fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Umpire mailing list is hosted on Google Groups, and is a great place to ask 
 [Umpire Users Google Group](https://groups.google.com/forum/#!forum/umpire-users)
 
 You can also join our RADIUSS slack group and find the "umpire-users" channel to ask questions.
-To be sent an invite to the channel, email us at [umpire-dev@llnl.gov](mailto:umpire-dev@llnl.gov)
+To be sent an invite to the slack group, email us at [umpire-dev@llnl.gov](mailto:umpire-dev@llnl.gov)
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # <img src="https://cdn.rawgit.com/LLNL/Umpire/develop/share/umpire/logo/umpire-logo.png" width="128" valign="middle" alt="Umpire"/>  Umpire v2024.07.0
 
-[![Azure Pipelines Build Status](https://dev.azure.com/davidbeckingsale/Umpire/_apis/build/status/LLNL.Umpire?branchName=develop)](https://dev.azure.com/davidbeckingsale/Umpire/_build/latest?definitionId=1&branchName=develop)
 [![Documentation Status](https://readthedocs.org/projects/umpire/badge/?version=develop)](https://umpire.readthedocs.io/en/develop/?badge=develop)
 
 Umpire is a resource management library that allows the discovery, provision,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img src="https://cdn.rawgit.com/LLNL/Umpire/develop/share/umpire/logo/umpire-logo.png" width="128" valign="middle" alt="Umpire"/>  Umpire v2024.07.0
 
 [![Documentation Status](https://readthedocs.org/projects/umpire/badge/?version=develop)](https://umpire.readthedocs.io/en/develop/?badge=develop)
+[![Github Actions Build Status](https://github.com/LLNL/Umpire/actions/workflows/build.yml/badge.svg)](https://github.com/LLNL/Umpire/actions/workflows/build.yml)
 
 Umpire is a resource management library that allows the discovery, provision,
 and management of memory on machines with multiple memory devices like NUMA and GPUs.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # <img src="https://cdn.rawgit.com/LLNL/Umpire/develop/share/umpire/logo/umpire-logo.png" width="128" valign="middle" alt="Umpire"/>  Umpire v2024.07.0
 
-[![Travis Build Status](https://travis-ci.com/LLNL/Umpire.svg?branch=develop)](https://travis-ci.com/LLNL/Umpire)
 [![Azure Pipelines Build Status](https://dev.azure.com/davidbeckingsale/Umpire/_apis/build/status/LLNL.Umpire?branchName=develop)](https://dev.azure.com/davidbeckingsale/Umpire/_build/latest?definitionId=1&branchName=develop)
 [![Documentation Status](https://readthedocs.org/projects/umpire/badge/?version=develop)](https://umpire.readthedocs.io/en/develop/?badge=develop)
-[![codecov](https://codecov.io/gh/LLNL/Umpire/branch/develop/graph/badge.svg)](https://codecov.io/gh/LLNL/Umpire) [![Join the chat at https://gitter.im/LLNL/Umpire](https://badges.gitter.im/LLNL/Umpire.svg)](https://gitter.im/LLNL/Umpire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Umpire is a resource management library that allows the discovery, provision,
 and management of memory on machines with multiple memory devices like NUMA and GPUs.
@@ -38,10 +36,15 @@ If you have build problems, we have comprehensive [build system documentation](h
 
 Umpire is an open-source project, and we welcome contributions from the community.
 
-## Mailing List
+You can also start an issue for a [bug report](https://github.com/LLNL/Umpire/issues/new?assignees=&labels=&projects=&template=bug_report.md) or [feature request](https://github.com/LLNL/Umpire/issues/new?assignees=&labels=&projects=&template=feature_request.md).
+
+## Mailing List and Slack
 
 The Umpire mailing list is hosted on Google Groups, and is a great place to ask questions:
-- [Umpire Users Google Group](https://groups.google.com/forum/#!forum/umpire-users)
+[Umpire Users Google Group](https://groups.google.com/forum/#!forum/umpire-users)
+
+You can also join our RADIUSS slack group and find the "umpire-users" channel to ask questions.
+To be sent an invite to the channel, email us at [umpire-dev@llnl.gov](mailto:umpire-dev@llnl.gov)
 
 ## Contributions
 


### PR DESCRIPTION
It seems like we do not use our Travis CI build page (no updates since 5 years ago) and our code coverage site has been deactivated. I don't think we use that anymore, so I removed both links. Plus, better links for making issues, link to umpire-dev mailing list, and umpire-users slack channel added....