### PR TITLE
ResourceAwarePool Optimizations

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -7,7 +7,6 @@
 
 # We define the following GitLab pipeline variables:
 variables:
-  SPEC: "${SPEC} ^camp@git.52f70d977de9382ebd9923a25b19e234767b3cb0=https://github.com/LLNL/camp.git"
 # On LLNL's machine, this pipeline creates only one allocation shared among jobs
 # in order to save time and resources. This allocation has to be uniquely named
 # so that we are sure to retrieve it and avoid collisions.

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -7,6 +7,7 @@
 
 # We define the following GitLab pipeline variables:
 variables:
+  SPEC: "${SPEC} ^camp@git.52f70d977de9382ebd9923a25b19e234767b3cb0=https://github.com/LLNL/camp.git"
 # On LLNL's machine, this pipeline creates only one allocation shared among jobs
 # in order to save time and resources. This allocation has to be uniquely named
 # so that we are sure to retrieve it and avoid collisions.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -23,6 +23,11 @@ if (UMPIRE_ENABLE_CUDA)
     SOURCES resource_aware_pool_stress_test.cpp
     DEPENDS_ON umpire cuda)
 
+  blt_add_executable(
+    NAME resource_aware_pool_benchmarks
+    SOURCES resource_aware_pool_benchmarks.cpp
+    DEPENDS_ON umpire cuda)
+
   if (UMPIRE_ENABLE_DEVICE_ALLOCATOR)
   blt_add_executable(
     NAME device_allocator_stress_test
@@ -41,6 +46,11 @@ elseif (UMPIRE_ENABLE_HIP)
   blt_add_executable(
     NAME resource_aware_pool_stress_test
     SOURCES resource_aware_pool_stress_test.cpp
+    DEPENDS_ON umpire blt::hip blt::hip_runtime)
+
+  blt_add_executable(
+    NAME resource_aware_pool_benchmarks
+    SOURCES resource_aware_pool_benchmarks.cpp
     DEPENDS_ON umpire blt::hip blt::hip_runtime)
 
   if (UMPIRE_ENABLE_DEVICE_ALLOCATOR)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -23,11 +23,6 @@ if (UMPIRE_ENABLE_CUDA)
     SOURCES resource_aware_pool_stress_test.cpp
     DEPENDS_ON umpire cuda)
 
-  blt_add_executable(
-    NAME resource_aware_pool_benchmarks
-    SOURCES resource_aware_pool_benchmarks.cpp
-    DEPENDS_ON umpire cuda)
-
   if (UMPIRE_ENABLE_DEVICE_ALLOCATOR)
   blt_add_executable(
     NAME device_allocator_stress_test
@@ -46,11 +41,6 @@ elseif (UMPIRE_ENABLE_HIP)
   blt_add_executable(
     NAME resource_aware_pool_stress_test
     SOURCES resource_aware_pool_stress_test.cpp
-    DEPENDS_ON umpire blt::hip blt::hip_runtime)
-
-  blt_add_executable(
-    NAME resource_aware_pool_benchmarks
-    SOURCES resource_aware_pool_benchmarks.cpp
     DEPENDS_ON umpire blt::hip blt::hip_runtime)
 
   if (UMPIRE_ENABLE_DEVICE_ALLOCATOR)

--- a/src/umpire/strategy/ResourceAwarePool.cpp
+++ b/src/umpire/strategy/ResourceAwarePool.cpp
@@ -181,7 +181,7 @@ void ResourceAwarePool::do_deallocate(Chunk* chunk, void* ptr) noexcept
   UMPIRE_USE_VAR(ptr);
   chunk->free = true;
 
-  // Remove chunk from pending
+  // Remove chunk from pending and invalidate iterator
   if (chunk->pending_map_it != m_pending_map.end()) {
     m_pending_map.erase(chunk->pending_map_it);
     chunk->pending_map_it = m_pending_map.end();
@@ -273,7 +273,7 @@ void ResourceAwarePool::deallocate_resource(void* ptr, camp::resources::Resource
   if (chunk->event.check()) {
     do_deallocate(chunk, ptr);
   } else {
-    // Chunk is now pending, add to pending map
+    // Chunk is now pending, add to pending map and set iterator
     auto it = m_pending_map.insert({std::optional<Resource>(chunk->resource), chunk});
     chunk->pending_map_it = it;
   }
@@ -293,51 +293,18 @@ void ResourceAwarePool::release()
   std::size_t prev_size{m_actual_bytes};
 #endif
 
-//TODO: double check this
-  auto it = m_pending_map.begin();
-  while (it != m_pending_map.end()) {
-    auto chunk = it->second;
-    UMPIRE_LOG(Debug, "Found chunk @ " << chunk->data);
-
-    // If we are destructing, wait for all deallocations to occur
-    if (m_is_destructing) {
+  // If we are destructing, wait for all deallocations to occur
+  if (m_is_destructing) {
+    // Wait for all pending operations
+    for (auto& [resource, chunk] : m_pending_map) {
       chunk->event.wait();
     }
-
-    // Otherwise, free all finished pending chunks
-    if (chunk->event.check()) {
-      if (chunk->size == chunk->chunk_size) {
-        UMPIRE_LOG(Debug, "Releasing chunk " << chunk->data);
-
-        m_actual_bytes -= chunk->chunk_size;
-        m_releasable_bytes -= chunk->chunk_size;
-        m_releasable_blocks--;
-        m_total_blocks--;
-
-        try {
-          aligned_deallocate(chunk->data);
-        } catch (...) {
-          if (m_is_destructing) {
-            //
-            // Ignore error in case the underlying vendor API has already shutdown
-            //
-            UMPIRE_LOG(Error, "Pool is destructing, runtime_error Ignored");
-          } else {
-            throw;
-          }
-        }
-
-        chunk->~Chunk(); // manually call destructor
-        m_chunk_pool.deallocate(chunk);
-        it = m_pending_map.erase(it);
-        chunk->pending_map_it = m_pending_map.end();
-      } else {
-        it = m_pending_map.erase(it);
-        chunk->pending_map_it = m_pending_map.end();
-        do_deallocate(chunk, chunk->data);
-      }
-    } else {
-      ++it;
+  
+    // Deallocate pending chunks (moves to free map)
+    while (!m_pending_map.empty()) {
+      auto it = m_pending_map.begin();
+      auto chunk = it->second;
+      do_deallocate(chunk, chunk->data);
     }
   }
 
@@ -430,34 +397,32 @@ Platform ResourceAwarePool::getPlatform() noexcept
 
 camp::resources::Resource ResourceAwarePool::getResource(void* ptr) const
 {
-  for (auto& [resource, chunk] : m_pending_map) { // check pending chunks
-    if (chunk->data == ptr) {
-      assert(resource.has_value()); //since resource is optional
-      return *resource;
-    }
-  }
-  auto it = m_used_map.find(ptr); // check used chunks
+  static camp::resources::Resource default_host_resource{camp::resources::Host::get_default()};
+
+  // First, check used chunks
+  auto it = m_used_map.find(ptr);
   if (it != m_used_map.end()) {
     auto chunk = it->second;
     return chunk->resource;
   }
-  for (auto pair = m_free_map.begin(); pair != m_free_map.end(); pair++) {
-    auto chunk = (*pair).second;
+
+  // If not found, check pending chunks
+  for (auto& [resource, chunk] : m_pending_map) {
     if (chunk->data == ptr) {
-      UMPIRE_LOG(
-          Warning,
-          fmt::format(
-              "Ptr {} corresponded to a free chunk in the ResourceAwarePool, so the resource may no longer be valid...",
-              ptr));
-      return chunk->resource;
+      if (!resource.has_value()) { //since resource is optional
+        UMPIRE_LOG(Error, fmt::format("Found ptr {} in pending_map but resource is null", ptr));
+        // Returning a default resource for the ResourceAwarePool
+        return default_host_resource;
+      }
+      return *resource;
     }
   }
 
-  UMPIRE_LOG(Warning, fmt::format("The pointer {} does not seem to be associated with the ResourceAwarePool."
-                                  "Returning the default Host resource...",
-                                  ptr));
+  UMPIRE_LOG(Warning, fmt::format("The pointer {} is either free or not associated with the ResourceAwarePool."
+                                  "Returning the default Host resource...", ptr));
 
-  return camp::resources::Host().get_default(); // Returning a default resource for the ResourceAwarePool
+  // Returning a default resource for the ResourceAwarePool
+  return default_host_resource;
 }
 
 MemoryResourceTraits ResourceAwarePool::getTraits() const noexcept
@@ -490,11 +455,12 @@ void ResourceAwarePool::coalesce() noexcept
   umpire::event::record([&](auto& event) {
     event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
   });
- 
+
+  // TODO: Do we need to check pending in coalescing function? 
   auto it = m_pending_map.begin();
   while (it != m_pending_map.end()) {
     auto pending_chunk = it->second;
-    if (pending_chunk->free == false && pending_chunk->event.check()) { // a pending chunk is finished...
+    if (pending_chunk->event.check()) { // a pending chunk is finished...
       auto next_it = std::next(it);
       do_deallocate(pending_chunk, pending_chunk->data);
       it = next_it;

--- a/src/umpire/strategy/ResourceAwarePool.cpp
+++ b/src/umpire/strategy/ResourceAwarePool.cpp
@@ -57,17 +57,19 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
   const std::size_t rounded_bytes{aligned_round_up(bytes)};
   Chunk* chunk{nullptr};
 
-  if (!m_pending_list.empty()) {
-    for (auto it = m_pending_list.begin(); it != m_pending_list.end(); it++) {
+  if (!m_pending_map.empty()) {
+    for (auto it = m_pending_map.begin(); it != m_pending_map.end(); it++) {
       auto pending_chunk = (*it);
       if (pending_chunk->size >= rounded_bytes && pending_chunk->resource == r) { // reusing chunk with same resource
         chunk = pending_chunk;
         chunk->free = false;
-        m_pending_list.erase(it);
+        m_pending_map.erase(it);
         break;
       }
     }
   }
+
+  
 
   const auto& best = m_free_map.lower_bound(rounded_bytes);
 
@@ -179,10 +181,10 @@ void ResourceAwarePool::do_deallocate(Chunk* chunk, void* ptr) noexcept
   chunk->free = true;
 
   // Removing chunk from pending
-  for (auto it = m_pending_list.begin(); it != m_pending_list.end();) {
+  for (auto it = m_pending_map.begin(); it != m_pending_map.end();) {
     auto my_chunk = (*it);
     if (my_chunk == chunk) {
-      it = m_pending_list.erase(it);
+      it = m_pending_map.erase(it);
     } else {
       it++;
     }
@@ -274,8 +276,8 @@ void ResourceAwarePool::deallocate_resource(void* ptr, camp::resources::Resource
   if (chunk->event.check()) {
     do_deallocate(chunk, ptr);
   } else {
-    // Chunk is now pending, add to list
-    m_pending_list.push_back(chunk);
+    // Chunk is now pending, add to pending map
+    m_pending_map.push_back(chunk);
   }
 
   std::size_t suggested_size{m_should_coalesce(*this)};
@@ -293,7 +295,7 @@ void ResourceAwarePool::release()
   std::size_t prev_size{m_actual_bytes};
 #endif
 
-  for (auto it = m_pending_list.begin(); it != m_pending_list.end();) {
+  for (auto it = m_pending_map.begin(); it != m_pending_map.end();) {
     auto chunk = (*it);
     if (m_is_destructing) { // If we are destructing, wait for all deallocations to occur
       chunk->event.wait();
@@ -302,7 +304,7 @@ void ResourceAwarePool::release()
         chunk->event.check()) { // Otherwise, move all finished pending chunks to free map to be released
       m_free_map.insert(std::make_pair(chunk->size, chunk));
       chunk->free = true;
-      it = m_pending_list.erase(it);
+      it = m_pending_map.erase(it);
     } else {
       it++;
     }
@@ -362,7 +364,7 @@ std::size_t ResourceAwarePool::getTotalBlocks() const noexcept
 
 std::size_t ResourceAwarePool::getNumPending() const noexcept
 {
-  return m_pending_list.size();
+  return m_pending_map.size();
 }
 
 std::size_t ResourceAwarePool::getActualSize() const noexcept
@@ -397,7 +399,7 @@ Platform ResourceAwarePool::getPlatform() noexcept
 
 camp::resources::Resource ResourceAwarePool::getResource(void* ptr) const
 {
-  for (auto& chunk : m_pending_list) { // check pending chunks
+  for (auto& chunk : m_pending_map) { // check pending chunks
     if (chunk->data == ptr) {
       return chunk->resource;
     }
@@ -438,7 +440,7 @@ bool ResourceAwarePool::tracksMemoryUse() const noexcept
 
 std::size_t ResourceAwarePool::getBlocksInPool() const noexcept
 {
-  return m_used_map.size() + m_free_map.size() + m_pending_list.size();
+  return m_used_map.size() + m_free_map.size() + m_pending_map.size();
 }
 
 std::size_t ResourceAwarePool::getLargestAvailableBlock() noexcept
@@ -457,8 +459,8 @@ void ResourceAwarePool::coalesce() noexcept
     event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
   });
 
-  if (!m_pending_list.empty()) {
-    for (auto it = m_pending_list.begin(); it != m_pending_list.end(); it++) {
+  if (!m_pending_map.empty()) {
+    for (auto it = m_pending_map.begin(); it != m_pending_map.end(); it++) {
       auto pending_chunk = (*it);
       if (pending_chunk->free == false && pending_chunk->event.check()) { // a pending chunk is finished...
         do_deallocate(pending_chunk, pending_chunk->data);

--- a/src/umpire/strategy/ResourceAwarePool.cpp
+++ b/src/umpire/strategy/ResourceAwarePool.cpp
@@ -139,7 +139,7 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
 
   chunk->free = false;
 
-  if (rounded_bytes != chunk->size) {
+  if ((rounded_bytes != chunk->size) && !was_pending) { // Don't split a reused pending chunk
     std::size_t remaining{chunk->size - rounded_bytes};
     UMPIRE_LOG(Debug, "Splitting chunk " << chunk->size << "into " << rounded_bytes << " and " << remaining);
 
@@ -155,16 +155,8 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
       split_chunk->next->prev = split_chunk;
 
     chunk->size = rounded_bytes;
-
-    // We are actually splitting up a pending chunk that is being reused, so split chunk is pending too
-//    if (was_pending) {
-//      split_chunk->pending_map_it = m_pending_map.insert({std::optional<Resource>(r), split_chunk});
-      // TODO should the split_chunk also have the same event as chunk in this case?
-//      split_chunk->free = false;
-//    } else { // Chunk we are splitting up is not pending, so split_chunk is free
-      split_chunk->size_map_it = m_free_map.insert(std::make_pair(remaining, split_chunk));
-      split_chunk->free = true;
-//    }
+    split_chunk->size_map_it = m_free_map.insert(std::make_pair(remaining, split_chunk));
+    split_chunk->free = true;
   }
 
   m_aligned_bytes += rounded_bytes;

--- a/src/umpire/strategy/ResourceAwarePool.cpp
+++ b/src/umpire/strategy/ResourceAwarePool.cpp
@@ -57,19 +57,20 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
   const std::size_t rounded_bytes{aligned_round_up(bytes)};
   Chunk* chunk{nullptr};
 
-  if (!m_pending_map.empty()) {
-    for (auto it = m_pending_map.begin(); it != m_pending_map.end(); it++) {
-      auto pending_chunk = (*it);
-      if (pending_chunk->size >= rounded_bytes && pending_chunk->resource == r) { // reusing chunk with same resource
+  auto range = m_pending_map.equal_range(std::optional<Resource>(r));
+  for (auto it = range.first; it != range.second; ++it) {
+    auto pending_chunk = it->second;
+    if (pending_chunk->size >= rounded_bytes) {
+        // reuse chunk with same resource
         chunk = pending_chunk;
         chunk->free = false;
-        m_pending_map.erase(it);
-        break;
-      }
-    }
-  }
 
-  
+        // delete from pending map and invalidate the iterator
+        m_pending_map.erase(it);
+        chunk->pending_map_it = m_pending_map.end();
+        break;
+    }
+  } 
 
   const auto& best = m_free_map.lower_bound(rounded_bytes);
 
@@ -180,14 +181,10 @@ void ResourceAwarePool::do_deallocate(Chunk* chunk, void* ptr) noexcept
   UMPIRE_USE_VAR(ptr);
   chunk->free = true;
 
-  // Removing chunk from pending
-  for (auto it = m_pending_map.begin(); it != m_pending_map.end();) {
-    auto my_chunk = (*it);
-    if (my_chunk == chunk) {
-      it = m_pending_map.erase(it);
-    } else {
-      it++;
-    }
+  // Remove chunk from pending
+  if (chunk->pending_map_it != m_pending_map.end()) {
+    m_pending_map.erase(chunk->pending_map_it);
+    chunk->pending_map_it = m_pending_map.end();
   }
 
   UMPIRE_LOG(Debug, "In the do_deallocate function. Deallocating data held by " << chunk);
@@ -277,7 +274,8 @@ void ResourceAwarePool::deallocate_resource(void* ptr, camp::resources::Resource
     do_deallocate(chunk, ptr);
   } else {
     // Chunk is now pending, add to pending map
-    m_pending_map.push_back(chunk);
+    auto it = m_pending_map.insert({std::optional<Resource>(chunk->resource), chunk});
+    chunk->pending_map_it = it;
   }
 
   std::size_t suggested_size{m_should_coalesce(*this)};
@@ -295,18 +293,51 @@ void ResourceAwarePool::release()
   std::size_t prev_size{m_actual_bytes};
 #endif
 
-  for (auto it = m_pending_map.begin(); it != m_pending_map.end();) {
-    auto chunk = (*it);
-    if (m_is_destructing) { // If we are destructing, wait for all deallocations to occur
+//TODO: double check this
+  auto it = m_pending_map.begin();
+  while (it != m_pending_map.end()) {
+    auto chunk = it->second;
+    UMPIRE_LOG(Debug, "Found chunk @ " << chunk->data);
+
+    // If we are destructing, wait for all deallocations to occur
+    if (m_is_destructing) {
       chunk->event.wait();
     }
-    if (chunk != nullptr && chunk->free == false &&
-        chunk->event.check()) { // Otherwise, move all finished pending chunks to free map to be released
-      m_free_map.insert(std::make_pair(chunk->size, chunk));
-      chunk->free = true;
-      it = m_pending_map.erase(it);
+
+    // Otherwise, free all finished pending chunks
+    if (chunk->event.check()) {
+      if (chunk->size == chunk->chunk_size) {
+        UMPIRE_LOG(Debug, "Releasing chunk " << chunk->data);
+
+        m_actual_bytes -= chunk->chunk_size;
+        m_releasable_bytes -= chunk->chunk_size;
+        m_releasable_blocks--;
+        m_total_blocks--;
+
+        try {
+          aligned_deallocate(chunk->data);
+        } catch (...) {
+          if (m_is_destructing) {
+            //
+            // Ignore error in case the underlying vendor API has already shutdown
+            //
+            UMPIRE_LOG(Error, "Pool is destructing, runtime_error Ignored");
+          } else {
+            throw;
+          }
+        }
+
+        chunk->~Chunk(); // manually call destructor
+        m_chunk_pool.deallocate(chunk);
+        it = m_pending_map.erase(it);
+        chunk->pending_map_it = m_pending_map.end();
+      } else {
+        it = m_pending_map.erase(it);
+        chunk->pending_map_it = m_pending_map.end();
+        do_deallocate(chunk, chunk->data);
+      }
     } else {
-      it++;
+      ++it;
     }
   }
 
@@ -399,9 +430,10 @@ Platform ResourceAwarePool::getPlatform() noexcept
 
 camp::resources::Resource ResourceAwarePool::getResource(void* ptr) const
 {
-  for (auto& chunk : m_pending_map) { // check pending chunks
+  for (auto& [resource, chunk] : m_pending_map) { // check pending chunks
     if (chunk->data == ptr) {
-      return chunk->resource;
+      assert(resource.has_value()); //since resource is optional
+      return *resource;
     }
   }
   auto it = m_used_map.find(ptr); // check used chunks
@@ -458,14 +490,16 @@ void ResourceAwarePool::coalesce() noexcept
   umpire::event::record([&](auto& event) {
     event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
   });
-
-  if (!m_pending_map.empty()) {
-    for (auto it = m_pending_map.begin(); it != m_pending_map.end(); it++) {
-      auto pending_chunk = (*it);
-      if (pending_chunk->free == false && pending_chunk->event.check()) { // a pending chunk is finished...
-        do_deallocate(pending_chunk, pending_chunk->data);
-        break;
-      }
+ 
+  auto it = m_pending_map.begin();
+  while (it != m_pending_map.end()) {
+    auto pending_chunk = it->second;
+    if (pending_chunk->free == false && pending_chunk->event.check()) { // a pending chunk is finished...
+      auto next_it = std::next(it);
+      do_deallocate(pending_chunk, pending_chunk->data);
+      it = next_it;
+    } else {
+      ++it;
     }
   }
 

--- a/src/umpire/strategy/ResourceAwarePool.cpp
+++ b/src/umpire/strategy/ResourceAwarePool.cpp
@@ -59,6 +59,7 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
   Chunk* chunk{nullptr};
 
   auto range = m_pending_map.equal_range(std::optional<Resource>(r));
+  bool was_pending = false;
   for (auto it = range.first; it != range.second; ++it) {
     auto pending_chunk = it->second;
     if (pending_chunk->size >= rounded_bytes) {
@@ -69,6 +70,7 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
         // delete from pending map and invalidate the iterator
         m_pending_map.erase(it);
         chunk->pending_map_it = m_pending_map.end();
+        was_pending = true; // If we split the chunk later, we need this info
         break;
     }
   } 
@@ -153,8 +155,16 @@ void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::R
       split_chunk->next->prev = split_chunk;
 
     chunk->size = rounded_bytes;
-    split_chunk->size_map_it = m_free_map.insert(std::make_pair(remaining, split_chunk));
-    split_chunk->free = true;
+
+    // We are actually splitting up a pending chunk that is being reused, so split chunk is pending too
+//    if (was_pending) {
+//      split_chunk->pending_map_it = m_pending_map.insert({std::optional<Resource>(r), split_chunk});
+      // TODO should the split_chunk also have the same event as chunk in this case?
+//      split_chunk->free = false;
+//    } else { // Chunk we are splitting up is not pending, so split_chunk is free
+      split_chunk->size_map_it = m_free_map.insert(std::make_pair(remaining, split_chunk));
+      split_chunk->free = true;
+//    }
   }
 
   m_aligned_bytes += rounded_bytes;

--- a/src/umpire/strategy/ResourceAwarePool.cpp
+++ b/src/umpire/strategy/ResourceAwarePool.cpp
@@ -54,6 +54,7 @@ void* ResourceAwarePool::allocate(std::size_t bytes)
 void* ResourceAwarePool::allocate_resource(std::size_t bytes, camp::resources::Resource r)
 {
   UMPIRE_LOG(Debug, "(bytes=" << bytes << ")");
+  UMPIRE_LOG(Debug, "(Resource=" << camp::resources::to_string(r) << ")");
   const std::size_t rounded_bytes{aligned_round_up(bytes)};
   Chunk* chunk{nullptr};
 
@@ -397,7 +398,7 @@ Platform ResourceAwarePool::getPlatform() noexcept
 
 camp::resources::Resource ResourceAwarePool::getResource(void* ptr) const
 {
-  static camp::resources::Resource default_host_resource{camp::resources::Host::get_default()};
+  UMPIRE_LOG(Debug, "Calling getResource with (ptr=" << ptr << ")");
 
   // First, check used chunks
   auto it = m_used_map.find(ptr);
@@ -412,7 +413,7 @@ camp::resources::Resource ResourceAwarePool::getResource(void* ptr) const
       if (!resource.has_value()) { //since resource is optional
         UMPIRE_LOG(Error, fmt::format("Found ptr {} in pending_map but resource is null", ptr));
         // Returning a default resource for the ResourceAwarePool
-        return default_host_resource;
+        return camp::resources::Host::get_default();
       }
       return *resource;
     }
@@ -422,7 +423,7 @@ camp::resources::Resource ResourceAwarePool::getResource(void* ptr) const
                                   "Returning the default Host resource...", ptr));
 
   // Returning a default resource for the ResourceAwarePool
-  return default_host_resource;
+  return camp::resources::Host::get_default();
 }
 
 MemoryResourceTraits ResourceAwarePool::getTraits() const noexcept
@@ -456,11 +457,11 @@ void ResourceAwarePool::coalesce() noexcept
     event.name("coalesce").category(event::category::operation).tag("allocator_name", getName()).tag("replay", "true");
   });
 
-  // TODO: Do we need to check pending in coalescing function? 
   auto it = m_pending_map.begin();
   while (it != m_pending_map.end()) {
     auto pending_chunk = it->second;
-    if (pending_chunk->event.check()) { // a pending chunk is finished...
+    if (pending_chunk->event.check()) { 
+      // pending chunk is finished
       auto next_it = std::next(it);
       do_deallocate(pending_chunk, pending_chunk->data);
       it = next_it;

--- a/src/umpire/strategy/ResourceAwarePool.hpp
+++ b/src/umpire/strategy/ResourceAwarePool.hpp
@@ -27,22 +27,6 @@
 using Resource = camp::resources::Resource;
 using Event = camp::resources::Event;
 
-namespace std {
-  // Hash function for variant Resource
-  template<>
-  struct hash<std::variant<std::monostate, Resource>> {
-    size_t operator()(const std::variant<std::monostate, Resource>& key) const {
-      if (std::holds_alternative<std::monostate>(key)) {
-        return 0; // Hash for no resource
-      }
-      // If there is a Resource, get it
-      const auto& resource = std::get<Resource>(key);
-      return std::hash<const void*>{}(&resource); // use the address of the resource object
-    }
-  };
-  // End of PendingMap definitions
-}
-
 namespace umpire {
 
 class Allocator;
@@ -201,11 +185,7 @@ class ResourceAwarePool : public AllocationStrategy, private mixins::AlignedAllo
   };
 
   using PointerMap = std::unordered_map<void*, Chunk*>;
-
-  // PendingMap definitions
-  using ResourceKey = std::variant<std::monostate, Resource>;
-  using PendingMap = std::unordered_multimap<ResourceKey, Chunk*>;
-
+  using PendingMap = std::unordered_multimap<std::optional<Resource>, Chunk*>;
   using SizeMap =
       std::multimap<std::size_t, Chunk*, std::less<std::size_t>, pool_allocator<std::pair<const std::size_t, Chunk*>>>;
 

--- a/src/umpire/strategy/ResourceAwarePool.hpp
+++ b/src/umpire/strategy/ResourceAwarePool.hpp
@@ -13,7 +13,6 @@
 #include <tuple>
 #include <unordered_map>
 #include <optional>
-#include <variant>
 
 #include "camp/camp.hpp"
 #include "camp/resource.hpp"

--- a/src/umpire/strategy/ResourceAwarePool.hpp
+++ b/src/umpire/strategy/ResourceAwarePool.hpp
@@ -12,6 +12,8 @@
 #include <memory>
 #include <tuple>
 #include <unordered_map>
+#include <optional>
+#include <variant>
 
 #include "camp/camp.hpp"
 #include "camp/resource.hpp"
@@ -24,6 +26,22 @@
 
 using Resource = camp::resources::Resource;
 using Event = camp::resources::Event;
+
+namespace std {
+  // Hash function for variant Resource
+  template<>
+  struct hash<std::variant<std::monostate, Resource>> {
+    size_t operator()(const std::variant<std::monostate, Resource>& key) const {
+      if (std::holds_alternative<std::monostate>(key)) {
+        return 0; // Hash for no resource
+      }
+      // If there is a Resource, get it
+      const auto& resource = std::get<Resource>(key);
+      return std::hash<const void*>{}(&resource); // use the address of the resource object
+    }
+  };
+  // End of PendingMap definitions
+}
 
 namespace umpire {
 
@@ -183,7 +201,11 @@ class ResourceAwarePool : public AllocationStrategy, private mixins::AlignedAllo
   };
 
   using PointerMap = std::unordered_map<void*, Chunk*>;
-  using PendingList = std::list<Chunk*>;
+
+  // PendingMap definitions
+  using ResourceKey = std::variant<std::monostate, Resource>;
+  using PendingMap = std::unordered_multimap<ResourceKey, Chunk*>;
+
   using SizeMap =
       std::multimap<std::size_t, Chunk*, std::less<std::size_t>, pool_allocator<std::pair<const std::size_t, Chunk*>>>;
 
@@ -214,6 +236,7 @@ class ResourceAwarePool : public AllocationStrategy, private mixins::AlignedAllo
     Chunk* prev{nullptr};
     Chunk* next{nullptr};
     SizeMap::iterator size_map_it;
+    PendingMap::iterator pending_map_it;
     Resource resource;
     Event event;
   };
@@ -221,7 +244,7 @@ class ResourceAwarePool : public AllocationStrategy, private mixins::AlignedAllo
  private:
   PointerMap m_used_map{};
   SizeMap m_free_map{};
-  PendingList m_pending_list{};
+  PendingMap m_pending_map{};
 
   util::FixedMallocPool m_chunk_pool{sizeof(Chunk)};
 

--- a/tests/integration/resource_aware_pool_tests.cpp
+++ b/tests/integration/resource_aware_pool_tests.cpp
@@ -14,6 +14,7 @@
 #include "umpire/Umpire.hpp"
 #include "umpire/config.hpp"
 #include "umpire/strategy/ResourceAwarePool.hpp"
+#include "umpire/util/wrap_allocator.hpp"
 
 using namespace camp::resources;
 
@@ -239,21 +240,21 @@ TEST_P(ResourceAwarePoolTest, PendingToFreeTransition)
   m_pool.deallocate(ptr2, d1);
 }
 
-//TODO: do we need this to work?
-/*
 TEST_P(ResourceAwarePoolTest, ResourceMismatchOnDeallocate)
 {
   resource_type d1, d2;
   
   double* ptr = static_cast<double*>(m_pool.allocate(1024, d1));
   
-  // Try to deallocate with wrong resource
-  EXPECT_THROW(m_pool.deallocate(ptr, d2), umpire::runtime_error);
-  
   // Correct deallocation should work
   EXPECT_NO_THROW(m_pool.deallocate(ptr, d1));
+
+  double* ptr2 = static_cast<double*>(m_pool.allocate(2048, d1));
+  
+  // Try to deallocate with wrong resource
+  EXPECT_THROW(m_pool.deallocate(ptr2, d2), umpire::runtime_error);
+  
 }
-*/
 
 TEST_P(ResourceAwarePoolTest, MultiplePendingChunksSameResource)
 {
@@ -328,11 +329,9 @@ TEST_P(ResourceAwarePoolTest, ChunkSplittingAndMerging)
   m_pool.deallocate(large2, d1);
 }
 
-/*
 TEST_P(ResourceAwarePoolTest, GetResourceEdgeCases)
 {
   resource_type d1;
-  static camp::resources::Resource default_host_resource{camp::resources::Host::get_default()};
   
   double* ptr = static_cast<double*>(m_pool.allocate(1024, d1));
   
@@ -344,22 +343,28 @@ TEST_P(ResourceAwarePoolTest, GetResourceEdgeCases)
   m_pool.deallocate(ptr, d1);
   
   // Should still find it in pending
+  EXPECT_EQ(get_num_pending(m_pool), 1);
   EXPECT_EQ(get_resource(m_pool, ptr), Resource{d1});
   
   // Wait for completion
   d1.get_event().wait();
-  m_pool.release(); // Force processing of pending
+
+  // Force processing of pending 
+  // (release only processes pending chunks upon destruction, so call coalesce instead)
+  auto rap = umpire::util::unwrap_allocator<umpire::strategy::ResourceAwarePool>(m_pool);
+  rap->coalesce();
+
+  EXPECT_EQ(get_num_pending(m_pool), 0);
   
   // Now it's free - should return warning and default
   camp::resources::Resource res = get_resource(m_pool, ptr);
-  EXPECT_EQ(res, default_host_resource);
+  EXPECT_TRUE(res == camp::resources::Resource{Host{}});
   
   // Invalid pointer
   double* invalid_ptr = reinterpret_cast<double*>(0xDEADBEEF);
   res = get_resource(m_pool, invalid_ptr);
-  EXPECT_EQ(res, default_host_resource);
+  EXPECT_EQ(res, camp::resources::Resource{Host{}});
 }
-*/
 
 TEST_P(ResourceAwarePoolTest, StressTestMultipleResources)
 {

--- a/tests/integration/resource_aware_pool_tests.cpp
+++ b/tests/integration/resource_aware_pool_tests.cpp
@@ -188,6 +188,210 @@ TEST_P(ResourceAwarePoolTest, ReleaseCheck)
   EXPECT_NO_THROW(m_pool.release());
 }
 
+TEST_P(ResourceAwarePoolTest, CoalescingAdjacentChunks)
+{
+  resource_type d1;
+  
+  // Allocate two adjacent chunks
+  void* ptr1 = m_pool.allocate(1024, d1);
+  void* ptr2 = m_pool.allocate(1024, d1);
+  void* ptr3 = m_pool.allocate(1024, d1);
+  
+  // Deallocate non-adjacent chunks
+  m_pool.deallocate(ptr1, d1);
+  m_pool.deallocate(ptr3, d1);
+  
+  // Wait for any pending ops
+  d1.get_event().wait();
+  
+  // Deallocate middle chunk - should trigger coalescing
+  m_pool.deallocate(ptr2, d1);
+  
+  // Force coalesce
+  m_pool.release();
+  
+  // Should be able to allocate a larger chunk now
+  void* large_ptr = m_pool.allocate(3072, d1);
+  EXPECT_NE(large_ptr, nullptr);
+  
+  m_pool.deallocate(large_ptr, d1);
+}
+
+TEST_P(ResourceAwarePoolTest, PendingToFreeTransition)
+{
+  resource_type d1, d2;
+  
+  double* ptr = static_cast<double*>(m_pool.allocate(2048, d1));
+  
+  // Start async operation
+  do_sleep<<<1, 32, 0, d1.get_stream()>>>(ptr);
+  
+  // Deallocate - goes to pending
+  m_pool.deallocate(ptr, d1);
+  EXPECT_EQ(get_num_pending(m_pool), 1);
+  
+  // Try to allocate same size with same resource while pending
+  double* ptr2 = static_cast<double*>(m_pool.allocate(2048, d1));
+  
+  // Should reuse the pending chunk if it's done, or get new chunk
+  EXPECT_EQ(get_num_pending(m_pool), 0); // pending chunk was reused
+  
+  m_pool.deallocate(ptr2, d1);
+}
+
+//TODO: do we need this to work?
+/*
+TEST_P(ResourceAwarePoolTest, ResourceMismatchOnDeallocate)
+{
+  resource_type d1, d2;
+  
+  double* ptr = static_cast<double*>(m_pool.allocate(1024, d1));
+  
+  // Try to deallocate with wrong resource
+  EXPECT_THROW(m_pool.deallocate(ptr, d2), umpire::runtime_error);
+  
+  // Correct deallocation should work
+  EXPECT_NO_THROW(m_pool.deallocate(ptr, d1));
+}
+*/
+
+TEST_P(ResourceAwarePoolTest, MultiplePendingChunksSameResource)
+{
+  resource_type d1;
+  Resource r1{d1};
+  
+  // Create multiple allocations
+  std::vector<double*> ptrs;
+  for (int i = 0; i < 5; ++i) {
+    ptrs.push_back(static_cast<double*>(m_pool.allocate(1024, r1)));
+    do_sleep<<<1, 32, 0, d1.get_stream()>>>(ptrs[i]);
+  }
+  
+  // Deallocate all - should create multiple pending entries
+  for (auto ptr : ptrs) {
+    m_pool.deallocate(ptr, r1);
+  }
+  
+  EXPECT_EQ(get_num_pending(m_pool), 5);
+  
+  // Allocate with same resource - should reuse pending
+  double* new_ptr = static_cast<double*>(m_pool.allocate(1024, r1));
+  EXPECT_LT(get_num_pending(m_pool), 5); // One was reused
+  
+  m_pool.deallocate(new_ptr, r1);
+}
+
+TEST_P(ResourceAwarePoolTest, DestructorWithPendingChunks)
+{
+  auto& rm = umpire::ResourceManager::getInstance();
+  {
+    auto pool = rm.makeAllocator<umpire::strategy::ResourceAwarePool>(
+        "temp-pool" + GetParam(), rm.getAllocator(GetParam()));
+    
+    resource_type d1;
+    double* ptr = static_cast<double*>(pool.allocate(1024, d1));
+    
+    do_sleep<<<1, 32, 0, d1.get_stream()>>>(ptr);
+    
+    pool.deallocate(ptr, d1);
+    EXPECT_EQ(get_num_pending(pool), 1);
+    
+    // Pool destructor should handle pending chunks correctly
+  } // Pool destroyed here
+  
+  // Should not crash or leak
+}
+
+TEST_P(ResourceAwarePoolTest, ChunkSplittingAndMerging)
+{
+  resource_type d1;
+  
+  // Allocate large chunk
+  void* large = m_pool.allocate(4096, d1);
+  m_pool.deallocate(large, d1);
+  d1.get_event().wait();
+  
+  // Allocate smaller chunk - should split
+  void* small1 = m_pool.allocate(1024, d1);
+  void* small2 = m_pool.allocate(1024, d1);
+  
+  // Deallocate in order that promotes merging
+  m_pool.deallocate(small1, d1);
+  d1.get_event().wait();
+  m_pool.deallocate(small2, d1);
+  d1.get_event().wait();
+  
+  // Should be able to allocate large chunk again
+  void* large2 = m_pool.allocate(4096, d1);
+  EXPECT_NE(large2, nullptr);
+  
+  m_pool.deallocate(large2, d1);
+}
+
+/*
+TEST_P(ResourceAwarePoolTest, GetResourceEdgeCases)
+{
+  resource_type d1;
+  static camp::resources::Resource default_host_resource{camp::resources::Host::get_default()};
+  
+  double* ptr = static_cast<double*>(m_pool.allocate(1024, d1));
+  
+  // Valid pointer in used map
+  EXPECT_EQ(get_resource(m_pool, ptr), Resource{d1});
+  
+  // After deallocation - goes to pending
+  do_sleep<<<1, 32, 0, d1.get_stream()>>>(ptr);
+  m_pool.deallocate(ptr, d1);
+  
+  // Should still find it in pending
+  EXPECT_EQ(get_resource(m_pool, ptr), Resource{d1});
+  
+  // Wait for completion
+  d1.get_event().wait();
+  m_pool.release(); // Force processing of pending
+  
+  // Now it's free - should return warning and default
+  camp::resources::Resource res = get_resource(m_pool, ptr);
+  EXPECT_EQ(res, default_host_resource);
+  
+  // Invalid pointer
+  double* invalid_ptr = reinterpret_cast<double*>(0xDEADBEEF);
+  res = get_resource(m_pool, invalid_ptr);
+  EXPECT_EQ(res, default_host_resource);
+}
+*/
+
+TEST_P(ResourceAwarePoolTest, StressTestMultipleResources)
+{
+  const int num_iterations = 100;
+  std::vector<resource_type> resources(4);
+  std::vector<void*> allocations;
+  std::vector<Resource> allocation_resources;
+  
+  for (int i = 0; i < num_iterations; ++i) {
+    int res_idx = i % resources.size();
+    resource_type& res = resources[res_idx];
+    
+    void* ptr = m_pool.allocate(512 + (i * 128) % 2048, res);
+    allocations.push_back(ptr);
+    allocation_resources.push_back(Resource{res});
+    
+    // Deallocate some
+    if (i > 10 && i % 3 == 0) {
+      int idx = (i - 10) / 2;
+      m_pool.deallocate(allocations[idx], allocation_resources[idx]);
+      allocations[idx] = nullptr;
+    }
+  }
+  
+  // Clean up remaining
+  for (size_t i = 0; i < allocations.size(); ++i) {
+    if (allocations[i]) {
+      m_pool.deallocate(allocations[i], allocation_resources[i]);
+    }
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(ResourceAwarePoolTests, ResourceAwarePoolTest, ::testing::ValuesIn(get_allocator_strings()));
 
 #endif


### PR DESCRIPTION
Updating the `PendingList` to a `PendingMap`, including:
- storing an iterator for each pending chunk
- using an unordered multimap for the pending map with key `std::optional<Resource>` and `Chunk*` values
- In release function, pending chunks (if finished) are freed directly instead of being copied to the free map first

Waiting on [Camp PR](https://github.com/LLNL/camp/pull/190) to get merged first, then this will include a Camp update