### PR TITLE
Fix a communicator leak in HostMpi3SharedMemoryResource.

### DIFF
--- a/src/umpire/resource/HostMpi3SharedMemoryResource.cpp
+++ b/src/umpire/resource/HostMpi3SharedMemoryResource.cpp
@@ -25,7 +25,7 @@ HostMpi3SharedMemoryResource::HostMpi3SharedMemoryResource(const std::string& na
   // by turning it into an int (as for Fortran) and then decoding that in the callback.
   int keyval = 0;
   MPI_Comm_create_keyval(MPI_COMM_NULL_COPY_FN, free_comm, &keyval, nullptr);
-  MPI_Comm_set_attr(MPI_COMM_SELF, keyval, (void *)(intptr_t)MPI_Comm_c2f(m_shared_comm));
+  MPI_Comm_set_attr(MPI_COMM_SELF, keyval, (void*)(intptr_t)MPI_Comm_c2f(m_shared_comm));
 }
 
 HostMpi3SharedMemoryResource::~HostMpi3SharedMemoryResource()
@@ -73,7 +73,7 @@ Platform HostMpi3SharedMemoryResource::getPlatform() noexcept
 }
 
 int HostMpi3SharedMemoryResource::free_comm(MPI_Comm UMPIRE_UNUSED_ARG(comm), int UMPIRE_UNUSED_ARG(keyval),
-    void* attribute_val, void* UMPIRE_UNUSED_ARG(extra_state))
+                                            void* attribute_val, void* UMPIRE_UNUSED_ARG(extra_state))
 {
   // Interpret attribute_val as a MPI_Fint comm number.
   const auto comm_number = (MPI_Fint)(intptr_t)(attribute_val);

--- a/src/umpire/resource/HostMpi3SharedMemoryResource.cpp
+++ b/src/umpire/resource/HostMpi3SharedMemoryResource.cpp
@@ -20,12 +20,17 @@ HostMpi3SharedMemoryResource::HostMpi3SharedMemoryResource(const std::string& na
   constexpr int IGNORE_KEY{0};
   MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, IGNORE_KEY, MPI_INFO_NULL, &m_shared_comm);
   MPI_Comm_rank(m_shared_comm, &m_local_rank);
+
+  // Free the comm at exit during cleanup in MPI_Finalize. We pass the m_shared_comm
+  // by turning it into an int (as for Fortran) and then decoding that in the callback.
+  int keyval = 0;
+  MPI_Comm_create_keyval(MPI_COMM_NULL_COPY_FN, free_comm, &keyval, nullptr);
+  MPI_Comm_set_attr(MPI_COMM_SELF, keyval, (void *)(intptr_t)MPI_Comm_c2f(m_shared_comm));
 }
 
 HostMpi3SharedMemoryResource::~HostMpi3SharedMemoryResource()
 {
-  // TODO: Add finalize routine for cleanup pre MPI_Finalize
-  // MPI_Comm_free(&m_shared_comm);
+  // NOTE: m_shared_comm is freed at cleanup pre MPI_Finalize
 }
 
 void* HostMpi3SharedMemoryResource::allocate(std::size_t bytes)
@@ -65,6 +70,16 @@ bool HostMpi3SharedMemoryResource::isAccessibleFrom(Platform p) noexcept
 Platform HostMpi3SharedMemoryResource::getPlatform() noexcept
 {
   return Platform::host;
+}
+
+int HostMpi3SharedMemoryResource::free_comm(MPI_Comm UMPIRE_UNUSED_ARG(comm), int UMPIRE_UNUSED_ARG(keyval),
+    void* attribute_val, void* UMPIRE_UNUSED_ARG(extra_state))
+{
+  // Interpret attribute_val as a MPI_Fint comm number.
+  const auto comm_number = (MPI_Fint)(intptr_t)(attribute_val);
+  MPI_Comm comm_to_free = MPI_Comm_f2c(comm_number);
+  MPI_Comm_free(&comm_to_free);
+  return MPI_SUCCESS;
 }
 
 } // end of namespace resource

--- a/src/umpire/resource/HostMpi3SharedMemoryResource.hpp
+++ b/src/umpire/resource/HostMpi3SharedMemoryResource.hpp
@@ -33,6 +33,8 @@ class HostMpi3SharedMemoryResource : public MemoryResource {
   Platform getPlatform() noexcept override;
 
  private:
+  static int free_comm(MPI_Comm comm, int keyval, void* attribute_val, void* extra_state);
+
   MPI_Comm m_shared_comm;
   int m_local_rank;
   std::map<void*, MPI_Win> m_shared_windows;


### PR DESCRIPTION
I was using Umpire shared memory in Axom and I ran valgrind on it and it reported leaks due to arrays associated with `MPI_Win` in `HostMpi3SharedMemoryResource`. The destructor for this class contained a commented-out `MPI_Comm_free()` call as well as a *TODO* note about freeing the communicator later prior to `MPI_Finalize()`.

This PR takes a stab at freeing the communicator via a callback that is executed during the MPI_Finalize process. The `m_shared_comm` member is passed to the callback via a `void*` callback argument (the comm's integer name is stored in the `void*`). This is to avoid potential stack problems. With these changes, valgrind in Axom no longer reported these leaks.