### PR TITLE
Add C API for untracked quick pool

### DIFF
--- a/src/umpire/interface/c_fortran/wrapResourceManager.cpp
+++ b/src/umpire/interface/c_fortran/wrapResourceManager.cpp
@@ -153,6 +153,26 @@ umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool(
     // splicer end class.ResourceManager.method.make_allocator_quick_pool
 }
 
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_quick_pool_untracked
+    const std::string SHCXX_name(name);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::QuickPool, false>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_quick_pool_untracked
+}
+
 umpire_allocator * umpire_resourcemanager_make_allocator_bufferify_quick_pool(
     umpire_resourcemanager * self, const char * name, int Lname,
     umpire_allocator allocator, size_t initial_size, size_t block,

--- a/src/umpire/interface/c_fortran/wrapResourceManager.h
+++ b/src/umpire/interface/c_fortran/wrapResourceManager.h
@@ -61,6 +61,11 @@ umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool(
     umpire_allocator allocator, size_t initial_size, size_t block,
     umpire_allocator * SHC_rv);
 
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    umpire_allocator * SHC_rv);
+
 umpire_allocator * umpire_resourcemanager_make_allocator_bufferify_quick_pool(
     umpire_resourcemanager * self, const char * name, int Lname,
     umpire_allocator allocator, size_t initial_size, size_t block,


### PR DESCRIPTION
Add C API `umpire_resourcemanager_make_allocator_quick_pool_untracked` to create a QuickPool with tracking disabled. 

This allows C libraries like hypre to avoid per-allocation introspection overhead. Preliminary experiments show speedup in AMG setup time by up to 1.3x when using Umpire for host memory.

cc @Sbozzolo @v-dobrev 
