### PR TITLE
Shared Memory Clarifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,10 @@ cmake_dependent_option( UMPIRE_ENABLE_MPI3_SHARED_MEMORY "Enable MPI3 Shared Mem
 
 if(UMPIRE_ENABLE_IPC_SHARED_MEMORY AND NOT UMPIRE_ENABLE_MPI3_SHARED_MEMORY)
   set(UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE "POSIX" CACHE STRING "Default implementation for SHARED memory resource (POSIX)")
+  message("-- Default Shared Memory Resource is POSIX")
 elseif(UMPIRE_ENABLE_MPI3_SHARED_MEMORY)
   set(UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE "MPI3" CACHE STRING "Default implementation for SHARED memory resource (MPI3)")
+  message("-- Default Shared Memory Resource is MPI3")
 else()
   set (UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE "" CACHE STRING "")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,16 @@ cmake_dependent_option( UMPIRE_ENABLE_MPI3_SHARED_MEMORY "Enable MPI3 Shared Mem
 
 if(UMPIRE_ENABLE_IPC_SHARED_MEMORY AND NOT UMPIRE_ENABLE_MPI3_SHARED_MEMORY)
   set(UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE "POSIX" CACHE STRING "Default implementation for SHARED memory resource (POSIX)")
-  message("-- Default Shared Memory Resource is POSIX")
 elseif(UMPIRE_ENABLE_MPI3_SHARED_MEMORY)
   set(UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE "MPI3" CACHE STRING "Default implementation for SHARED memory resource (MPI3)")
-  message("-- Default Shared Memory Resource is MPI3")
 else()
   set (UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE "" CACHE STRING "")
+endif()
+
+if(UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE)
+  message(STATUS "Default Shared Memory Resource is ${UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE}")
+else()
+  message(STATUS "No Default Shared Memory Resource configured")
 endif()
 
 ########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,8 +131,6 @@ endif()
 
 if(UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE)
   message(STATUS "Default Shared Memory Resource is ${UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE}")
-else()
-  message(STATUS "No Default Shared Memory Resource configured")
 endif()
 
 ########

--- a/docs/sphinx/features/shared_memory_allocators.rst
+++ b/docs/sphinx/features/shared_memory_allocators.rst
@@ -33,8 +33,8 @@ Enabling Both Shared Memory Allocators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As of v2025.09.0, users can enable both Shared Memory Allocators at the same time. Thus, we introduced a "default" shared memory
-resource. The default allows a shortcut for users to simply specify ``SHARED`` and that default shared memory resource will be used. 
-See table below which describes this default.
+resource cmake variable, `UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE`. The default allows a shortcut for users to simply specify 
+``SHARED`` and that default shared memory resource will be used. See table below which describes this default.
 
 +-------------+-------------+---------+
 | MPI3        | IPC         | Default |
@@ -52,6 +52,7 @@ As indicated in the table above, if both IPC and MPI3 Shared Memory is enabled, 
 assumed that MPI is enabled.) In order to use IPC shared memory, users need to be explicit when creating the allocator. For example:
 
 .. code-block:: cpp
+
    auto traits{umpire::get_default_resource_traits("SHARED::POSIX")};
    ...
    auto node_allocator{rm.makeResource("SHARED::POSIX::alloc", traits)};
@@ -60,6 +61,7 @@ Note that the ``SHARED::POSIX`` prefix is required to use IPC Shared Memory in t
 is an IPC Shared Memory allocator with the following code:
 
 .. code-block:: cpp
+
    if (umpire::util::matchesSharedMemoryResource("SHARED::POSIX::alloc", "POSIX")) {
      // The "SHARED::POSIX::alloc" allocator is indeed a POSIX(IPC) Shared Memory Allocator!
    }

--- a/docs/sphinx/features/shared_memory_allocators.rst
+++ b/docs/sphinx/features/shared_memory_allocators.rst
@@ -32,9 +32,9 @@ which set it apart from other Umpire allocators.
 Enabling Both Shared Memory Allocators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As of v2025.09.0, users can enable both Shared Memory Allocators at the same time. Thus, we introduced a "default" shared memory
-resource cmake variable, `UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE`. The default allows a shortcut for users to simply specify 
-``SHARED`` and that default shared memory resource will be used. See table below which describes this default.
+As of v2025.09.0, users can enable both Shared Memory allocators at the same time. Thus, we introduced a "default" shared memory
+resource cmake variable, ``UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE``. The default allows a shortcut for users to simply specify 
+``SHARED`` and then that default shared memory resource will be used. See table below which describes this default.
 
 +-------------+-------------+---------+
 | MPI3        | IPC         | Default |
@@ -48,7 +48,7 @@ resource cmake variable, `UMPIRE_DEFAULT_SHARED_MEMORY_RESOURCE`. The default al
 | disabled    | disabled    | N/A     |
 +-------------+-------------+---------+
 
-As indicated in the table above, if both IPC and MPI3 Shared Memory is enabled, then MPI3 is the default. (For the table above, it is
+As indicated in the table above, if both IPC and MPI3 Shared Memory are enabled, then MPI3 is the default. (For the table above, it is
 assumed that MPI is enabled.) In order to use IPC shared memory, users need to be explicit when creating the allocator. For example:
 
 .. code-block:: cpp

--- a/docs/sphinx/features/shared_memory_allocators.rst
+++ b/docs/sphinx/features/shared_memory_allocators.rst
@@ -28,7 +28,44 @@ which set it apart from other Umpire allocators.
 6. For some LC machines, running Shared Memory Allocators on the login node may produce runtime errors because the login node may not have access to the correct files. If you get an error on the login node, try a compute node instead.
 7. MPI3 Shared Memory Allocators only support a `shared_scope` trait of `node`. For IPC Shared Memory, there is an option for either `node` or `socket`.
 8. MPI3 Shared Memory Allocators do not need an explicit name during creation like IPC Shared Memory Allocators do.
-9. Users can only use one type of Shared Memory Allocator at a time, not both.
+
+Enabling Both Shared Memory Allocators
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As of v2025.09.0, users can enable both Shared Memory Allocators at the same time. Thus, we introduced a "default" shared memory
+resource. The default allows a shortcut for users to simply specify ``SHARED`` and that default shared memory resource will be used. 
+See table below which describes this default.
+
++-------------+-------------+---------+
+| MPI3        | IPC         | Default |
++=============+=============+=========+
+| enabled     | disabled    | MPI3    |
++-------------+-------------+---------+
+| disabled    | enabled     | IPC     |
++-------------+-------------+---------+
+| enabled     | enabled     | MPI3    |
++-------------+-------------+---------+
+| disabled    | disabled    | N/A     |
++-------------+-------------+---------+
+
+As indicated in the table above, if both IPC and MPI3 Shared Memory is enabled, then MPI3 is the default. (For the table above, it is
+assumed that MPI is enabled.) In order to use IPC shared memory, users need to be explicit when creating the allocator. For example:
+
+.. code-block:: cpp
+   auto traits{umpire::get_default_resource_traits("SHARED::POSIX")};
+   ...
+   auto node_allocator{rm.makeResource("SHARED::POSIX::alloc", traits)};
+
+Note that the ``SHARED::POSIX`` prefix is required to use IPC Shared Memory in this case. You can confirm that your allocator
+is an IPC Shared Memory allocator with the following code:
+
+.. code-block:: cpp
+   if (umpire::util::matchesSharedMemoryResource("SHARED::POSIX::alloc", "POSIX")) {
+     // The "SHARED::POSIX::alloc" allocator is indeed a POSIX(IPC) Shared Memory Allocator!
+   }
+
+Other Shared Memory Helper Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are a few helper functions provided in the ``Umpire.hpp`` header that will be useful when working with 
 Shared Memory allocators. For example, you can grab the MPI communicator for a particular Shared Memory allocator with:
@@ -36,9 +73,6 @@ Shared Memory allocators. For example, you can grab the MPI communicator for a p
 .. code-block:: cpp
 
    MPI_Comm shared_allocator_comm = umpire::get_communicator_for_allocator(node_allocator, MPI_COMM_WORLD);
-
-Note that the ``node_allocator`` is the IPC Shared Memory allocator we created above. You can also refer to
-the full example of the IPC Shared Memory cookbook recipe below.
 
 .. warning::
    If you use the ``umpire::get_communicators_for_allocator(...)`` helper function then you MUST
@@ -51,3 +85,4 @@ Additionally, we can double check that an allocator has the ``SHARED`` memory re
 
   UMPIRE_ASSERT(node_allocator.getAllocationStrategy()->getTraits().resource == umpire::MemoryResourceTraits::resource_type::shared);
 
+Check out the cookbook for more Shared Memory examples.

--- a/examples/cookbook/recipe_naming_shim.cpp
+++ b/examples/cookbook/recipe_naming_shim.cpp
@@ -35,5 +35,6 @@ int main(int, char**)
   void* ptr = shim.allocate(1024);
   std::cout << "Ptr = " << ptr << std::endl;
   shim.deallocate(ptr);
+
   return 0;
 }

--- a/examples/cookbook/recipe_naming_shim.cpp
+++ b/examples/cookbook/recipe_naming_shim.cpp
@@ -14,18 +14,26 @@
 #include "umpire/resource/HostSharedMemoryResource.hpp"
 #include "umpire/strategy/NamingShim.hpp"
 #include "umpire/util/MemoryResourceTraits.hpp"
+#include "umpire/util/shared_memory_helper.hpp"
 
 int main(int, char**)
 {
   auto& rm = umpire::ResourceManager::getInstance();
-  auto traits{umpire::get_default_resource_traits("SHARED")};
+  auto traits{umpire::get_default_resource_traits("SHARED::POSIX")};
   traits.size = 1 * 1024 * 1024;                                   // Maximum size of this Allocator
   traits.scope = umpire::MemoryResourceTraits::shared_scope::node; // default
-  auto node_allocator{rm.makeResource("SHARED::node_allocator", traits)};
+
+  auto node_allocator{rm.makeResource("SHARED::POSIX::ipc_node_allocator", traits)};
+
+  // Use the matchesSharedMemoryResource function to double check the type of shared memory
+  if (umpire::util::matchesSharedMemoryResource("SHARED::POSIX::ipc_node_allocator", "POSIX")) {
+    std::cout << "Confirmed this is an IPC Shared Memory allocator..." <<std::endl;
+  }
+
   auto shim{rm.makeAllocator<umpire::strategy::NamingShim>("shim", node_allocator)};
 
   void* ptr = shim.allocate(1024);
   std::cout << "Ptr = " << ptr << std::endl;
-  std::cout << "Total Memory Allocated: " << umpire::get_total_bytes_allocated() << std::endl;
   shim.deallocate(ptr);
+  return 0;
 }


### PR DESCRIPTION
Adding cmake messages, docs, and fixing a bug in shared memory example to clarify what happens when both shared memory allocators are enabled at the same time