### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # <img src="https://cdn.rawgit.com/LLNL/Umpire/develop/share/umpire/logo/umpire-logo.png" width="128" valign="middle" alt="Umpire"/> Umpire
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/llnl/Umpire)
 
 [![Documentation Status](https://readthedocs.org/projects/umpire/badge/?version=develop)](https://umpire.readthedocs.io/en/develop/?badge=develop)
 [![Github Actions Build Status](https://github.com/LLNL/Umpire/actions/workflows/build.yml/badge.svg)](https://github.com/LLNL/Umpire/actions/workflows/build.yml)


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/llnl/Umpire) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.