### PR TITLE
Add `.mailmap` file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,74 @@
-David Beckingsale <davidbeckingsale@gmail.com> David Beckingsale <beckingsale1@llnl.gov>
-David Beckingsale <davidbeckingsale@gmail.com> David Alexander Beckingsale <beckingsale1@llnl.gov>
-Marty McFadden <mcfadden8@llnl.gov> Marty McFadden <mcfadden8@users.noreply.github.com>
-Marty McFadden <mcfadden8@llnl.gov> Marty Mcfadden <mcfadden8@llnl.gov>
-Johann Dahm <johann.dahm@ibm.com> Johann Dahm <johann.dahm@gmail.com>
+Abhishek Bagusetty    <abagusetty@anl.gov>              Abhishek Bagusetty          <59661409+abagusetty@users.noreply.github.com>
+Adrien Bernede        <bernede1@llnl.gov>               Adrien Bernede              <51493078+adrienbernede@users.noreply.github.com>
+Adrien Bernede        <bernede1@llnl.gov>               Adrien M. BERNEDE           <bernede1@llnl.gov>
+Adrien Bernede        <bernede1@llnl.gov>               Adrien M. Bernede           <bernede1@llnl.gov>
+Aileen Perez          <perezaileen9111@gmail.com>       Aileen                      <45980757+aileenperez@users.noreply.github.com>
+Aileen Perez          <perezaileen9111@gmail.com>       Aileen Perez                <45980757+aileenperez@users.noreply.github.com>
+David Beckingsale     <davidbeckingsale@gmail.com>      David Alexander Beckingsale <beckingsale1@llnl.gov>
+David Beckingsale     <davidbeckingsale@gmail.com>      David Alexander Beckingsale <beckingsale1@llnl.gov>
+David Beckingsale     <davidbeckingsale@gmail.com>      David Beckingsale           <beckingsale1@llnl.gov>
+David Beckingsale     <davidbeckingsale@gmail.com>      David Beckingsale           <beckingsale1@llnl.gov>
+Eduard Valeyev        <eduard@valeyev.net>              Eduard Valeyev              <eduard.valeyev@gmail.com>
+George Zagaris        <george.zagaris@gmail.com>        George Zagaris              <george.zagaris@us.af.mil>
+George Zagaris        <george.zagaris@gmail.com>        George Zagaris              <zagaris2@llnl.gov>
+Johann Dahm           <johann.dahm@ibm.com>             Johann Dahm                 <johann.dahm@gmail.com>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi                      <belcher6@llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi                      <belcher6@rzansel25.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi                      <belcher6@rzansel61.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@capella.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona161.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona162.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona163.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona170.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona211.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona212.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona82.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona89.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona90.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona91.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona93.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@corona94.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen110.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen133.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen134.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen181.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen190.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen211.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen217.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen272.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen308.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen330.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen336.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen341.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen349.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen38.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen401.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen406.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen41.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen411.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen426.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen459.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen465.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen511.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen582.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen588.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen602.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen607.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen613.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen616.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen639.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen676.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen708.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen709.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen730.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen731.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen732.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen737.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen763.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@lassen77.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@quartz386.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@quartz770.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@rzansel61.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@rzansel9.coral.llnl.gov>
+Kristi Belcher        <belcher6@llnl.gov>               Kristi Belcher              <belcher6@rzgenie2.llnl.gov>
+Marty McFadden        <mcfadden8@llnl.gov>              Marty Mcfadden              <mcfadden8@llnl.gov>


### PR DESCRIPTION
This will clean up the output of commands like `git shortlog` that aggregate work by different users. e.g., Kristi has used 59 different emails in the Umpire project.

It unfortunately looks like GitHub's own stats do not account for this, but if we do analytics on umpire, e.g., with [`contrib`](https://github.com/spack/contrib), this will help.