### PR TITLE
Add C/Fortran interfaces for controlling pool alignment

### DIFF
--- a/src/umpire/interface/c_fortran/gencumpiresplicer.inc
+++ b/src/umpire/interface/c_fortran/gencumpiresplicer.inc
@@ -48,6 +48,78 @@ SHC_rv->idtor = 1;
 return SHC_rv;
 // splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_untracked_bufferify
 
+// splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned_bufferify
+const std::string SHCXX_name(name, Lname);
+umpire::Allocator * SHCXX_allocator =
+    static_cast<umpire::Allocator *>(allocator.addr);
+umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+*SHCXX_rv = SH_this->makeAllocator<umpire::strategy::DynamicPoolList>(
+    SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+SHC_rv->addr = SHCXX_rv;
+SHC_rv->idtor = 1;
+return SHC_rv;
+// splicer end class.ResourceManager.method.make_allocator_list_pool_aligned_bufferify
+
+// splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned_bufferify
+const std::string SHCXX_name(name, Lname);
+umpire::Allocator * SHCXX_allocator =
+    static_cast<umpire::Allocator *>(allocator.addr);
+umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+*SHCXX_rv = SH_this->makeAllocator<umpire::strategy::QuickPool>(
+    SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+SHC_rv->addr = SHCXX_rv;
+SHC_rv->idtor = 1;
+return SHC_rv;
+// splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned_bufferify
+
+// splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_bufferify
+const std::string SHCXX_name(name, Lname);
+umpire::Allocator * SHCXX_allocator =
+    static_cast<umpire::Allocator *>(allocator.addr);
+umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+*SHCXX_rv = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool>(
+    SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+SHC_rv->addr = SHCXX_rv;
+SHC_rv->idtor = 1;
+return SHC_rv;
+// splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_bufferify
+
+// splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned_untracked_bufferify
+const std::string SHCXX_name(name, Lname);
+umpire::Allocator * SHCXX_allocator =
+    static_cast<umpire::Allocator *>(allocator.addr);
+umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+*SHCXX_rv = SH_this->makeAllocator<umpire::strategy::DynamicPoolList, false>(
+    SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+SHC_rv->addr = SHCXX_rv;
+SHC_rv->idtor = 1;
+return SHC_rv;
+// splicer end class.ResourceManager.method.make_allocator_list_pool_aligned_untracked_bufferify
+
+// splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked_bufferify
+const std::string SHCXX_name(name, Lname);
+umpire::Allocator * SHCXX_allocator =
+    static_cast<umpire::Allocator *>(allocator.addr);
+umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+*SHCXX_rv = SH_this->makeAllocator<umpire::strategy::QuickPool, false>(
+    SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+SHC_rv->addr = SHCXX_rv;
+SHC_rv->idtor = 1;
+return SHC_rv;
+// splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked_bufferify
+
+// splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked_bufferify
+const std::string SHCXX_name(name, Lname);
+umpire::Allocator * SHCXX_allocator =
+    static_cast<umpire::Allocator *>(allocator.addr);
+umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+*SHCXX_rv = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool, false>(
+    SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+SHC_rv->addr = SHCXX_rv;
+SHC_rv->idtor = 1;
+return SHC_rv;
+// splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked_bufferify
+
 // splicer begin class.ResourceManager.method.make_allocator_fixed_pool_untracked_bufferify
 const std::string SHCXX_name(name, Lname);
 umpire::Allocator * SHCXX_allocator =

--- a/src/umpire/interface/c_fortran/wrapResourceManager.cpp
+++ b/src/umpire/interface/c_fortran/wrapResourceManager.cpp
@@ -215,6 +215,126 @@ umpire_allocator * umpire_resourcemanager_make_allocator_bufferify_resource_awar
     // splicer end class.ResourceManager.method.make_allocator_bufferify_resource_aware_pool
 }
 
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned
+    const std::string SHC_name_cxx(name);
+    umpire::Allocator *SHC_allocator_cxx =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+    *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::DynamicPoolList>(
+        SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+    SHC_rv->addr  = SHC_rv_cxx;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_list_pool_aligned
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned_bufferify
+    const std::string SHCXX_name(name, Lname);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::DynamicPoolList>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_list_pool_aligned_bufferify
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned
+    const std::string SHC_name_cxx(name);
+    umpire::Allocator *SHC_allocator_cxx =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+    *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::QuickPool>(
+        SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+    SHC_rv->addr  = SHC_rv_cxx;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned_bufferify
+    const std::string SHCXX_name(name, Lname);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::QuickPool>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned_bufferify
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned
+    const std::string SHC_name_cxx(name);
+    umpire::Allocator *SHC_allocator_cxx =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+    *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool>(
+        SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+    SHC_rv->addr  = SHC_rv_cxx;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_bufferify
+    const std::string SHCXX_name(name, Lname);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_bufferify
+}
+
 umpire_allocator * umpire_resourcemanager_make_allocator_advisor(
     umpire_resourcemanager * self, const char * name,
     umpire_allocator allocator, const char * advice_op, int device_id,
@@ -793,6 +913,126 @@ umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_unt
     SHC_rv->idtor = 1;
     return SHC_rv;
     // splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_untracked_bufferify
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned_untracked
+    const std::string SHC_name_cxx(name);
+    umpire::Allocator *SHC_allocator_cxx =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+    *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::DynamicPoolList, false>(
+        SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+    SHC_rv->addr  = SHC_rv_cxx;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_list_pool_aligned_untracked
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned_untracked_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned_untracked_bufferify
+    const std::string SHCXX_name(name, Lname);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::DynamicPoolList, false>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_list_pool_aligned_untracked_bufferify
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked
+    const std::string SHC_name_cxx(name);
+    umpire::Allocator *SHC_allocator_cxx =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+    *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::QuickPool, false>(
+        SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+    SHC_rv->addr  = SHC_rv_cxx;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned_untracked_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked_bufferify
+    const std::string SHCXX_name(name, Lname);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::QuickPool, false>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked_bufferify
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked
+    const std::string SHC_name_cxx(name);
+    umpire::Allocator *SHC_allocator_cxx =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+    *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool, false>(
+        SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+    SHC_rv->addr  = SHC_rv_cxx;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked
+}
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_untracked_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv)
+{
+    umpire::ResourceManager *SH_this =
+        static_cast<umpire::ResourceManager *>(self->addr);
+    // splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked_bufferify
+    const std::string SHCXX_name(name, Lname);
+    umpire::Allocator * SHCXX_allocator =
+        static_cast<umpire::Allocator *>(allocator.addr);
+    umpire::Allocator * SHCXX_rv = new umpire::Allocator;
+    *SHCXX_rv = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool, false>(
+        SHCXX_name, *SHCXX_allocator, initial_size, block, alignment);
+    SHC_rv->addr = SHCXX_rv;
+    SHC_rv->idtor = 1;
+    return SHC_rv;
+    // splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked_bufferify
 }
 
 umpire_allocator * umpire_resourcemanager_make_allocator_fixed_pool_untracked(

--- a/src/umpire/interface/c_fortran/wrapResourceManager.h
+++ b/src/umpire/interface/c_fortran/wrapResourceManager.h
@@ -76,6 +76,36 @@ umpire_allocator * umpire_resourcemanager_make_allocator_bufferify_resource_awar
     umpire_allocator allocator, size_t initial_size, size_t block,
     umpire_allocator * SHC_rv);
 
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
 umpire_allocator * umpire_resourcemanager_make_allocator_advisor(
     umpire_resourcemanager * self, const char * name,
     umpire_allocator allocator, const char * advice_op, int device_id,
@@ -215,6 +245,36 @@ umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_unt
     umpire_resourcemanager * self, const char * name, int Lname,
     umpire_allocator allocator, size_t initial_size, size_t block,
     umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_list_pool_aligned_untracked_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_quick_pool_aligned_untracked_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_untracked(
+    umpire_resourcemanager * self, const char * name,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
+
+umpire_allocator * umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_untracked_bufferify(
+    umpire_resourcemanager * self, const char * name, int Lname,
+    umpire_allocator allocator, size_t initial_size, size_t block,
+    size_t alignment, umpire_allocator * SHC_rv);
 
 umpire_allocator * umpire_resourcemanager_make_allocator_fixed_pool_untracked(
     umpire_resourcemanager * self, const char * name,

--- a/src/umpire/interface/c_fortran/wrapfumpire.f
+++ b/src/umpire/interface/c_fortran/wrapfumpire.f
@@ -231,6 +231,9 @@ module umpire_mod
         procedure :: make_allocator_list_pool => resourcemanager_make_allocator_list_pool
         procedure :: make_allocator_quick_pool => resourcemanager_make_allocator_quick_pool
         procedure :: make_allocator_resource_aware_pool => resourcemanager_make_allocator_resource_aware_pool
+        procedure :: make_allocator_list_pool_aligned => make_alloc_dynamic_p_list_a
+        procedure :: make_allocator_quick_pool_aligned => make_alloc_quick_p_a
+        procedure :: make_allocator_resource_aware_pool_aligned => make_alloc_res_aware_p_a
         procedure :: make_allocator_advisor => resourcemanager_make_allocator_advisor
         procedure :: make_allocator_named => resourcemanager_make_allocator_named
         procedure :: make_allocator_thread_safe => resourcemanager_make_allocator_thread_safe
@@ -245,6 +248,9 @@ module umpire_mod
         procedure :: make_allocator_list_pool_untracked => make_alloc_dynamic_p_list_u
         procedure :: make_allocator_quick_pool_untracked => make_alloc_quick_p_u
         procedure :: make_allocator_resource_aware_pool_untracked => make_alloc_res_aware_p_u
+        procedure :: make_allocator_list_pool_aligned_untracked => make_alloc_dynamic_p_list_au
+        procedure :: make_allocator_quick_pool_aligned_untracked => make_alloc_quick_p_au
+        procedure :: make_allocator_resource_aware_pool_aligned_untracked => make_alloc_res_aware_p_au
         procedure :: make_allocator_fixed_pool_untracked => make_alloc_fixed_p_u
         procedure :: make_allocator_monotonic_untracked => make_alloc_monotonic_u
         procedure :: make_allocator_slot_pool_untracked => make_alloc_slot_p_u
@@ -564,6 +570,115 @@ module umpire_mod
             type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_resourcemanager_make_allocator_bufferify_resource_aware_pool
+
+        function c_resourcemanager_make_alloc_dynamic_p_list_a(self, &
+                name, allocator, initial_size, block, alignment, &
+                SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_list_pool_aligned")
+            use iso_c_binding, only : C_CHAR, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_dynamic_p_list_a
+
+        function c_resourcemanager_make_alloc_dynamic_p_list_a_bufferify( &
+                self, name, Lname, allocator, initial_size, block, &
+                alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_list_pool_aligned_bufferify")
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT), value, intent(IN) :: Lname
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_dynamic_p_list_a_bufferify
+
+        function c_resourcemanager_make_alloc_quick_p_a(self, name, &
+                allocator, initial_size, block, alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_quick_pool_aligned")
+            use iso_c_binding, only : C_CHAR, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_quick_p_a
+
+        function c_resourcemanager_make_alloc_quick_p_a_bufferify(self, &
+                name, Lname, allocator, initial_size, block, alignment, &
+                SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_quick_pool_aligned_bufferify")
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT), value, intent(IN) :: Lname
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_quick_p_a_bufferify
+
+        function c_resourcemanager_make_alloc_res_aware_p_a(self, name, &
+                allocator, initial_size, block, alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_resource_aware_pool_aligned")
+            use iso_c_binding, only : C_CHAR, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_res_aware_p_a
+
+        function c_resourcemanager_make_alloc_res_aware_p_a_bufferify( &
+                self, name, Lname, allocator, initial_size, block, &
+                alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_bufferify")
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT), value, intent(IN) :: Lname
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_res_aware_p_a_bufferify
 
         function c_resourcemanager_make_allocator_advisor(self, name, &
                 allocator, advice_op, device_id, SHT_crv) &
@@ -1024,6 +1139,115 @@ module umpire_mod
             type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_resourcemanager_make_alloc_res_aware_p_u_bufferify
+
+        function c_resourcemanager_make_alloc_dynamic_p_list_au(self, &
+                name, allocator, initial_size, block, alignment, &
+                SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_list_pool_aligned_untracked")
+            use iso_c_binding, only : C_CHAR, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_dynamic_p_list_au
+
+        function c_resourcemanager_make_alloc_dynamic_p_list_au_bufferify( &
+                self, name, Lname, allocator, initial_size, block, &
+                alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_list_pool_aligned_untracked_bufferify")
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT), value, intent(IN) :: Lname
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_dynamic_p_list_au_bufferify
+
+        function c_resourcemanager_make_alloc_quick_p_au(self, name, &
+                allocator, initial_size, block, alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_quick_pool_aligned_untracked")
+            use iso_c_binding, only : C_CHAR, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_quick_p_au
+
+        function c_resourcemanager_make_alloc_quick_p_au_bufferify(self, &
+                name, Lname, allocator, initial_size, block, alignment, &
+                SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_quick_pool_aligned_untracked_bufferify")
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT), value, intent(IN) :: Lname
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_quick_p_au_bufferify
+
+        function c_resourcemanager_make_alloc_res_aware_p_au(self, name, &
+                allocator, initial_size, block, alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_untracked")
+            use iso_c_binding, only : C_CHAR, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_res_aware_p_au
+
+        function c_resourcemanager_make_alloc_res_aware_p_au_bufferify( &
+                self, name, Lname, allocator, initial_size, block, &
+                alignment, SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="umpire_resourcemanager_make_allocator_resource_aware_pool_aligned_untracked_bufferify")
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR, C_SIZE_T
+            import :: umpire_SHROUD_allocator_capsule, umpire_SHROUD_resourcemanager_capsule
+            implicit none
+            type(umpire_SHROUD_resourcemanager_capsule), intent(IN) :: self
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT), value, intent(IN) :: Lname
+            type(umpire_SHROUD_allocator_capsule), intent(IN), value :: allocator
+            integer(C_SIZE_T), value, intent(IN) :: initial_size
+            integer(C_SIZE_T), value, intent(IN) :: block
+            integer(C_SIZE_T), value, intent(IN) :: alignment
+            type(umpire_SHROUD_allocator_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function c_resourcemanager_make_alloc_res_aware_p_au_bufferify
 
         function c_resourcemanager_make_alloc_fixed_p_u(self, name, &
                 allocator, object_size, SHT_crv) &
@@ -3219,6 +3443,63 @@ contains
         ! splicer end class.ResourceManager.method.make_allocator_resource_aware_pool
     end function resourcemanager_make_allocator_resource_aware_pool
 
+    function make_alloc_dynamic_p_list_a(obj, name, allocator, &
+            initial_size, block, alignment) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
+        class(UmpireResourceManager) :: obj
+        character(len=*), intent(IN) :: name
+        type(UmpireAllocator), value, intent(IN) :: allocator
+        integer(C_SIZE_T), value, intent(IN) :: initial_size
+        integer(C_SIZE_T), value, intent(IN) :: block
+        integer(C_SIZE_T), value, intent(IN) :: alignment
+        type(UmpireAllocator) :: SHT_rv
+        ! splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned
+        type(C_PTR) :: SHT_prv
+        SHT_prv = c_resourcemanager_make_alloc_dynamic_p_list_a_bufferify(obj%cxxmem, &
+            name, len_trim(name, kind=C_INT), allocator%cxxmem, &
+            initial_size, block, alignment, SHT_rv%cxxmem)
+        ! splicer end class.ResourceManager.method.make_allocator_list_pool_aligned
+    end function make_alloc_dynamic_p_list_a
+
+    function make_alloc_quick_p_a(obj, name, allocator, initial_size, &
+            block, alignment) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
+        class(UmpireResourceManager) :: obj
+        character(len=*), intent(IN) :: name
+        type(UmpireAllocator), value, intent(IN) :: allocator
+        integer(C_SIZE_T), value, intent(IN) :: initial_size
+        integer(C_SIZE_T), value, intent(IN) :: block
+        integer(C_SIZE_T), value, intent(IN) :: alignment
+        type(UmpireAllocator) :: SHT_rv
+        ! splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned
+        type(C_PTR) :: SHT_prv
+        SHT_prv = c_resourcemanager_make_alloc_quick_p_a_bufferify(obj%cxxmem, &
+            name, len_trim(name, kind=C_INT), allocator%cxxmem, &
+            initial_size, block, alignment, SHT_rv%cxxmem)
+        ! splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned
+    end function make_alloc_quick_p_a
+
+    function make_alloc_res_aware_p_a(obj, name, allocator, &
+            initial_size, block, alignment) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
+        class(UmpireResourceManager) :: obj
+        character(len=*), intent(IN) :: name
+        type(UmpireAllocator), value, intent(IN) :: allocator
+        integer(C_SIZE_T), value, intent(IN) :: initial_size
+        integer(C_SIZE_T), value, intent(IN) :: block
+        integer(C_SIZE_T), value, intent(IN) :: alignment
+        type(UmpireAllocator) :: SHT_rv
+        ! splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned
+        type(C_PTR) :: SHT_prv
+        SHT_prv = c_resourcemanager_make_alloc_res_aware_p_a_bufferify(obj%cxxmem, &
+            name, len_trim(name, kind=C_INT), allocator%cxxmem, &
+            initial_size, block, alignment, SHT_rv%cxxmem)
+        ! splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned
+    end function make_alloc_res_aware_p_a
+
     function resourcemanager_make_allocator_advisor(obj, name, &
             allocator, advice_op, device_id) &
             result(SHT_rv)
@@ -3469,6 +3750,63 @@ contains
             initial_size, block, SHT_rv%cxxmem)
         ! splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_untracked
     end function make_alloc_res_aware_p_u
+
+    function make_alloc_dynamic_p_list_au(obj, name, allocator, &
+            initial_size, block, alignment) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
+        class(UmpireResourceManager) :: obj
+        character(len=*), intent(IN) :: name
+        type(UmpireAllocator), value, intent(IN) :: allocator
+        integer(C_SIZE_T), value, intent(IN) :: initial_size
+        integer(C_SIZE_T), value, intent(IN) :: block
+        integer(C_SIZE_T), value, intent(IN) :: alignment
+        type(UmpireAllocator) :: SHT_rv
+        ! splicer begin class.ResourceManager.method.make_allocator_list_pool_aligned_untracked
+        type(C_PTR) :: SHT_prv
+        SHT_prv = c_resourcemanager_make_alloc_dynamic_p_list_au_bufferify(obj%cxxmem, &
+            name, len_trim(name, kind=C_INT), allocator%cxxmem, &
+            initial_size, block, alignment, SHT_rv%cxxmem)
+        ! splicer end class.ResourceManager.method.make_allocator_list_pool_aligned_untracked
+    end function make_alloc_dynamic_p_list_au
+
+    function make_alloc_quick_p_au(obj, name, allocator, initial_size, &
+            block, alignment) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
+        class(UmpireResourceManager) :: obj
+        character(len=*), intent(IN) :: name
+        type(UmpireAllocator), value, intent(IN) :: allocator
+        integer(C_SIZE_T), value, intent(IN) :: initial_size
+        integer(C_SIZE_T), value, intent(IN) :: block
+        integer(C_SIZE_T), value, intent(IN) :: alignment
+        type(UmpireAllocator) :: SHT_rv
+        ! splicer begin class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked
+        type(C_PTR) :: SHT_prv
+        SHT_prv = c_resourcemanager_make_alloc_quick_p_au_bufferify(obj%cxxmem, &
+            name, len_trim(name, kind=C_INT), allocator%cxxmem, &
+            initial_size, block, alignment, SHT_rv%cxxmem)
+        ! splicer end class.ResourceManager.method.make_allocator_quick_pool_aligned_untracked
+    end function make_alloc_quick_p_au
+
+    function make_alloc_res_aware_p_au(obj, name, allocator, &
+            initial_size, block, alignment) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
+        class(UmpireResourceManager) :: obj
+        character(len=*), intent(IN) :: name
+        type(UmpireAllocator), value, intent(IN) :: allocator
+        integer(C_SIZE_T), value, intent(IN) :: initial_size
+        integer(C_SIZE_T), value, intent(IN) :: block
+        integer(C_SIZE_T), value, intent(IN) :: alignment
+        type(UmpireAllocator) :: SHT_rv
+        ! splicer begin class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked
+        type(C_PTR) :: SHT_prv
+        SHT_prv = c_resourcemanager_make_alloc_res_aware_p_au_bufferify(obj%cxxmem, &
+            name, len_trim(name, kind=C_INT), allocator%cxxmem, &
+            initial_size, block, alignment, SHT_rv%cxxmem)
+        ! splicer end class.ResourceManager.method.make_allocator_resource_aware_pool_aligned_untracked
+    end function make_alloc_res_aware_p_au
 
     function make_alloc_fixed_p_u(obj, name, allocator, object_size) &
             result(SHT_rv)

--- a/src/umpire/interface/umpire_shroud.yaml
+++ b/src/umpire/interface/umpire_shroud.yaml
@@ -190,6 +190,57 @@ declarations:
             template_suffix: _resource_aware_pool
             function_suffix: ""
 
+      - decl: Allocator makeAllocator_list_pool_aligned(const std::string& name, Allocator allocator, size_t initial_size, size_t block, size_t alignment)
+        options:
+          F_C_name_template: c_resourcemanager_make_alloc_dynamic_p_list_a{function_suffix}{template_suffix}
+        format:
+          F_name_impl: make_alloc_dynamic_p_list_a
+        splicer:
+          c: |
+            const std::string SHC_name_cxx(name);
+            umpire::Allocator *SHC_allocator_cxx =
+                static_cast<umpire::Allocator *>(allocator.addr);
+            umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+            *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::DynamicPoolList>(
+                SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+            SHC_rv->addr  = SHC_rv_cxx;
+            SHC_rv->idtor = 1;
+            return SHC_rv;
+
+      - decl: Allocator makeAllocator_quick_pool_aligned(const std::string& name, Allocator allocator, size_t initial_size, size_t block, size_t alignment)
+        options:
+          F_C_name_template: c_resourcemanager_make_alloc_quick_p_a{function_suffix}{template_suffix}
+        format:
+          F_name_impl: make_alloc_quick_p_a
+        splicer:
+          c: |
+            const std::string SHC_name_cxx(name);
+            umpire::Allocator *SHC_allocator_cxx =
+                static_cast<umpire::Allocator *>(allocator.addr);
+            umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+            *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::QuickPool>(
+                SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+            SHC_rv->addr  = SHC_rv_cxx;
+            SHC_rv->idtor = 1;
+            return SHC_rv;
+
+      - decl: Allocator makeAllocator_resource_aware_pool_aligned(const std::string& name, Allocator allocator, size_t initial_size, size_t block, size_t alignment)
+        options:
+          F_C_name_template: c_resourcemanager_make_alloc_res_aware_p_a{function_suffix}{template_suffix}
+        format:
+          F_name_impl: make_alloc_res_aware_p_a
+        splicer:
+          c: |
+            const std::string SHC_name_cxx(name);
+            umpire::Allocator *SHC_allocator_cxx =
+                static_cast<umpire::Allocator *>(allocator.addr);
+            umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+            *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool>(
+                SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+            SHC_rv->addr  = SHC_rv_cxx;
+            SHC_rv->idtor = 1;
+            return SHC_rv;
+
       - decl: template <typename T> Allocator makeAllocator(const std::string& name, Allocator allocator, const std::string& advice_op, int device_id);
         options:
           F_create_generic: False
@@ -326,6 +377,57 @@ declarations:
             umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
             *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool, false>(
                 SHC_name_cxx, *SHC_allocator_cxx, initial_size, block);
+            SHC_rv->addr  = SHC_rv_cxx;
+            SHC_rv->idtor = 1;
+            return SHC_rv;
+
+      - decl: Allocator makeAllocator_list_pool_aligned_untracked(const std::string& name, Allocator allocator, size_t initial_size, size_t block, size_t alignment)
+        options:
+          F_C_name_template: c_resourcemanager_make_alloc_dynamic_p_list_au{function_suffix}{template_suffix}
+        format:
+          F_name_impl: make_alloc_dynamic_p_list_au
+        splicer:
+          c: |
+            const std::string SHC_name_cxx(name);
+            umpire::Allocator *SHC_allocator_cxx =
+                static_cast<umpire::Allocator *>(allocator.addr);
+            umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+            *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::DynamicPoolList, false>(
+                SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+            SHC_rv->addr  = SHC_rv_cxx;
+            SHC_rv->idtor = 1;
+            return SHC_rv;
+
+      - decl: Allocator makeAllocator_quick_pool_aligned_untracked(const std::string& name, Allocator allocator, size_t initial_size, size_t block, size_t alignment)
+        options:
+          F_C_name_template: c_resourcemanager_make_alloc_quick_p_au{function_suffix}{template_suffix}
+        format:
+          F_name_impl: make_alloc_quick_p_au
+        splicer:
+          c: |
+            const std::string SHC_name_cxx(name);
+            umpire::Allocator *SHC_allocator_cxx =
+                static_cast<umpire::Allocator *>(allocator.addr);
+            umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+            *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::QuickPool, false>(
+                SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
+            SHC_rv->addr  = SHC_rv_cxx;
+            SHC_rv->idtor = 1;
+            return SHC_rv;
+
+      - decl: Allocator makeAllocator_resource_aware_pool_aligned_untracked(const std::string& name, Allocator allocator, size_t initial_size, size_t block, size_t alignment)
+        options:
+          F_C_name_template: c_resourcemanager_make_alloc_res_aware_p_au{function_suffix}{template_suffix}
+        format:
+          F_name_impl: make_alloc_res_aware_p_au
+        splicer:
+          c: |
+            const std::string SHC_name_cxx(name);
+            umpire::Allocator *SHC_allocator_cxx =
+                static_cast<umpire::Allocator *>(allocator.addr);
+            umpire::Allocator *SHC_rv_cxx = new umpire::Allocator;
+            *SHC_rv_cxx = SH_this->makeAllocator<umpire::strategy::ResourceAwarePool, false>(
+                SHC_name_cxx, *SHC_allocator_cxx, initial_size, block, alignment);
             SHC_rv->addr  = SHC_rv_cxx;
             SHC_rv->idtor = 1;
             return SHC_rv;


### PR DESCRIPTION
This PR adds explicit alignment control for pool allocators in the C and Fortran interfaces.

TODO: unit/regression tests