### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -33,7 +33,7 @@ ibm_clang_14_0_5_mpi_shmem:
 
 ibm_clang_14_0_5_mpi_shmem_memleak:
   variables:
-    SPEC: "~shared +asan +tools tests=basic +ipc_shmem +mpi %clang@=14.0.5.ibm.gcc.8.3.1 cxxflags==-fsanitize=address ^spectrum-mpi"
+    SPEC: "~shared +asan +tools tests=basic +ipc_shmem +mpi cxxflags==-fsanitize=address %clang@=14.0.5.ibm.gcc.8.3.1 ^spectrum-mpi"
     ASAN_OPTIONS: "detect_leaks=1"
     LSAN_OPTIONS: "suppressions=/usr/workspace/umdev/MyASan.supp"
   extends: .job_on_lassen
@@ -51,12 +51,12 @@ ibm_clang_14_0_5_gcc_8_3_1_cuda_11_7_0_mpi_shmem:
 
 clang_12_0_1_libcpp:
   variables:
-    SPEC: "~shared +tools tests=basic %clang@=12.0.1 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
+    SPEC: "~shared +tools tests=basic cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\" %clang@=12.0.1"
   extends: .job_on_lassen
 
 clang_12_0_1_gcc_8_3_1_memleak:
   variables:
-    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic %clang@=12.0.1.gcc.8.3.1 cxxflags==-fsanitize=address"
+    SPEC: "~shared +asan +sanitizer_tests +tools tests=basic cxxflags==-fsanitize=address %clang@=12.0.1.gcc.8.3.1"
     ASAN_OPTIONS: "detect_leaks=1"
     LASSEN_JOB_ALLOC: "1 -W 20 -q pci"
   extends: .job_on_lassen


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
