### PR TITLE
Add GitLab CI foldable sections to build script

### DIFF
--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -314,7 +314,12 @@ then
     else
         section_end
         section_start "install" "Installing Umpire" "collapsed"
-        $cmake_exe --install .
+        if ! $cmake_exe --install .
+        then
+            section_end
+            echo "[Error]: Installation failed."
+            exit 1
+        fi
         section_end
     fi
 fi

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -58,7 +58,7 @@ section_start ()
     local collapsed="false"
     if [[ "${section_state}" == "collapsed" ]]
     then
-        local collapsed="true"
+        collapsed="true"
     fi
 
     # Generate unique section ID

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -69,6 +69,27 @@ print_info ()
     echo -e "[Information]: ${info_msg}"
 }
 
+# Portable UTC timestamp formatter for epoch seconds.
+format_utc_timestamp ()
+{
+    local timestamp="${1}"
+    # BSD/macOS date supports epoch conversion via: date -r <seconds>
+    if date -u -r "${timestamp}" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1
+    then
+        date -u -r "${timestamp}" "+%Y-%m-%dT%H:%M:%SZ"
+    else
+        # GNU date supports epoch conversion via: date -d "@<seconds>"
+        date -u -d "@${timestamp}" "+%Y-%m-%dT%H:%M:%SZ"
+    fi
+}
+
+# Portable elapsed time formatter (HH:MM:SS).
+format_elapsed_hms ()
+{
+    local elapsed="${1}"
+    printf '%02d:%02d:%02d' $((elapsed / 3600)) $(((elapsed % 3600) / 60)) $((elapsed % 60))
+}
+
 # GitLab CI collapsible section helpers with nesting support
 section_start ()
 {
@@ -87,9 +108,9 @@ section_start ()
     local section_id="${section_name}_${section_counter}"
 
     local timestamp=$(date +%s)
-    local current_time=$(date -d @${timestamp} --rfc-3339=seconds)
+    local current_time=$(format_utc_timestamp "${timestamp}")
     local total_elapsed=$((timestamp - script_start_time))
-    local total_elapsed_formatted=$(date -d @${total_elapsed} -u +%H:%M:%S)
+    local total_elapsed_formatted=$(format_elapsed_hms "${total_elapsed}")
 
     # Store section start time for later calculation
     section_start_times[${section_id}]=${timestamp}
@@ -122,14 +143,14 @@ section_end ()
     unset section_id_stack[$stack_index]
 
     local timestamp=$(date +%s)
-    local current_time=$(date -d @${timestamp} --rfc-3339=seconds)
+    local current_time=$(format_utc_timestamp "${timestamp}")
     local total_elapsed=$((timestamp - script_start_time))
-    local total_elapsed_formatted=$(date -d @${total_elapsed} -u +%H:%M:%S)
+    local total_elapsed_formatted=$(format_elapsed_hms "${total_elapsed}")
 
     # Calculate section elapsed time
     local section_start=${section_start_times[${section_id}]:-${timestamp}}
     local section_elapsed=$((timestamp - section_start))
-    local section_elapsed_formatted=$(date -d @${section_elapsed} -u +%H:%M:%S)
+    local section_elapsed_formatted=$(format_elapsed_hms "${section_elapsed}")
 
     echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K\033[0m"
     echo "\033[90m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}\033[0m"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -139,6 +139,25 @@ section_end ()
     unset section_start_times[${section_id}]
 }
 
+# For convenience, a helper function to run a command within a section and handle errors
+run_section() {
+    local id="$1"
+    local title="$2"
+    local collapsed="$3"
+    local err_msg="$4"
+    shift 4
+
+    section_start "$id" "$title" "$collapsed"
+    "$@"
+    local status=$?
+    section_end
+
+    if [[ $status -ne 0 ]]; then
+        print_error "$err_msg"
+        exit $status
+    fi
+}
+
 if [[ ${debug_mode} == true ]]
 then
     print_info "Debug mode:"
@@ -196,8 +215,7 @@ then
 
     if [[ -z ${spec} ]]
     then
-        section_end
-        print_error "SPEC is undefined, aborting..."
+        section_end ; print_error "SPEC is undefined, aborting..."
         exit 1
     fi
 
@@ -212,26 +230,26 @@ then
     mkdir -p ${spack_user_cache}
 
     # generate cmake cache file with uberenv and radiuss spack package
-    section_start "spack_setup" "Spack setup and environment" "collapsed"
-    ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
-    section_end
+    run_section "spack_setup" "Spack setup and environment" "collapsed" \
+      "Spack environment setup failed (Uberenv)" \
+      ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
     if [[ -n ${ci_registry_token} ]]
     then
-        section_start "registry_setup" "GitLab registry as Spack Buildcache" "collapsed"
-        ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username-variable ci_registry_user --oci-password-variable ci_registry_token gitlab_ci oci://${ci_registry_image}
-        section_end
+        run_section "registry_setup" "GitLab registry as Spack Buildcache" "collapsed" \
+          "Adding gitlab registry to spack environment failed" \
+          ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username-variable ci_registry_user --oci-password-variable ci_registry_token gitlab_ci oci://${ci_registry_image}
     fi
 
-    section_start "spack_build" "Spack build of dependencies" "collapsed"
-    ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
-    section_end
+    run_section "spack_build" "Spack build of dependencies" "collapsed" \
+      "Spack build of dependencies failed (Uberenv)" \
+      ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
     if [[ -n ${ci_registry_token} && ${push_to_registry} == true ]]
     then
-        section_start "buildcache_push" "Push dependencies to buildcache" "collapsed"
-        ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
-        section_end
+        run_section "buildcache_push" "Push dependencies to buildcache" "collapsed" \
+          "Pushing dependencies to gitlab registry failed" \
+          ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
     fi
 
     section_end
@@ -312,8 +330,7 @@ then
       ${project_dir}
       then
         status=$?
-        section_end
-        print_error "CMake configuration failed, dumping output..."
+        section_end ; print_error "CMake configuration failed, dumping output..."
 
         $cmake_exe \
           -C ${hostconfig_path} \
@@ -329,8 +346,7 @@ then
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
         status=$?
-        section_end
-        print_error "Compilation failed, building with verbose output..."
+        section_end ; print_error "Compilation failed, building with verbose output..."
 
         section_start "build_verbose" "Verbose Rebuild"
         $cmake_exe --build . --verbose -j 1
@@ -344,8 +360,7 @@ then
     if ! $cmake_exe --install .
     then
         status=$?
-        section_end
-        print_error "Installation failed."
+        section_end ; print_error "Installation failed."
 
         exit ${status}
     fi
@@ -379,8 +394,7 @@ then
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
     then
-        section_end
-        print_error "No tests were found"
+        section_end ; print_error "No tests were found"
         exit ${ctest_status}
     fi
 
@@ -390,8 +404,7 @@ then
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        section_end
-        print_error "Failure(s) while running CTest"
+        section_end ; print_error "Failure(s) while running CTest"
         exit ${ctest_status}
     fi
     section_end
@@ -399,27 +412,23 @@ then
     section_start "install_test" "Testing Installed Examples" "collapsed"
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
-        section_end
-        print_warning "Not testing install with HIP"
+        section_end ; print_warning "Not testing install with HIP"
     else
         if [[ ! -d ${install_dir} ]]
         then
-            section_end
-            print_error "Install directory not found : ${install_dir}"
+            section_end ; print_error "Install directory not found : ${install_dir}"
             exit 1
         fi
 
         cd ${install_dir}/examples/umpire/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then
-            section_end
-            print_error "Running $cmake_exe for using-with-cmake test"
+            section_end ; print_error "Running $cmake_exe for using-with-cmake test"
             exit 1
         fi
 
         if ! make; then
-            section_end
-            print_error "Running make for using-with-cmake test"
+            section_end ; print_error "Running make for using-with-cmake test"
             exit 1
         fi
         section_end

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -182,7 +182,7 @@ mkdir -p ${prefix}
 
 spack_cmd="${prefix}/spack/bin/spack"
 spack_env_path="${prefix}/spack_env"
-uberenv_cmd="./scripts/uberenv/uberenv.py"
+uberenv_cmd="${project_dir}/scripts/uberenv/uberenv.py"
 if [[ ${spack_debug} == true ]]
 then
     spack_cmd="${spack_cmd} --debug --stacktrace"
@@ -332,7 +332,9 @@ then
         section_end
         print_error "Compilation failed, building with verbose output..."
 
+        section_start "build_verbose" "Verbose Rebuild"
         $cmake_exe --build . --verbose -j 1
+        section_end
 
         exit ${status}
     fi
@@ -365,11 +367,6 @@ then
     section_start "tests" "Running Tests" "collapsed"
     ctest --output-on-failure --no-compress-output -T test -VV 2>&1 | tee tests_output.txt
     ctest_status=${PIPESTATUS[0]}
-    if [[ ${ctest_status} -ne 0 ]]
-    then
-        section_end
-        exit ${ctest_status}
-    fi
 
     # If Developer benchmarks enabled, run the no-op benchmark and show output
     if [[ "${option}" != "--build-only" ]] && grep -q -i "UMPIRE_ENABLE_DEVELOPER_BENCHMARKS.*ON" ${hostconfig_path}
@@ -384,7 +381,7 @@ then
     then
         section_end
         print_error "No tests were found"
-        exit 1
+        exit ${ctest_status}
     fi
 
     tree Testing
@@ -395,7 +392,7 @@ then
     then
         section_end
         print_error "Failure(s) while running CTest"
-        exit 1
+        exit ${ctest_status}
     fi
     section_end
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -148,11 +148,9 @@ run_section() {
     shift 4
 
     section_start "$id" "$title" "$collapsed"
-    "$@"
-    local status=$?
-    section_end
-
-    if [[ $status -ne 0 ]]; then
+    if ! "$@"; then
+        status=$?
+        section_end
         print_error "$err_msg"
         exit $status
     fi
@@ -260,7 +258,7 @@ if [[ -z ${hostconfig} ]]
 then
     # If no host config file was provided, we assume it was generated.
     # This means we are looking of a unique one in project dir.
-    hostconfigs=( $( ls "${project_dir}/"*.cmake ) )
+    shopt -s nullglob; hostconfigs=( "${project_dir}"/*.cmake ); shopt -u nullglob
     if [[ ${#hostconfigs[@]} == 1 ]]
     then
         hostconfig_path=${hostconfigs[0]}
@@ -386,9 +384,7 @@ then
     # If Developer benchmarks enabled, run the no-op benchmark and show output
     if [[ "${option}" != "--build-only" ]] && grep -q -i "UMPIRE_ENABLE_DEVELOPER_BENCHMARKS.*ON" ${hostconfig_path}
     then
-        date
         ctest --verbose -C Benchmark -R no-op_stress_test
-        date
     fi
 
     no_test_str="No tests were found!!!"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -342,6 +342,12 @@ then
 
     section_start "tests" "Running Tests" "collapsed"
     ctest --output-on-failure --no-compress-output -T test -VV 2>&1 | tee tests_output.txt
+    ctest_status=${PIPESTATUS[0]}
+    if [[ ${ctest_status} -ne 0 ]]
+    then
+        section_end
+        exit ${ctest_status}
+    fi
 
     # If Developer benchmarks enabled, run the no-op benchmark and show output
     if [[ "${option}" != "--build-only" ]] && grep -q -i "UMPIRE_ENABLE_DEVELOPER_BENCHMARKS.*ON" ${hostconfig_path}

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -69,10 +69,10 @@ section_start ()
     # Push section ID onto stack
     section_id_stack+=("${section_id}")
 
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~ TIME                      | TOTAL    | SECTION  "
-    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_title}"
-    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K~ ${section_indent}${section_title}"
+    echo "${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "${section_indent}~ TIME                      | TOTAL    | SECTION  "
+    echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_title}"
+    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K${section_indent}~ ${section_title}"
 
     # Increase indentation for nested sections
     section_indent="${section_indent}  "
@@ -104,8 +104,8 @@ section_end ()
     local section_elapsed_formatted=$(date -d @${section_elapsed} -u +%H:%M:%S)
 
     echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K"
-    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_elapsed_formatted}"
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}"
+    echo "${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     # Clean up stored time
     unset section_start_times[${section_id}]
@@ -126,9 +126,8 @@ fi
 
 if [[ -n ${module_list} ]]
 then
-    section_start "module_load" "Loading modules: ${module_list}"
+    echo "Loading modules: ${module_list}"
     module load ${module_list}
-    section_end
 fi
 
 prefix=""

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -175,6 +175,7 @@ run_section() {
         print_error "$err_msg"
         exit $status
     fi
+    section_end
 }
 
 if [[ ${debug_mode} == true ]]

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -44,6 +44,22 @@ timed_message ()
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 }
 
+# GitLab CI collapsible section helpers
+section_start ()
+{
+    local section_id="${1}"
+    local section_title="${2}"
+    local timestamp=$(date +%s)
+    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K${section_title}"
+}
+
+section_end ()
+{
+    local section_id="${1}"
+    local timestamp=$(date +%s)
+    echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K"
+}
+
 if [[ ${debug_mode} == true ]]
 then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -100,6 +116,7 @@ fi
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
     timed_message "Building dependencies"
+    section_start "dependencies" "Building Dependencies"
 
     if [[ -z ${spec} ]]
     then
@@ -136,6 +153,7 @@ then
         ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
     fi
 
+    section_end "dependencies"
     timed_message "Dependencies built"
 fi
 
@@ -209,19 +227,29 @@ then
         cmake_options="-DBLT_MPI_COMMAND_APPEND:STRING=--overlap"
     fi
 
+    section_start "cmake_config" "CMake Configuration"
     $cmake_exe \
       -C ${hostconfig_path} \
       ${cmake_options} \
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
+    section_end "cmake_config"
+
+    section_start "build" "Building Umpire"
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
+        section_end "build"
         echo "[Error]: Compilation failed, building with verbose output..."
         timed_message "Re-building with --verbose"
+        section_start "build_verbose" "Verbose Rebuild"
         $cmake_exe --build . --verbose -j 1
+        section_end "build_verbose"
     else
+        section_end "build"
         timed_message "Installing"
+        section_start "install" "Installing Umpire"
         $cmake_exe --install .
+        section_end "install"
     fi
 
     timed_message "Umpire built and installed"
@@ -239,6 +267,7 @@ then
     cd ${build_dir}
 
     timed_message "Testing Umpire"
+    section_start "tests" "Running Tests"
     ctest --output-on-failure --no-compress-output -T test -VV 2>&1 | tee tests_output.txt
 
     # If Developer benchmarks enabled, run the no-op benchmark and show output
@@ -248,6 +277,7 @@ then
         ctest --verbose -C Benchmark -R no-op_stress_test
         date
     fi
+    section_end "tests"
 
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
@@ -256,9 +286,11 @@ then
     fi
 
     timed_message "Preparing tests xml reports for export"
+    section_start "test_xml" "Processing Test XML Reports"
     tree Testing
     xsltproc -o junit.xml ${project_dir}/scripts/radiuss-spack-configs/utilities/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml
+    section_end "test_xml"
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
@@ -274,6 +306,7 @@ then
             echo "[Error]: Install directory not found : ${install_dir}" && exit 1
         fi
 
+        section_start "install_test" "Testing Installed Examples"
         cd ${install_dir}/examples/umpire/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then
@@ -283,6 +316,7 @@ then
         if ! make; then
             echo "[Error]: Running make for using-with-cmake test" && exit 1
         fi
+        section_end "install_test"
     fi
 
     timed_message "Umpire tests completed"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -410,8 +410,8 @@ then
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
     then
-        section_end ; print_error "No tests were found"
-        exit ${ctest_status}
+        section_end ; print_error "No tests were found (ctest status: ${ctest_status})"
+        exit 1
     fi
 
     tree Testing
@@ -420,8 +420,8 @@ then
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        section_end ; print_error "Failure(s) while running CTest"
-        exit ${ctest_status}
+        section_end ; print_error "Failure(s) while running CTest (ctest status: ${ctest_status})"
+        exit 1
     fi
     section_end
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -166,16 +166,18 @@ run_section() {
     local title="$2"
     local collapsed="$3"
     local err_msg="$4"
+    local status=0
     shift 4
 
     section_start "$id" "$title" "$collapsed"
-    if ! "$@"; then
+    if "$@"; then
+        section_end
+    else
         status=$?
         section_end
         print_error "$err_msg"
         exit $status
     fi
-    section_end
 }
 
 if [[ ${debug_mode} == true ]]

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -40,61 +40,71 @@ export ci_registry_token=${CI_JOB_TOKEN:-"${registry_token}"}
 # Track script start time for elapsed time calculations
 script_start_time=$(date +%s)
 
-# Format seconds to HH:MM:SS
-format_time ()
-{
-    local total_seconds=${1}
-    local hours=$((total_seconds / 3600))
-    local minutes=$(( (total_seconds % 3600) / 60 ))
-    local seconds=$((total_seconds % 60))
-    printf "%02d:%02d:%02d" ${hours} ${minutes} ${seconds}
-}
-
-# Storage for section start times (non-nested)
+# Storage for section start times (supports nesting)
 declare -A section_start_times
 
-# Legacy timed_message function (to be replaced with timed sections in future)
-timed_message ()
-{
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~ $(date --rfc-3339=seconds) ~ ${1}"
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-}
+# Section stack for tracking nested sections
+section_id_stack=()
+section_counter=0
+section_indent=""
 
-# GitLab CI collapsible section helpers
+# GitLab CI collapsible section helpers with nesting support
 section_start ()
 {
-    local section_id="${1}"
+    local section_name="${1}"
     local section_title="${2}"
+
+    # Generate unique section ID
+    section_counter=$((section_counter + 1))
+    local section_id="${section_name}_${section_counter}"
+
     local timestamp=$(date +%s)
-    local current_time=$(date --rfc-3339=seconds)
+    local current_time=$(date -d @${timestamp} --rfc-3339=seconds)
     local total_elapsed=$((timestamp - script_start_time))
-    local total_elapsed_formatted=$(format_time ${total_elapsed})
+    local total_elapsed_formatted=$(date -d @${total_elapsed} -u +%H:%M:%S)
 
     # Store section start time for later calculation
     section_start_times[${section_id}]=${timestamp}
 
+    # Push section ID onto stack
+    section_id_stack+=("${section_id}")
+
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "~ TIME                      | TOTAL    | SECTION  "
-    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_title}"
-    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K~ ${section_title}"
+    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_title}"
+    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K~ ${section_indent}${section_title}"
+
+    # Increase indentation for nested sections
+    section_indent="${section_indent}  "
 }
 
 section_end ()
 {
-    local section_id="${1}"
+    # Pop section ID from stack
+    if [[ ${#section_id_stack[@]} -eq 0 ]]; then
+        echo "[Warning]: section_end called with empty stack"
+        return 1
+    fi
+
+    # Decrease indentation before displaying
+    section_indent="${section_indent%  }"
+
+    local stack_index=$((${#section_id_stack[@]} - 1))
+    local section_id="${section_id_stack[$stack_index]}"
+    unset section_id_stack[$stack_index]
+
     local timestamp=$(date +%s)
-    local current_time=$(date --rfc-3339=seconds)
+    local current_time=$(date -d @${timestamp} --rfc-3339=seconds)
     local total_elapsed=$((timestamp - script_start_time))
-    local total_elapsed_formatted=$(format_time ${total_elapsed})
+    local total_elapsed_formatted=$(date -d @${total_elapsed} -u +%H:%M:%S)
 
     # Calculate section elapsed time
     local section_start=${section_start_times[${section_id}]:-${timestamp}}
     local section_elapsed=$((timestamp - section_start))
-    local section_elapsed_formatted=$(format_time ${section_elapsed})
+    local section_elapsed_formatted=$(date -d @${section_elapsed} -u +%H:%M:%S)
 
     echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K"
-    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}"
+    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_elapsed_formatted}"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     # Clean up stored time
@@ -116,8 +126,9 @@ fi
 
 if [[ -n ${module_list} ]]
 then
-    timed_message "Modules to load: ${module_list}"
+    section_start "module_load" "Loading modules: ${module_list}"
     module load ${module_list}
+    section_end
 fi
 
 prefix=""
@@ -156,7 +167,6 @@ fi
 # Dependencies
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
-    timed_message "Building dependencies"
     section_start "dependencies" "Building Dependencies"
 
     if [[ -z ${spec} ]]
@@ -176,26 +186,29 @@ then
     mkdir -p ${spack_user_cache}
 
     # generate cmake cache file with uberenv and radiuss spack package
-    timed_message "Spack setup and environment"
+    section_start "spack_setup" "Spack setup and environment"
     ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
+    section_end
 
     if [[ -n ${ci_registry_token} ]]
     then
-        timed_message "GitLab registry as Spack Buildcache"
+        section_start "registry_setup" "GitLab registry as Spack Buildcache"
         ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username-variable ci_registry_user --oci-password-variable ci_registry_token gitlab_ci oci://${ci_registry_image}
+        section_end
     fi
 
-    timed_message "Spack build of dependencies"
+    section_start "spack_build" "Spack build of dependencies"
     ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
+    section_end
 
     if [[ -n ${ci_registry_token} && ${push_to_registry} == true ]]
     then
-        timed_message "Push dependencies to buildcache"
+        section_start "buildcache_push" "Push dependencies to buildcache"
         ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
+        section_end
     fi
 
-    section_end "dependencies"
-    timed_message "Dependencies built"
+    section_end
 fi
 
 # Find cmake cache file (hostconfig)
@@ -246,8 +259,8 @@ then
     echo "~~~~~ Install Dir: ${install_dir}"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo ""
-    timed_message "Cleaning working directory"
 
+    section_start "clean" "Cleaning working directory"
     # Map CPU core allocations
     declare -A core_counts=(["lassen"]=40 ["poodle"]=28 ["dane"]=28 ["matrix"]=28 ["corona"]=32 ["rzansel"]=48 ["tioga"]=32 ["tuolumne"]=48)
 
@@ -257,8 +270,8 @@ then
     #       use max cores.
     rm -rf ${build_dir} 2>/dev/null
     mkdir -p ${build_dir} && cd ${build_dir}
+    section_end
 
-    timed_message "Building Umpire"
     # We set the MPI tests command to allow overlapping.
     # Shared allocation: Allows build_and_test.sh to run within a sub-allocation (see CI config).
     # Use /dev/shm: Prevent MPI tests from running on a node where the build dir doesn't exist.
@@ -274,26 +287,22 @@ then
       ${cmake_options} \
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
-    section_end "cmake_config"
+    section_end
 
     section_start "build" "Building Umpire"
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
-        section_end "build"
+        section_end
         echo "[Error]: Compilation failed, building with verbose output..."
-        timed_message "Re-building with --verbose"
         section_start "build_verbose" "Verbose Rebuild"
         $cmake_exe --build . --verbose -j 1
-        section_end "build_verbose"
+        section_end
     else
-        section_end "build"
-        timed_message "Installing"
+        section_end
         section_start "install" "Installing Umpire"
         $cmake_exe --install .
-        section_end "install"
+        section_end
     fi
-
-    timed_message "Umpire built and installed"
 fi
 
 # Test
@@ -307,7 +316,6 @@ then
 
     cd ${build_dir}
 
-    timed_message "Testing Umpire"
     section_start "tests" "Running Tests"
     ctest --output-on-failure --no-compress-output -T test -VV 2>&1 | tee tests_output.txt
 
@@ -318,7 +326,7 @@ then
         ctest --verbose -C Benchmark -R no-op_stress_test
         date
     fi
-    section_end "tests"
+    section_end
 
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
@@ -326,12 +334,11 @@ then
         echo "[Error]: No tests were found" && exit 1
     fi
 
-    timed_message "Preparing tests xml reports for export"
     section_start "test_xml" "Processing Test XML Reports"
     tree Testing
     xsltproc -o junit.xml ${project_dir}/scripts/radiuss-spack-configs/utilities/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml
-    section_end "test_xml"
+    section_end
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
@@ -357,10 +364,8 @@ then
         if ! make; then
             echo "[Error]: Running make for using-with-cmake test" && exit 1
         fi
-        section_end "install_test"
+        section_end
     fi
-
-    timed_message "Umpire tests completed"
 fi
 
 #timed_message "Cleaning up"
@@ -368,4 +373,6 @@ fi
 
 cd ${project_dir}
 
-timed_message "Build and test completed"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "~ Build and test completed"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -110,7 +110,7 @@ section_end ()
 {
     # Pop section ID from stack
     if [[ ${#section_id_stack[@]} -eq 0 ]]; then
-        echo "[Warning]: section_end called with empty stack"
+        print_warning "section_end called with empty stack"
         return 1
     fi
 
@@ -400,7 +400,7 @@ then
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
         section_end
-        echo "[Warning]: Not testing install with HIP"
+        print_warning "Not testing install with HIP"
     else
         if [[ ! -d ${install_dir} ]]
         then

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -292,11 +292,16 @@ then
         section_end
         echo "[Error]: CMake configuration failed, dumping output..."
         section_start "cmake_config_verbose" "Verbose CMake Configuration"
-        $cmake_exe \
+        if ! $cmake_exe \
           -C ${hostconfig_path} \
           ${cmake_options} \
           -DCMAKE_INSTALL_PREFIX=${install_dir} \
           ${project_dir} --debug-output --trace-expand
+        then
+          verbose_status=$?
+          section_end
+          exit ${verbose_status}
+        fi
         section_end
         exit 1
       else

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -29,6 +29,8 @@ fi
 set -o errexit
 set -o nounset
 
+exec 2>&1
+
 option=${1:-""}
 hostname="$(hostname)"
 truehostname=${hostname//[0-9]/}
@@ -339,7 +341,7 @@ build_root=${BUILD_ROOT:-"${prefix}"}
 build_dir="${build_root}/build_${hostconfig//.cmake/}"
 install_dir="${build_root}/install_${hostconfig//.cmake/}"
 
-cmake_exe=`grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs`
+cmake_exe=$(grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs 2>/dev/null)
 
 if [[ "${option}" != "--deps-only" && "${option}" != "--test-only" ]]
 then

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -13,6 +13,19 @@ fi
 # SPDX-License-Identifier: (MIT)
 ###############################################################################
 
+# Navigation:
+# - VARIABLES
+# - HELPER FUNCTIONS
+# - SETUP
+# - BUILD DEPENDENCIES
+# - HOST CONFIG / CMAKE CACHE FILES
+# - BUILD PROJECT
+# - TEST PROJECT
+
+###############################################################################
+# VARIABLES
+###############################################################################
+
 set -o errexit
 set -o nounset
 
@@ -37,16 +50,9 @@ ci_registry_image=${CI_REGISTRY_IMAGE:-"czregistry.llnl.gov:5050/radiuss/umpire"
 export ci_registry_user=${CI_REGISTRY_USER:-"${USER}"}
 export ci_registry_token=${CI_JOB_TOKEN:-"${registry_token}"}
 
-# Track script start time for elapsed time calculations
-script_start_time=$(date +%s)
-
-# Storage for section start times (supports nesting)
-declare -A section_start_times
-
-# Section stack for tracking nested sections
-section_id_stack=()
-section_counter=0
-section_indent=""
+###############################################################################
+# HELPER FUNCTIONS
+###############################################################################
 
 # Helper function to print errors in red
 print_error ()
@@ -89,6 +95,17 @@ format_elapsed_hms ()
     local elapsed="${1}"
     printf '%02d:%02d:%02d' $((elapsed / 3600)) $(((elapsed % 3600) / 60)) $((elapsed % 60))
 }
+
+# Track script start time for elapsed time calculations
+script_start_time=$(date +%s)
+
+# Storage for section start times (supports nesting)
+declare -A section_start_times
+
+# Section stack for tracking nested sections
+section_id_stack=()
+section_counter=0
+section_indent=""
 
 # GitLab CI collapsible section helpers with nesting support
 section_start ()
@@ -180,6 +197,10 @@ run_section() {
     fi
 }
 
+###############################################################################
+# SETUP
+###############################################################################
+
 if [[ ${debug_mode} == true ]]
 then
     print_info "Debug mode:"
@@ -230,7 +251,9 @@ then
     uberenv_cmd="${uberenv_cmd} --spack-debug"
 fi
 
-# Dependencies
+###############################################################################
+# BUILD DEPENDENCIES
+###############################################################################
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
     section_start "dependencies" "Building Dependencies"
@@ -277,7 +300,9 @@ then
     section_end
 fi
 
-# Find cmake cache file (hostconfig)
+###############################################################################
+# HOST CONFIG / CMAKE CACHE FILE
+###############################################################################
 if [[ -z ${hostconfig} ]]
 then
     # If no host config file was provided, we assume it was generated.
@@ -305,7 +330,9 @@ fi
 hostconfig=$(basename ${hostconfig_path})
 print_info "Found hostconfig ${hostconfig_path}"
 
-# Build Directory
+###############################################################################
+# BUILD PROJECT
+###############################################################################
 # When using /dev/shm, we use prefix for both spack builds and source build, unless BUILD_ROOT was defined
 build_root=${BUILD_ROOT:-"${prefix}"}
 
@@ -314,7 +341,6 @@ install_dir="${build_root}/install_${hostconfig//.cmake/}"
 
 cmake_exe=`grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs`
 
-# Build
 if [[ "${option}" != "--deps-only" && "${option}" != "--test-only" ]]
 then
     print_info "Prefix       ${prefix}"
@@ -385,7 +411,9 @@ then
       $cmake_exe --install .
 fi
 
-# Test
+###############################################################################
+# TEST PROJECT
+###############################################################################
 if [[ "${option}" != "--build-only" ]] && grep -q -i "ENABLE_TESTS.*ON" ${hostconfig_path}
 then
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -48,6 +48,13 @@ section_id_stack=()
 section_counter=0
 section_indent=""
 
+# Helper function to print errors in red
+print_error ()
+{
+    local error_msg="${1}"
+    echo -e "\e[31m[Error]: ${error_msg}\e[0m"
+}
+
 # GitLab CI collapsible section helpers with nesting support
 section_start ()
 {
@@ -175,7 +182,8 @@ then
 
     if [[ -z ${spec} ]]
     then
-        echo "[Error]: SPEC is undefined, aborting..."
+        section_end
+        print_error "SPEC is undefined, aborting..."
         exit 1
     fi
 
@@ -226,13 +234,13 @@ then
         hostconfig_path=${hostconfigs[0]}
     elif [[ ${#hostconfigs[@]} == 0 ]]
     then
-        echo "[Error]: No result for: ${project_dir}/*.cmake"
-        echo "[Error]: Spack generated host-config not found."
+        print_error "No result for: ${project_dir}/*.cmake"
+        print_error "Spack generated host-config not found."
         exit 1
     else
-        echo "[Error]: More than one result for: ${project_dir}/*.cmake"
-        echo "[Error]: ${hostconfigs[@]}"
-        echo "[Error]: Please specify one with HOST_CONFIG variable"
+        print_error "More than one result for: ${project_dir}/*.cmake"
+        print_error "${hostconfigs[@]}"
+        print_error "Please specify one with HOST_CONFIG variable"
         exit 1
     fi
 else
@@ -290,7 +298,7 @@ then
       ${project_dir}
       then
         section_end
-        echo "[Error]: CMake configuration failed, dumping output..."
+        print_error "CMake configuration failed, dumping output..."
         section_start "cmake_config_verbose" "Verbose CMake Configuration"
         if ! $cmake_exe \
           -C ${hostconfig_path} \
@@ -312,7 +320,7 @@ then
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
         section_end
-        echo "[Error]: Compilation failed, building with verbose output..."
+        print_error "Compilation failed, building with verbose output..."
         section_start "build_verbose" "Verbose Rebuild" "collapsed"
         $cmake_exe --build . --verbose -j 1
         section_end
@@ -322,7 +330,7 @@ then
         if ! $cmake_exe --install .
         then
             section_end
-            echo "[Error]: Installation failed."
+            print_error "Installation failed."
             exit 1
         fi
         section_end
@@ -335,7 +343,8 @@ then
 
     if [[ ! -d ${build_dir} ]]
     then
-        echo "[Error]: Build directory not found : ${build_dir}" && exit 1
+        print_error "Build directory not found : ${build_dir}"
+        exit 1
     fi
 
     cd ${build_dir}
@@ -360,7 +369,9 @@ then
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
     then
-        echo "[Error]: No tests were found" && exit 1
+        section_end
+        print_error "No tests were found"
+        exit 1
     fi
 
     tree Testing
@@ -369,7 +380,9 @@ then
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        echo "[Error]: Failure(s) while running CTest" && exit 1
+        section_end
+        print_error "Failure(s) while running CTest"
+        exit 1
     fi
     section_end
 
@@ -381,17 +394,23 @@ then
     else
         if [[ ! -d ${install_dir} ]]
         then
-            echo "[Error]: Install directory not found : ${install_dir}" && exit 1
+            section_end
+            print_error "Install directory not found : ${install_dir}"
+            exit 1
         fi
 
         cd ${install_dir}/examples/umpire/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then
-            echo "[Error]: Running $cmake_exe for using-with-cmake test" && exit 1
+            section_end
+            print_error "Running $cmake_exe for using-with-cmake test"
+            exit 1
         fi
 
         if ! make; then
-            echo "[Error]: Running make for using-with-cmake test" && exit 1
+            section_end
+            print_error "Running make for using-with-cmake test"
+            exit 1
         fi
         section_end
     fi

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -345,12 +345,14 @@ then
     fi
 
     section_start "cmake_config" "CMake Configuration" "collapsed"
-    if ! $cmake_exe \
+    if $cmake_exe \
       -C ${hostconfig_path} \
       ${cmake_options} \
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
-      then
+    then
+        section_end
+    else
         status=$?
         section_end ; print_error "CMake configuration failed, dumping output..."
 
@@ -362,11 +364,12 @@ then
 
         exit ${status}
     fi
-    section_end
 
     section_start "build" "Building Umpire" "collapsed"
-    if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
+    if $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
+        section_end
+    else
         status=$?
         section_end ; print_error "Compilation failed, building with verbose output..."
 
@@ -376,17 +379,10 @@ then
 
         exit ${status}
     fi
-    section_end
 
-    section_start "install" "Installing Umpire" "collapsed"
-    if ! $cmake_exe --install .
-    then
-        status=$?
-        section_end ; print_error "Installation failed."
-
-        exit ${status}
-    fi
-    section_end
+    run_section "install" "Installing Umpire" "collapsed" \
+      "Installation failed" \
+      $cmake_exe --install .
 fi
 
 # Test

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -78,7 +78,7 @@ section_start ()
 
     echo "${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "${section_indent}~ TIME                      | TOTAL    | SECTION  "
-    echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_title}"
+    echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}"
     echo -e "\e[0Ksection_start:${timestamp}:${section_id}[collapsed=${collapsed}]\r\e[0K${section_indent}~ ${section_title}"
 
     # Increase indentation for nested sections
@@ -120,12 +120,10 @@ section_end ()
 
 if [[ ${debug_mode} == true ]]
 then
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~~~~~ Debug mode:"
-    echo "~~~~~ - Spack debug mode."
-    echo "~~~~~ - Deactivated shared memory."
-    echo "~~~~~ - Do not push to buildcache."
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "[Information]: Debug mode:"
+    echo "[Information]: - Spack debug mode."
+    echo "[Information]: - Deactivated shared memory."
+    echo "[Information]: - Do not push to buildcache."
     use_dev_shm=false
     spack_debug=true
     push_to_registry=false
@@ -133,7 +131,7 @@ fi
 
 if [[ -n ${module_list} ]]
 then
-    echo "Loading modules: ${module_list}"
+    echo "[Information]: Loading modules: ${module_list}"
     module load ${module_list}
 fi
 
@@ -156,8 +154,8 @@ else
     prefix="${project_dir}/../spack-and-build-root"
 fi
 
-echo "Creating directory ${prefix}"
-echo "project_dir: ${project_dir}"
+echo "[Information]: Creating directory ${prefix}"
+echo "[Information]: project_dir: ${project_dir}"
 
 mkdir -p ${prefix}
 
@@ -257,14 +255,11 @@ cmake_exe=`grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs`
 # Build
 if [[ "${option}" != "--deps-only" && "${option}" != "--test-only" ]]
 then
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~~~~~ Prefix: ${prefix}"
-    echo "~~~~~ Host-config: ${hostconfig_path}"
-    echo "~~~~~ Build Dir:   ${build_dir}"
-    echo "~~~~~ Project Dir: ${project_dir}"
-    echo "~~~~~ Install Dir: ${install_dir}"
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo ""
+    echo "[Information]: Prefix       ${prefix}"
+    echo "[Information]: Host-config  ${hostconfig_path}"
+    echo "[Information]: Build Dir    ${build_dir}"
+    echo "[Information]: Project Dir  ${project_dir}"
+    echo "[Information]: Install Dir  ${install_dir}"
 
     section_start "clean" "Cleaning working directory" "collapsed"
     # Map CPU core allocations
@@ -352,11 +347,9 @@ then
         echo "[Error]: No tests were found" && exit 1
     fi
 
-    section_start "test_xml" "Processing Test XML Reports" "collapsed"
     tree Testing
     xsltproc -o junit.xml ${project_dir}/scripts/radiuss-spack-configs/utilities/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml
-    section_end
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -37,6 +37,23 @@ ci_registry_image=${CI_REGISTRY_IMAGE:-"czregistry.llnl.gov:5050/radiuss/umpire"
 export ci_registry_user=${CI_REGISTRY_USER:-"${USER}"}
 export ci_registry_token=${CI_JOB_TOKEN:-"${registry_token}"}
 
+# Track script start time for elapsed time calculations
+script_start_time=$(date +%s)
+
+# Format seconds to HH:MM:SS
+format_time ()
+{
+    local total_seconds=${1}
+    local hours=$((total_seconds / 3600))
+    local minutes=$(( (total_seconds % 3600) / 60 ))
+    local seconds=$((total_seconds % 60))
+    printf "%02d:%02d:%02d" ${hours} ${minutes} ${seconds}
+}
+
+# Storage for section start times (non-nested)
+declare -A section_start_times
+
+# Legacy timed_message function (to be replaced with timed sections in future)
 timed_message ()
 {
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -50,14 +67,38 @@ section_start ()
     local section_id="${1}"
     local section_title="${2}"
     local timestamp=$(date +%s)
-    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K${section_title}"
+    local current_time=$(date --rfc-3339=seconds)
+    local total_elapsed=$((timestamp - script_start_time))
+    local total_elapsed_formatted=$(format_time ${total_elapsed})
+
+    # Store section start time for later calculation
+    section_start_times[${section_id}]=${timestamp}
+
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~ TIME                      | TOTAL    | SECTION  "
+    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_title}"
+    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K~ ${section_title}"
 }
 
 section_end ()
 {
     local section_id="${1}"
     local timestamp=$(date +%s)
+    local current_time=$(date --rfc-3339=seconds)
+    local total_elapsed=$((timestamp - script_start_time))
+    local total_elapsed_formatted=$(format_time ${total_elapsed})
+
+    # Calculate section elapsed time
+    local section_start=${section_start_times[${section_id}]:-${timestamp}}
+    local section_elapsed=$((timestamp - section_start))
+    local section_elapsed_formatted=$(format_time ${section_elapsed})
+
     echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K"
+    echo "~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+    # Clean up stored time
+    unset section_start_times[${section_id}]
 }
 
 if [[ ${debug_mode} == true ]]

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -53,9 +53,10 @@ section_start ()
 {
     local section_name="${1}"
     local section_title="${2}"
+    local section_state="${3:-""}"
 
     local collapsed="false"
-    if [[ "${3}" == "collapsed" ]]
+    if [[ "${section_state}" == "collapsed" ]]
     then
         local collapsed="true"
     fi

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -55,6 +55,20 @@ print_error ()
     echo -e "\e[31m[Error]: ${error_msg}\e[0m"
 }
 
+# Helper function to print warnings in gray
+print_warning ()
+{
+    local warning_msg="${1}"
+    echo -e "\e[1;30m[Warning]: ${warning_msg}\e[0m"
+}
+
+# Helper function to print information
+print_info ()
+{
+    local info_msg="${1}"
+    echo -e "[Information]: ${info_msg}"
+}
+
 # GitLab CI collapsible section helpers with nesting support
 section_start ()
 {
@@ -127,10 +141,10 @@ section_end ()
 
 if [[ ${debug_mode} == true ]]
 then
-    echo "[Information]: Debug mode:"
-    echo "[Information]: - Spack debug mode."
-    echo "[Information]: - Deactivated shared memory."
-    echo "[Information]: - Do not push to buildcache."
+    print_info "Debug mode:"
+    print_info "- Spack debug mode."
+    print_info "- Deactivated shared memory."
+    print_info "- Do not push to buildcache."
     use_dev_shm=false
     spack_debug=true
     push_to_registry=false
@@ -138,7 +152,7 @@ fi
 
 if [[ -n ${module_list} ]]
 then
-    echo "[Information]: Loading modules: ${module_list}"
+    print_info "Loading modules: ${module_list}"
     module load ${module_list}
 fi
 
@@ -161,8 +175,8 @@ else
     prefix="${project_dir}/../spack-and-build-root"
 fi
 
-echo "[Information]: Creating directory ${prefix}"
-echo "[Information]: project_dir: ${project_dir}"
+print_info "Creating directory ${prefix}"
+print_info "project_dir: ${project_dir}"
 
 mkdir -p ${prefix}
 
@@ -249,7 +263,7 @@ else
 fi
 
 hostconfig=$(basename ${hostconfig_path})
-echo "[Information]: Found hostconfig ${hostconfig_path}"
+print_info "Found hostconfig ${hostconfig_path}"
 
 # Build Directory
 # When using /dev/shm, we use prefix for both spack builds and source build, unless BUILD_ROOT was defined
@@ -263,11 +277,11 @@ cmake_exe=`grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs`
 # Build
 if [[ "${option}" != "--deps-only" && "${option}" != "--test-only" ]]
 then
-    echo "[Information]: Prefix       ${prefix}"
-    echo "[Information]: Host-config  ${hostconfig_path}"
-    echo "[Information]: Build Dir    ${build_dir}"
-    echo "[Information]: Project Dir  ${project_dir}"
-    echo "[Information]: Install Dir  ${install_dir}"
+    print_info "Prefix       ${prefix}"
+    print_info "Host-config  ${hostconfig_path}"
+    print_info "Build Dir    ${build_dir}"
+    print_info "Project Dir  ${project_dir}"
+    print_info "Install Dir  ${install_dir}"
 
     section_start "clean" "Cleaning working directory" "collapsed"
     # Map CPU core allocations
@@ -297,44 +311,43 @@ then
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
       then
+        status=$?
         section_end
         print_error "CMake configuration failed, dumping output..."
-        section_start "cmake_config_verbose" "Verbose CMake Configuration"
-        if ! $cmake_exe \
+
+        $cmake_exe \
           -C ${hostconfig_path} \
           ${cmake_options} \
           -DCMAKE_INSTALL_PREFIX=${install_dir} \
           ${project_dir} --debug-output --trace-expand
-        then
-          verbose_status=$?
-          section_end
-          exit ${verbose_status}
-        fi
-        section_end
-        exit 1
-      else
-        section_end
+
+        exit ${status}
     fi
+    section_end
 
     section_start "build" "Building Umpire" "collapsed"
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
+        status=$?
         section_end
         print_error "Compilation failed, building with verbose output..."
-        section_start "build_verbose" "Verbose Rebuild" "collapsed"
+
         $cmake_exe --build . --verbose -j 1
-        section_end
-    else
-        section_end
-        section_start "install" "Installing Umpire" "collapsed"
-        if ! $cmake_exe --install .
-        then
-            section_end
-            print_error "Installation failed."
-            exit 1
-        fi
-        section_end
+
+        exit ${status}
     fi
+    section_end
+
+    section_start "install" "Installing Umpire" "collapsed"
+    if ! $cmake_exe --install .
+    then
+        status=$?
+        section_end
+        print_error "Installation failed."
+
+        exit ${status}
+    fi
+    section_end
 fi
 
 # Test
@@ -389,8 +402,8 @@ then
     section_start "install_test" "Testing Installed Examples" "collapsed"
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
-        echo "[Warning]: Not testing install with HIP"
         section_end
+        echo "[Warning]: Not testing install with HIP"
     else
         if [[ ! -d ${install_dir} ]]
         then

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -74,12 +74,12 @@ format_utc_timestamp ()
 {
     local timestamp="${1}"
     # BSD/macOS date supports epoch conversion via: date -r <seconds>
-    if date -u -r "${timestamp}" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1
+    if date -u -r "${timestamp}" "+%Y-%m-%d %H:%M:%S UTC" >/dev/null 2>&1
     then
-        date -u -r "${timestamp}" "+%Y-%m-%dT%H:%M:%SZ"
+        date -u -r "${timestamp}" "+%Y-%m-%d %H:%M:%S UTC"
     else
         # GNU date supports epoch conversion via: date -d "@<seconds>"
-        date -u -d "@${timestamp}" "+%Y-%m-%dT%H:%M:%SZ"
+        date -u -d "@${timestamp}" "+%Y-%m-%d %H:%M:%S UTC"
     fi
 }
 
@@ -119,7 +119,7 @@ section_start ()
     section_id_stack+=("${section_id}")
 
     echo -e "\e[1;30m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\e[0m"
-    echo -e "\e[1;30m${section_indent}~ TIME                      | TOTAL    | SECTION  \e[0m"
+    echo -e "\e[1;30m${section_indent}~ TIME                    | TOTAL    | SECTION  \e[0m"
     echo -e "\e[1;30m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}\e[0m"
     echo -e "\e[0Ksection_start:${timestamp}:${section_id}[collapsed=${collapsed}]\r\e[0K${section_indent}~ ${section_title}"
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -118,9 +118,9 @@ section_start ()
     # Push section ID onto stack
     section_id_stack+=("${section_id}")
 
-    echo "\033[90m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\033[0m"
-    echo "\033[90m${section_indent}~ TIME                      | TOTAL    | SECTION  \033[0m"
-    echo "\033[90m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}\033[0m"
+    echo -e "\e[1;30m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\e[0m"
+    echo -e "\e[1;30m${section_indent}~ TIME                      | TOTAL    | SECTION  \e[0m"
+    echo -e "\e[1;30m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}\e[0m"
     echo -e "\e[0Ksection_start:${timestamp}:${section_id}[collapsed=${collapsed}]\r\e[0K${section_indent}~ ${section_title}"
 
     # Increase indentation for nested sections
@@ -152,9 +152,9 @@ section_end ()
     local section_elapsed=$((timestamp - section_start))
     local section_elapsed_formatted=$(format_elapsed_hms "${section_elapsed}")
 
-    echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K\033[0m"
-    echo "\033[90m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}\033[0m"
-    echo "\033[90m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K\e[0m"
+    echo -e "\e[1;30m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}\e[0m"
+    echo -e "\e[1;30m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\e[0m"
 
     # Clean up stored time
     unset section_start_times[${section_id}]

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -54,6 +54,12 @@ section_start ()
     local section_name="${1}"
     local section_title="${2}"
 
+    local collapsed="false"
+    if [[ "${3}" == "collapsed" ]]
+    then
+        local collapsed="true"
+    fi
+
     # Generate unique section ID
     section_counter=$((section_counter + 1))
     local section_id="${section_name}_${section_counter}"
@@ -72,7 +78,7 @@ section_start ()
     echo "${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "${section_indent}~ TIME                      | TOTAL    | SECTION  "
     echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_indent}${section_title}"
-    echo -e "\e[0Ksection_start:${timestamp}:${section_id}\r\e[0K${section_indent}~ ${section_title}"
+    echo -e "\e[0Ksection_start:${timestamp}:${section_id}[collapsed=${collapsed}]\r\e[0K${section_indent}~ ${section_title}"
 
     # Increase indentation for nested sections
     section_indent="${section_indent}  "
@@ -185,24 +191,24 @@ then
     mkdir -p ${spack_user_cache}
 
     # generate cmake cache file with uberenv and radiuss spack package
-    section_start "spack_setup" "Spack setup and environment"
+    section_start "spack_setup" "Spack setup and environment" "collapsed"
     ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
     section_end
 
     if [[ -n ${ci_registry_token} ]]
     then
-        section_start "registry_setup" "GitLab registry as Spack Buildcache"
+        section_start "registry_setup" "GitLab registry as Spack Buildcache" "collapsed"
         ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username-variable ci_registry_user --oci-password-variable ci_registry_token gitlab_ci oci://${ci_registry_image}
         section_end
     fi
 
-    section_start "spack_build" "Spack build of dependencies"
+    section_start "spack_build" "Spack build of dependencies" "collapsed"
     ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
     section_end
 
     if [[ -n ${ci_registry_token} && ${push_to_registry} == true ]]
     then
-        section_start "buildcache_push" "Push dependencies to buildcache"
+        section_start "buildcache_push" "Push dependencies to buildcache" "collapsed"
         ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
         section_end
     fi
@@ -259,7 +265,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo ""
 
-    section_start "clean" "Cleaning working directory"
+    section_start "clean" "Cleaning working directory" "collapsed"
     # Map CPU core allocations
     declare -A core_counts=(["lassen"]=40 ["poodle"]=28 ["dane"]=28 ["matrix"]=28 ["corona"]=32 ["rzansel"]=48 ["tioga"]=32 ["tuolumne"]=48)
 
@@ -280,25 +286,38 @@ then
         cmake_options="-DBLT_MPI_COMMAND_APPEND:STRING=--overlap"
     fi
 
-    section_start "cmake_config" "CMake Configuration"
-    $cmake_exe \
+    section_start "cmake_config" "CMake Configuration" "collapsed"
+    if ! $cmake_exe \
       -C ${hostconfig_path} \
       ${cmake_options} \
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
-    section_end
+      then
+        section_end
+        echo "[Error]: CMake configuration failed, dumping output..."
+        section_start "cmake_config_verbose" "Verbose CMake Configuration"
+        $cmake_exe \
+          -C ${hostconfig_path} \
+          ${cmake_options} \
+          -DCMAKE_INSTALL_PREFIX=${install_dir} \
+          ${project_dir} --debug-output --trace-expand
+        section_end
+        exit 1
+      else
+        section_end
+    fi
 
-    section_start "build" "Building Umpire"
+    section_start "build" "Building Umpire" "collapsed"
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
         section_end
         echo "[Error]: Compilation failed, building with verbose output..."
-        section_start "build_verbose" "Verbose Rebuild"
+        section_start "build_verbose" "Verbose Rebuild" "collapsed"
         $cmake_exe --build . --verbose -j 1
         section_end
     else
         section_end
-        section_start "install" "Installing Umpire"
+        section_start "install" "Installing Umpire" "collapsed"
         $cmake_exe --install .
         section_end
     fi
@@ -315,7 +334,7 @@ then
 
     cd ${build_dir}
 
-    section_start "tests" "Running Tests"
+    section_start "tests" "Running Tests" "collapsed"
     ctest --output-on-failure --no-compress-output -T test -VV 2>&1 | tee tests_output.txt
 
     # If Developer benchmarks enabled, run the no-op benchmark and show output
@@ -325,7 +344,6 @@ then
         ctest --verbose -C Benchmark -R no-op_stress_test
         date
     fi
-    section_end
 
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
@@ -333,7 +351,7 @@ then
         echo "[Error]: No tests were found" && exit 1
     fi
 
-    section_start "test_xml" "Processing Test XML Reports"
+    section_start "test_xml" "Processing Test XML Reports" "collapsed"
     tree Testing
     xsltproc -o junit.xml ${project_dir}/scripts/radiuss-spack-configs/utilities/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml
@@ -343,9 +361,12 @@ then
     then
         echo "[Error]: Failure(s) while running CTest" && exit 1
     fi
+    section_end
 
+    section_start "install_test" "Testing Installed Examples" "collapsed"
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
+        section_end
         echo "[Warning]: Not testing install with HIP"
     else
         if [[ ! -d ${install_dir} ]]
@@ -353,7 +374,6 @@ then
             echo "[Error]: Install directory not found : ${install_dir}" && exit 1
         fi
 
-        section_start "install_test" "Testing Installed Examples"
         cd ${install_dir}/examples/umpire/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -365,8 +365,8 @@ then
     section_start "install_test" "Testing Installed Examples" "collapsed"
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
     then
-        section_end
         echo "[Warning]: Not testing install with HIP"
+        section_end
     else
         if [[ ! -d ${install_dir} ]]
         then

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -97,9 +97,9 @@ section_start ()
     # Push section ID onto stack
     section_id_stack+=("${section_id}")
 
-    echo "${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "${section_indent}~ TIME                      | TOTAL    | SECTION  "
-    echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}"
+    echo "\033[90m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\033[0m"
+    echo "\033[90m${section_indent}~ TIME                      | TOTAL    | SECTION  \033[0m"
+    echo "\033[90m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}\033[0m"
     echo -e "\e[0Ksection_start:${timestamp}:${section_id}[collapsed=${collapsed}]\r\e[0K${section_indent}~ ${section_title}"
 
     # Increase indentation for nested sections
@@ -131,9 +131,9 @@ section_end ()
     local section_elapsed=$((timestamp - section_start))
     local section_elapsed_formatted=$(date -d @${section_elapsed} -u +%H:%M:%S)
 
-    echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K"
-    echo "${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}"
-    echo "${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K\033[0m"
+    echo "\033[90m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}\033[0m"
+    echo "\033[90m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     # Clean up stored time
     unset section_start_times[${section_id}]


### PR DESCRIPTION
Implement collapsible sections in build_and_test.sh to improve CI log
readability.
- Adds helper functions section_start() and section_end()
to manage GitLab CI section markers
- Wraps all major build phases
(dependencies, cmake config, build, test, install) in foldable
sections.
- Special attention to handling errors to display appropriate message and get the CI job to fail.

Note: when a failure happens, there will be a message in red, but the failure output will be hidden in the above collapsed section.
- There is unfortunately no way to keep the last log section expanded upon failure.
- It happens with tests, but could be mitigated by looking for and printing the failed tests from the reports.
- A failed build is retried with debug and that build is not collapsed: no problem here.
