### PR TITLE
Integrate job override check component

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ include:
       shared_jobs_path: "gitlab/radiuss-jobs"
       local_jobs_path: ".gitlab/jobs"
       machine_files: "dane.yml matrix.yml corona.yml tioga.yml tuolumne.yml"
-      base_branch: "develop"
+      ref_branch: "develop"
 
   # Local custom variables (used for component inputs and forwarded to child pipelines)
   - local: '.gitlab/custom-variables.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,7 @@ include:
       github_token: $GITHUB_TOKEN
 
   # Job override checker
-  - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-job-override-check@ci-job-override-check
+  - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-job-override-check@woptim/ci-job-override-check
     inputs:
       submodule_path: "scripts/radiuss-spack-configs"
       shared_jobs_path: "gitlab/radiuss-jobs"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,7 @@ include:
       shared_jobs_path: "gitlab/radiuss-jobs"
       local_jobs_path: ".gitlab/jobs"
       machine_files: "dane.yml matrix.yml corona.yml tioga.yml tuolumne.yml"
+      base_branch: "develop"
 
   # Local custom variables (used for component inputs and forwarded to child pipelines)
   - local: '.gitlab/custom-variables.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,14 @@ include:
       github_project_org: $GITHUB_PROJECT_ORG
       github_token: $GITHUB_TOKEN
 
+  # Job override checker
+  - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-job-override-check@ci-job-override-check
+    inputs:
+      submodule_path: "scripts/radiuss-spack-configs"
+      shared_jobs_path: "gitlab/radiuss-jobs"
+      local_jobs_path: ".gitlab/jobs"
+      machine_files: "dane.yml matrix.yml corona.yml tioga.yml tuolumne.yml"
+
   # Local custom variables (used for component inputs and forwarded to child pipelines)
   - local: '.gitlab/custom-variables.yml'
 


### PR DESCRIPTION
  Add utility-job-override-check component to warn developers when
  radiuss-spack-configs submodule updates affect local job overrides.

  This component runs in the .pre stage and checks if shared job
  definitions (from scripts/radiuss-spack-configs/gitlab/radiuss-jobs)
  have been renamed, modified, or removed, alerting developers to
  review their local overrides in .gitlab/jobs/.

  The check also warns if the develop branch has newer submodule
  changes, suggesting to merge develop first.
  
  TODO:
  - [x] merge corresponding branch in RSCI: https://github.com/llnl/radiuss-shared-ci/pull/67