### PR TITLE
Fix incremental builds when using Umpire as a submodule within a project 

### DIFF
--- a/src/tpl/CMakeLists.txt
+++ b/src/tpl/CMakeLists.txt
@@ -150,7 +150,6 @@ if (NOT TARGET ${UMPIRE_FMT_TARGET})
       message(FATAL_ERROR "fmt submodule not initialized. Run 'git submodule update --init --recursive' in the git repository or set fmt_DIR to use an external build of fmt.")
     else ()
       # In this case, fmt will be installed inside of Umpire install prefix
-      set(fmt_DIR ${CMAKE_INSTALL_PREFIX} CACHE PATH "")
       set(FMT_INSTALL ON)
       set(FMT_SYSTEM_HEADERS ON)
       add_subdirectory(umpire/fmt)


### PR DESCRIPTION
When building Umpire as a submodule within a parent project incremental builds can fail with the following error:

```
CMake Error at .../Umpire/src/tpl/CMakeLists.txt:140 (find_package):
  Could not find a package configuration file provided by "fmt" with any of
  the following names:

    fmtConfig.cmake
    fmt-config.cmake

  Add the installation prefix of "fmt" to CMAKE_PREFIX_PATH or set "fmt_DIR"
  to a directory containing one of the above files.  If "fmt" provides a
  separate development package or SDK, be sure it has been installed.
```

A workaround is for the parent project to explicitly unset `fmt_DIR`:
```
unset(fmt_DIR CACHE)
```

However, unsetting a cache variable like this modifies the cache configuration for the project, which triggers a rebuild of the Umpire library and re-linkning to all targets that depend on it (which is a lot) -- even if no sources files are modified. This works, but, it is not ideal.

This commit proposes fixing the issue by not setting `fmt_DIR` in Umpire when the internal `fmt` submodule is used. It appears that explicitly setting `fmt_DIR` in this cases is unnecessary and can be safely omitted. This change fixes the errors with incremental builds when CMake re-configures and the allowing the builds to progress without triggerring unnecessary rebuilds of Umpire and its dependencies.