### PR TITLE
Update RSC (rocm toolchain, mpich, cce), spack and spack-packages

### DIFF
--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -18,7 +18,7 @@ variables:
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
 
   # Dane (SLURM) allocation settings
-  DANE_SHARED_ALLOC: "--exclusive --reservation=ci --time=8 --nodes=1"
+  DANE_SHARED_ALLOC: "--exclusive --reservation=ci --time=10 --nodes=1"
   # Note: We repeat the reservation, helpful when jobs are manually re-triggered.
   DANE_JOB_ALLOC: "--reservation=ci --overlap --nodes=1"
   # Project specific variants for dane
@@ -27,7 +27,7 @@ variables:
   PROJECT_DANE_DEPS: ""
 
   # Matrix (SLURM) allocation settings
-  MATRIX_SHARED_ALLOC: "--exclusive --partition=pci --time=8 --nodes=1"
+  MATRIX_SHARED_ALLOC: "--exclusive --partition=pci --time=10 --nodes=1"
   # Note: We repeat the reservation, helpful when jobs are manually re-triggered.
   MATRIX_JOB_ALLOC: "--partition=pci --overlap --nodes=1"
   # Project specific variants for matrix
@@ -36,7 +36,7 @@ variables:
   PROJECT_MATRIX_DEPS: ""
 
   # Corona (flux) allocation settings
-  CORONA_SHARED_ALLOC: "--exclusive --time-limit=12m --nodes=1 -o per-resource.count=2"
+  CORONA_SHARED_ALLOC: "--exclusive --time-limit=15m --nodes=1 -o per-resource.count=2"
   CORONA_JOB_ALLOC: "--nodes=1 --begin-time=+5s"
   # Project specific variants for corona
   PROJECT_CORONA_VARIANTS: "~shared +fortran +device_alloc tests=basic "
@@ -44,7 +44,7 @@ variables:
   PROJECT_CORONA_DEPS: ""
 
   # Tioga (flux) allocation settings
-  TIOGA_SHARED_ALLOC: "--queue=pci --exclusive --time-limit=20m --nodes=1 -o per-resource.count=2"
+  TIOGA_SHARED_ALLOC: "--queue=pci --exclusive --time-limit=30m --nodes=1 -o per-resource.count=2"
   TIOGA_JOB_ALLOC: "--nodes=1 --begin-time=+5s"
   # Project specific variants for tioga
   PROJECT_TIOGA_VARIANTS: "~shared +fortran +device_alloc tests=basic "
@@ -52,7 +52,7 @@ variables:
   PROJECT_TIOGA_DEPS: ""
 
   # Tuolumne (flux) allocation settings
-  TUOLUMNE_SHARED_ALLOC: "--queue=pci --exclusive --time-limit=20m --nodes=1 -o per-resource.count=2"
+  TUOLUMNE_SHARED_ALLOC: "--queue=pci --exclusive --time-limit=30m --nodes=1 -o per-resource.count=2"
   TUOLUMNE_JOB_ALLOC: "--nodes=1 --begin-time=+5s"
   # Project specific variants for tuolumne
   PROJECT_TUOLUMNE_VARIANTS: "~shared +fortran +device_alloc tests=basic "

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -30,8 +30,8 @@
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still disable tools from being built.
 ###
-rocmcc_5_7_1_hip_openmp_device_alloc:
+rocmcc_6_4_3_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +device_alloc tests=basic +rocm amdgpu_target=gfx906 %llvm-amdgpu@=5.7.1 ^hip@5.7.1"
+    SPEC: "~shared +fortran +openmp +device_alloc tests=basic +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_corona
 

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -30,8 +30,8 @@
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still disable tools from being built.
 ###
-rocmcc_6_4_3_hip_openmp_device_alloc:
+rocmcc_5_7_1_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +device_alloc tests=basic +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
+    SPEC: "~shared +fortran +openmp +device_alloc tests=basic +rocm amdgpu_target=gfx906 %llvm-amdgpu@=5.7.1 ^hip@5.7.1"
   extends: .job_on_corona
 

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -22,11 +22,6 @@ clang_18_1_8_gcc_13_cuda_12_6_0:
     SPEC: "${PROJECT_MATRIX_VARIANTS} +deviceconst %clang-18-gcc-13 ^cmake@3.25.2 ^cuda@12.6.0+allow-unsupported-compilers ${PROJECT_MATRIX_DEPS}"
   extends: .job_on_matrix
 
-clang_19_1_3_gcc_13_cuda_13_1_1:
-  variables:
-    SPEC: "${PROJECT_MATRIX_VARIANTS} +deviceconst %clang-19-gcc-13 ^cmake@3.25.2 ^cuda@13.1.1+allow-unsupported-compilers ${PROJECT_MATRIX_DEPS}"
-  extends: .job_on_matrix
-
 ############
 # Extra jobs
 ############

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -22,6 +22,11 @@ clang_18_1_8_gcc_13_cuda_12_6_0:
     SPEC: "${PROJECT_MATRIX_VARIANTS} +deviceconst %clang-18-gcc-13 ^cmake@3.25.2 ^cuda@12.6.0+allow-unsupported-compilers ${PROJECT_MATRIX_DEPS}"
   extends: .job_on_matrix
 
+clang_19_1_3_gcc_13_cuda_13_1_1:
+  variables:
+    SPEC: "${PROJECT_MATRIX_VARIANTS} +deviceconst %clang-19-gcc-13 ^cmake@3.25.2 ^cuda@13.1.1+allow-unsupported-compilers ${PROJECT_MATRIX_DEPS}"
+  extends: .job_on_matrix
+
 ############
 # Extra jobs
 ############

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -17,9 +17,9 @@
 # the comparison with the original job is easier.
 
 # We override the cce job because we can’t use +device-alloc with it
-cce_20_0_0:
+cce_21_0_0:
   variables:
-    SPEC: "~shared +fortran tests=basic %cce@=20.0.0"
+    SPEC: "~shared +fortran tests=basic %cce@=21.0.0"
   extends: .job_on_tioga
 
 ############
@@ -33,12 +33,12 @@ cce_20_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_6_4_3_hip_openmp_device_alloc:
+rocmcc_7_2_0_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
   extends: .job_on_tioga
 
-rocmcc_6_4_3_hip_deviceconst:
+rocmcc_7_2_0_hip_deviceconst:
   variables:
-    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
+    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
   extends: .job_on_tioga

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -16,6 +16,13 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
+# Override rocm 7.2.0 job to allow failure
+rocmcc_7_2_0_hip:
+  variables:
+    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %llvm-amdgpu@=7.2.0 ^hip@7.2.0 ${PROJECT_TIOGA_DEPS}"
+  extends: .job_on_tioga
+  allow_failure: true
+
 # We override the cce job because we can’t use +device-alloc with it
 cce_21_0_0:
   variables:

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -33,12 +33,12 @@ cce_21_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_7_2_0_hip_openmp_device_alloc:
+rocmcc_6.4.3_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tioga
 
-rocmcc_7_2_0_hip_deviceconst:
+rocmcc_6.4.3_hip_deviceconst:
   variables:
-    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
+    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tioga

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -33,12 +33,12 @@ cce_20_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_6_4_1_hip_openmp_device_alloc:
+rocmcc_6_4_3_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.1 ^hip@6.4.1"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tioga
 
-rocmcc_6_4_1_hip_deviceconst:
+rocmcc_6_4_3_hip_deviceconst:
   variables:
-    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.1 ^hip@6.4.1"
+    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tioga

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -17,9 +17,9 @@
 # the comparison with the original job is easier.
 
 # We override the cce job because we can’t use +device-alloc with it
-cce_20_0_0:
+cce_21_0_0:
   variables:
-    SPEC: "~shared +fortran tests=basic %cce@=20.0.0"
+    SPEC: "~shared +fortran tests=basic %cce@=21.0.0"
   extends: .job_on_tuolumne
 
 ############
@@ -33,12 +33,12 @@ cce_20_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_6_4_3_hip_openmp_device_alloc:
+rocmcc_7_2_0_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
   extends: .job_on_tuolumne
 
-rocmcc_6_4_3_hip_deviceconst:
+rocmcc_7_2_0_hip_deviceconst:
   variables:
-    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
+    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
   extends: .job_on_tuolumne

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -33,12 +33,12 @@ cce_21_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_7_2_0_hip_openmp_device_alloc:
+rocmcc_6_4_3_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tuolumne
 
-rocmcc_7_2_0_hip_deviceconst:
+rocmcc_6_4_3_hip_deviceconst:
   variables:
-    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=7.2.0 ^hip@7.2.0"
+    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tuolumne

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -33,12 +33,12 @@ cce_20_0_0:
 # This job intentionally tests our umpire package.py because although this job does not
 # explicitly have the ~tools, the package.py should still prevent tools from being built.
 ###
-rocmcc_6_4_1_hip_openmp_device_alloc:
+rocmcc_6_4_3_hip_openmp_device_alloc:
   variables:
-    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.1 ^hip@6.4.1"
+    SPEC: "~shared +fortran +openmp +rocm +device_alloc tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tuolumne
 
-rocmcc_6_4_1_hip_deviceconst:
+rocmcc_6_4_3_hip_deviceconst:
   variables:
-    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.1 ^hip@6.4.1"
+    SPEC: "~shared +fortran +deviceconst +rocm tests=basic amdgpu_target=gfx942 %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
   extends: .job_on_tuolumne

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -16,6 +16,13 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
+# Override rocm 7.2.0 job to allow failure
+rocmcc_7_2_0_hip:
+  variables:
+    SPEC: "${PROJECT_TUOLUMNE_VARIANTS} +rocm amdgpu_target=gfx942 %llvm-amdgpu@=7.2.0 ^hip@7.2.0 ${PROJECT_TUOLUMNE_DEPS}"
+  extends: .job_on_tuolumne
+  allow_failure: true
+
 # We override the cce job because we can’t use +device-alloc with it
 cce_21_0_0:
   variables:

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "v1.0.2",
+"spack_branch": "v1.1.1",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
 "spack_setup_clingo": false


### PR DESCRIPTION
- [X] Update to rocm 6.4.3 and mpich 8.1.33, then with mpich 9.0.1
- [X] Update to spack 1.1.1 (concretizer perf improvements)
- [X] Update to cce 21
- [X] Add one job with rocm 7.2 and mpich 9.1, keep rocm 6.4.3 for most specs (production state).
- [X] Increase allocation for CI jobs.