### PR TITLE
fixing the allocator access example for shared mem

### DIFF
--- a/examples/allocator_access.cpp
+++ b/examples/allocator_access.cpp
@@ -65,7 +65,9 @@ int main()
         data[i] = i * i;
       }
       UMPIRE_ASSERT(data[size - 1] == (size - 1) * (size - 1) && "Inequality found in array that should be accessible");
+      a.deallocate(data);
     }
   }
+
   return 0;
 }

--- a/examples/allocator_access.cpp
+++ b/examples/allocator_access.cpp
@@ -67,6 +67,5 @@ int main()
       UMPIRE_ASSERT(data[size - 1] == (size - 1) * (size - 1) && "Inequality found in array that should be accessible");
     }
   }
-
   return 0;
 }

--- a/examples/allocator_access.cpp
+++ b/examples/allocator_access.cpp
@@ -10,6 +10,7 @@
 #include "umpire/Allocator.hpp"
 #include "umpire/ResourceManager.hpp"
 #include "umpire/Umpire.hpp"
+#include "umpire/util/MemoryResourceTraits.hpp"
 
 bool is_accessible_from_host(umpire::Allocator a)
 {
@@ -54,7 +55,12 @@ int main()
   const int size = 100;
   for (auto a : alloc) {
     if (is_accessible_from_host(a)) {
-      int* data = static_cast<int*>(a.allocate(size * sizeof(int)));
+      int* data;
+      if (a.getAllocationStrategy()->getTraits().resource == umpire::MemoryResourceTraits::resource_type::shared) {
+        data = static_cast<int*>(a.allocate("shared_alloc", size * sizeof(int)));
+      } else {
+        data = static_cast<int*>(a.allocate(size * sizeof(int)));
+      }
       for (int i = 0; i < size; i++) {
         data[i] = i * i;
       }


### PR DESCRIPTION
With Shared memory on, the allocator access example crashes because the example does not use a name in the test allocation. This PR checks for a shared memory resource and allocates accordingly...