### PR TITLE
BUGFIX: add virtual destructor for event_store

### DIFF
--- a/src/umpire/event/event_store.hpp
+++ b/src/umpire/event/event_store.hpp
@@ -22,6 +22,8 @@ struct deallocate_resource;
 
 class event_store {
  public:
+  virtual ~event_store() = default;
+
   virtual void insert(const event& e) = 0;
   virtual void insert(const allocate& e) = 0;
   virtual void insert(const named_allocate& e) = 0;


### PR DESCRIPTION
This removes a clang compiler warning to reduce the risk of deleting event_store through a base pointer.

Local copy of #1024 