### PR TITLE
Track CI section timings and chart trends over commits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,30 +229,22 @@ tuolumne-build-and-test:
 # CI TIMING TRENDS
 # Collect the per-job section timings produced by build_and_test.sh across all
 # child pipelines, merge them into an accumulating history, and publish trend
-# charts to GitLab Pages. Runs only on the default branch so the published
-# series tracks the mainline. The history.jsonl artifact of the latest
-# default-branch pipeline is reused as the persistent store (relies on GitLab's
-# "keep artifacts from the most recent successful pipelines" setting).
+# charts to GitLab Pages. Runs only on the default branch (or when REPORT_TIMINGS
+# is "ON") so the published series tracks the mainline. The history.jsonl
+# artifact of the latest default-branch pipeline is reused as the persistent
+# store (relies on GitLab's "keep artifacts from the most recent successful
+# pipelines" setting).
+#
+# No `needs:` on purpose: this job relies on stage ordering. The build-and-test
+# trigger jobs inherit `trigger:strategy: depend` from the shared-CI
+# `.build-and-test` template, so the build-and-test stage completes only once all
+# child pipelines finish; this job, in the last stage, therefore runs after them.
+# (The per-job timings.json are fetched via the GitLab API, not via needs, so no
+# artifact dependency is required here.) `when: always` keeps it running -- and
+# charting partial data -- even when a child pipeline fails.
 pages:
   stage: finalizing
   tags: [shell, oslic]
-  # `optional: true` keeps this job runnable when a machine block is commented
-  # out or its availability check fails; it then charts whatever data exists.
-  # NOTE: this relies on the build-and-test trigger jobs propagating child
-  # pipeline completion (GitLab `trigger:strategy: depend`). The RADIUSS shared
-  # `.build-and-test` template is expected to set this; if child artifacts are
-  # missing here, add `strategy: depend` to the trigger blocks above.
-  needs:
-    - job: dane-build-and-test
-      optional: true
-    - job: matrix-build-and-test
-      optional: true
-    - job: corona-build-and-test
-      optional: true
-    - job: tioga-build-and-test
-      optional: true
-    - job: tuolumne-build-and-test
-      optional: true
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $REPORT_TIMINGS == "ON"'
       when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,7 +252,9 @@ pages:
     - job: tuolumne-build-and-test
       optional: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $REPORT_TIMINGS == "ON"'
+      when: always
+    - when: never
   script:
     - python3 -m venv .venv
     - .venv/bin/pip install --quiet matplotlib

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ stages:
   - prerequisites           # Required: machine availability checks
   - build-and-test          # Required: build and test jobs
   - multi-project           # Manual: trigger testing in dependent project (e.g., CHAI)
-  - radiuss-spack-testing   # TODO unused so far
+  - finalizing
 
 ###############################################################################
 # INCLUDES
@@ -234,7 +234,7 @@ tuolumne-build-and-test:
 # default-branch pipeline is reused as the persistent store (relies on GitLab's
 # "keep artifacts from the most recent successful pipelines" setting).
 pages:
-  stage: radiuss-spack-testing
+  stage: finalizing
   tags: [shell, oslic]
   # `optional: true` keeps this job runnable when a machine block is commented
   # out or its availability check fails; it then charts whatever data exists.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,8 @@ variables:
   GIT_SUBMODULE_DEPTH: 1
   GIT_SUBMODULE_UPDATE_FLAGS: --jobs 2
   GIT_SUBMODULE_PATHS: scripts/radiuss-spack-configs scripts/uberenv
+# Force export of timing reports by setting to "ON"
+  REPORT_TIMINGS: "OFF"
 
 # SHARED_CI CONFIGURATION
 # Required information about GitHub repository

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,6 +224,45 @@ tuolumne-build-and-test:
       - artifact: 'tuolumne-jobs.yml'
         job: 'generate-job-lists'
 
+# CI TIMING TRENDS
+# Collect the per-job section timings produced by build_and_test.sh across all
+# child pipelines, merge them into an accumulating history, and publish trend
+# charts to GitLab Pages. Runs only on the default branch so the published
+# series tracks the mainline. The history.jsonl artifact of the latest
+# default-branch pipeline is reused as the persistent store (relies on GitLab's
+# "keep artifacts from the most recent successful pipelines" setting).
+pages:
+  stage: radiuss-spack-testing
+  tags: [shell, oslic]
+  # `optional: true` keeps this job runnable when a machine block is commented
+  # out or its availability check fails; it then charts whatever data exists.
+  # NOTE: this relies on the build-and-test trigger jobs propagating child
+  # pipeline completion (GitLab `trigger:strategy: depend`). The RADIUSS shared
+  # `.build-and-test` template is expected to set this; if child artifacts are
+  # missing here, add `strategy: depend` to the trigger blocks above.
+  needs:
+    - job: dane-build-and-test
+      optional: true
+    - job: matrix-build-and-test
+      optional: true
+    - job: corona-build-and-test
+      optional: true
+    - job: tioga-build-and-test
+      optional: true
+    - job: tuolumne-build-and-test
+      optional: true
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  script:
+    - python3 -m venv .venv
+    - .venv/bin/pip install --quiet matplotlib
+    - .venv/bin/python scripts/gitlab/collect_and_chart_timings.py
+  artifacts:
+    paths:
+      - public
+      - history.jsonl
+    expire_in: never
+
 # MULTI-PROJECT PIPELINE
 trigger-chai:
   stage: multi-project

--- a/.gitlab/custom-jobs.yml
+++ b/.gitlab/custom-jobs.yml
@@ -22,11 +22,18 @@ workflow:
 # CI behavior.
 .custom_job:
   artifacts:
+    # Upload artifacts even when the job fails: build_and_test.sh writes
+    # timings.json from an EXIT trap, so failed builds still produce (partial)
+    # timing data we want to collect. Also preserves junit.xml on failure.
+    when: always
     reports:
       junit: junit.xml
     name: "${CI_PROJECT_NAME}-${CI_MACHINE}-${CI_JOB_NAME}-${CI_PIPELINE_ID}"
     paths:
       - ./*.cmake
+      # Per-job section timings, collected by the parent-pipeline `pages` job to
+      # track build/test timing evolution across commits.
+      - ./timings.json
 
 .reproducer_vars:
   script:

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -98,16 +98,87 @@ format_elapsed_hms ()
     printf '%02d:%02d:%02d' $((elapsed / 3600)) $(((elapsed % 3600) / 60)) $((elapsed % 60))
 }
 
+# Write the accumulated section timings as a machine-readable JSON file. This is
+# registered as an EXIT trap so that timings are captured even when the build
+# fails: each completed section is recorded by section_end before any early
+# exit. Built with printf to avoid a jq dependency. Must not change the script
+# exit status, so the incoming code is captured first and never overridden.
+write_timings_file ()
+{
+    local exit_code=$?
+    local timings_file="${project_dir}/timings.json"
+    local now=$(date +%s)
+    local total_seconds=$((now - script_start_time))
+
+    {
+        printf '{\n'
+        printf '  "schema": 1,\n'
+        printf '  "sha": "%s",\n' "${CI_COMMIT_SHA:-}"
+        printf '  "short_sha": "%s",\n' "${CI_COMMIT_SHORT_SHA:-}"
+        printf '  "ts": %s,\n' "${script_start_time}"
+        printf '  "machine": "%s",\n' "${CI_MACHINE:-${truehostname}}"
+        printf '  "job": "%s",\n' "${CI_JOB_NAME:-}"
+        printf '  "spec": "%s",\n' "${spec//\"/\\\"}"
+        printf '  "pipeline_id": "%s",\n' "${CI_PIPELINE_ID:-}"
+        printf '  "exit_code": %s,\n' "${exit_code}"
+        printf '  "total_seconds": %s,\n' "${total_seconds}"
+        printf '  "sections": ['
+
+        local first=true
+        local record
+        for record in "${timing_records[@]:-}"
+        do
+            [[ -z "${record}" ]] && continue
+            local name="${record%%|*}"
+            local rest="${record#*|}"
+            local depth="${rest%%|*}"
+            rest="${rest#*|}"
+            local parent="${rest%%|*}"
+            local seconds="${rest##*|}"
+            if [[ "${first}" == true ]]
+            then
+                first=false
+                printf '\n'
+            else
+                printf ',\n'
+            fi
+            printf '    {"name": "%s", "depth": %s, "parent": "%s", "seconds": %s}' \
+                "${name}" "${depth}" "${parent}" "${seconds}"
+        done
+        if [[ "${first}" == false ]]
+        then
+            printf '\n  ]\n'
+        else
+            printf ']\n'
+        fi
+        printf '}\n'
+    } > "${timings_file}" 2>/dev/null || print_warning "Failed to write timings file"
+
+    print_info "Wrote section timings to ${timings_file}"
+}
+
 # Track script start time for elapsed time calculations
 script_start_time=$(date +%s)
 
+# Always emit machine-readable section timings on exit (success or failure).
+trap write_timings_file EXIT
+
 # Storage for section start times (supports nesting)
 declare -A section_start_times
+
+# Storage for section metadata, used to emit machine-readable timings.
+declare -A section_names
+declare -A section_depths
+declare -A section_parents
 
 # Section stack for tracking nested sections
 section_id_stack=()
 section_counter=0
 section_indent=""
+
+# Accumulated per-section timing records ("name|depth|parent|seconds"), one per
+# completed section. Consumed by write_timings_file at script exit.
+timing_records=()
 
 # GitLab CI collapsible section helpers with nesting support
 section_start ()
@@ -133,6 +204,19 @@ section_start ()
 
     # Store section start time for later calculation
     section_start_times[${section_id}]=${timestamp}
+
+    # Store section metadata for machine-readable timings. The depth is the
+    # current stack size and the parent is the section currently on top of the
+    # stack (empty for top-level sections), both captured before pushing.
+    section_names[${section_id}]="${section_title}"
+    section_depths[${section_id}]=${#section_id_stack[@]}
+    if [[ ${#section_id_stack[@]} -gt 0 ]]
+    then
+        local parent_id="${section_id_stack[$((${#section_id_stack[@]} - 1))]}"
+        section_parents[${section_id}]="${section_names[${parent_id}]:-}"
+    else
+        section_parents[${section_id}]=""
+    fi
 
     # Push section ID onto stack
     section_id_stack+=("${section_id}")
@@ -175,8 +259,14 @@ section_end ()
     echo -e "\e[1;30m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}\e[0m"
     echo -e "\e[1;30m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\e[0m"
 
-    # Clean up stored time
+    # Record a machine-readable timing for this section.
+    timing_records+=("${section_names[${section_id}]:-${section_id}}|${section_depths[${section_id}]:-0}|${section_parents[${section_id}]:-}|${section_elapsed}")
+
+    # Clean up stored data
     unset section_start_times[${section_id}]
+    unset section_names[${section_id}]
+    unset section_depths[${section_id}]
+    unset section_parents[${section_id}]
 }
 
 # For convenience, a helper function to run a command within a section and handle errors

--- a/scripts/gitlab/collect_and_chart_timings.py
+++ b/scripts/gitlab/collect_and_chart_timings.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2022-25, Lawrence Livermore National Security, LLC and RADIUSS
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+###############################################################################
+"""Collect per-job CI section timings and render trend charts.
+
+Intended to run in the parent pipeline's ``pages`` job, after the per-machine
+child pipelines complete. It:
+
+  1. Gathers every child job's ``timings.json`` (written by
+     ``scripts/gitlab/build_and_test.sh``) via the GitLab API.
+  2. Merges those records into an accumulating ``history.jsonl`` pulled from the
+     latest default-branch pipeline's artifact, so the series survives the
+     per-pipeline artifact expiry window.
+  3. Renders one cumulative (stacked-area) chart per ``(machine, job)`` — commit
+     on the X axis, seconds on the Y axis, one band per top-level section — plus
+     an ``index.html`` linking them, under ``public/``.
+
+Offline / local testing
+------------------------
+Set ``TIMINGS_OFFLINE=1`` and place ``timings.json`` files (any names) under
+``TIMINGS_INPUT_DIR`` (default ``./timings_input``). A local ``history.jsonl``,
+if present in the working directory, is used as the starting history. No network
+calls are made in this mode, so the chart rendering can be exercised without a
+GitLab instance.
+"""
+
+import glob
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+OUTPUT_DIR = "public"
+HISTORY_FILE = "history.jsonl"
+# Cap the retained history to the most recent commits to keep the dataset and
+# charts manageable. Dropped commits are reported on stdout.
+MAX_COMMITS = 200
+
+API_URL = os.environ.get("CI_API_V4_URL", "")
+PROJECT_ID = os.environ.get("CI_PROJECT_ID", "")
+PIPELINE_ID = os.environ.get("CI_PIPELINE_ID", "")
+JOB_TOKEN = os.environ.get("CI_JOB_TOKEN", "")
+DEFAULT_BRANCH = os.environ.get("CI_DEFAULT_BRANCH", "develop")
+PAGES_JOB_NAME = os.environ.get("CI_JOB_NAME", "pages")
+OFFLINE = os.environ.get("TIMINGS_OFFLINE", "") == "1"
+INPUT_DIR = os.environ.get("TIMINGS_INPUT_DIR", "timings_input")
+
+
+def log(msg):
+    print("[timings] {}".format(msg), flush=True)
+
+
+###############################################################################
+# GitLab API helpers
+###############################################################################
+
+def _api_request(url):
+    """GET a URL with the CI job token. Returns response bytes, or None on 404."""
+    req = urllib.request.Request(url, headers={"JOB-TOKEN": JOB_TOKEN})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            return None
+        raise
+
+
+def _api_get_json_paginated(path):
+    """GET a paginated API list endpoint, returning the concatenated JSON list."""
+    results = []
+    page = 1
+    while True:
+        sep = "&" if "?" in path else "?"
+        url = "{}/{}{}per_page=100&page={}".format(API_URL, path, sep, page)
+        body = _api_request(url)
+        if not body:
+            break
+        chunk = json.loads(body)
+        if not chunk:
+            break
+        results.extend(chunk)
+        if len(chunk) < 100:
+            break
+        page += 1
+    return results
+
+
+def gather_pipeline_timings():
+    """Download every child job's timings.json for the current pipeline."""
+    records = []
+    bridges = _api_get_json_paginated(
+        "projects/{}/pipelines/{}/bridges".format(PROJECT_ID, PIPELINE_ID))
+    downstream_ids = [
+        b["downstream_pipeline"]["id"]
+        for b in bridges
+        if b.get("downstream_pipeline")
+    ]
+    log("Found {} downstream child pipeline(s)".format(len(downstream_ids)))
+
+    for dp_id in downstream_ids:
+        jobs = _api_get_json_paginated(
+            "projects/{}/pipelines/{}/jobs".format(PROJECT_ID, dp_id))
+        for job in jobs:
+            artifact_url = "{}/projects/{}/jobs/{}/artifacts/timings.json".format(
+                API_URL, PROJECT_ID, job["id"])
+            body = _api_request(artifact_url)
+            if not body:
+                continue
+            try:
+                records.append(json.loads(body))
+            except json.JSONDecodeError:
+                log("Skipping malformed timings.json from job {}".format(job["id"]))
+    log("Collected {} timings record(s) from this pipeline".format(len(records)))
+    return records
+
+
+def load_remote_history():
+    """Fetch history.jsonl from the latest default-branch pipeline artifact."""
+    path = "projects/{}/jobs/artifacts/{}/raw/{}".format(
+        PROJECT_ID, urllib.parse.quote(DEFAULT_BRANCH, safe=""), HISTORY_FILE)
+    url = "{}/{}?job={}".format(API_URL, path, urllib.parse.quote(PAGES_JOB_NAME))
+    body = _api_request(url)
+    if not body:
+        log("No prior history found (first run on {}?)".format(DEFAULT_BRANCH))
+        return []
+    return parse_history_bytes(body)
+
+
+###############################################################################
+# Offline / local input
+###############################################################################
+
+def gather_local_timings():
+    records = []
+    for path in sorted(glob.glob(os.path.join(INPUT_DIR, "*.json"))):
+        with open(path) as handle:
+            records.append(json.load(handle))
+    log("Loaded {} local timings record(s) from {}".format(len(records), INPUT_DIR))
+    return records
+
+
+def load_local_history():
+    if not os.path.exists(HISTORY_FILE):
+        return []
+    with open(HISTORY_FILE, "rb") as handle:
+        return parse_history_bytes(handle.read())
+
+
+###############################################################################
+# Merge & persist
+###############################################################################
+
+def parse_history_bytes(body):
+    records = []
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+    return records
+
+
+def record_key(record):
+    return (record.get("sha", ""), record.get("machine", ""), record.get("job", ""))
+
+
+def merge_records(history, new_records):
+    """Merge new records into history, deduped by (sha, machine, job).
+
+    Newer records (higher ts) win on conflict. History is then trimmed to the
+    most recent MAX_COMMITS distinct commits.
+    """
+    merged = {}
+    for record in history + new_records:
+        key = record_key(record)
+        existing = merged.get(key)
+        if existing is None or record.get("ts", 0) >= existing.get("ts", 0):
+            merged[key] = record
+
+    records = list(merged.values())
+
+    # Keep only the most recent MAX_COMMITS commits (by latest ts per sha).
+    latest_ts_by_sha = {}
+    for record in records:
+        sha = record.get("sha", "")
+        latest_ts_by_sha[sha] = max(latest_ts_by_sha.get(sha, 0), record.get("ts", 0))
+    kept_shas = set(
+        sha for sha, _ in
+        sorted(latest_ts_by_sha.items(), key=lambda kv: kv[1], reverse=True)[:MAX_COMMITS]
+    )
+    dropped = len(latest_ts_by_sha) - len(kept_shas)
+    if dropped > 0:
+        log("Trimming history: dropping {} oldest commit(s) beyond MAX_COMMITS={}"
+            .format(dropped, MAX_COMMITS))
+    records = [r for r in records if r.get("sha", "") in kept_shas]
+
+    records.sort(key=lambda r: (r.get("ts", 0), r.get("machine", ""), r.get("job", "")))
+    return records
+
+
+def write_history(records):
+    with open(HISTORY_FILE, "w") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    log("Wrote {} record(s) to {}".format(len(records), HISTORY_FILE))
+
+
+###############################################################################
+# Charts
+###############################################################################
+
+def top_level_section_order(records):
+    """Stable ordering of depth-0 section names, by first appearance over time."""
+    order = []
+    seen = set()
+    for record in sorted(records, key=lambda r: r.get("ts", 0)):
+        for section in record.get("sections", []):
+            if section.get("depth", 0) != 0:
+                continue
+            name = section["name"]
+            if name not in seen:
+                seen.add(name)
+                order.append(name)
+    return order
+
+
+def render_charts(records):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    # Group records per (machine, job).
+    groups = {}
+    for record in records:
+        groups.setdefault((record.get("machine", ""), record.get("job", "")), []).append(record)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    chart_index = {}  # machine -> list of (job, relative_png_path)
+
+    for (machine, job), group in sorted(groups.items()):
+        group.sort(key=lambda r: r.get("ts", 0))
+        section_names = top_level_section_order(group)
+        if not section_names:
+            continue
+
+        labels = [r.get("short_sha") or r.get("sha", "")[:8] for r in group]
+        x = list(range(len(group)))
+        series = []
+        for name in section_names:
+            row = []
+            for record in group:
+                seconds = 0
+                for section in record.get("sections", []):
+                    if section.get("depth", 0) == 0 and section["name"] == name:
+                        seconds = section.get("seconds", 0)
+                        break
+                row.append(seconds)
+            series.append(row)
+
+        fig, ax = plt.subplots(figsize=(max(8, len(group) * 0.35), 6))
+        ax.stackplot(x, series, labels=section_names)
+        ax.set_title("{} / {} — section timings".format(machine, job))
+        ax.set_xlabel("commit")
+        ax.set_ylabel("seconds")
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=90, fontsize=7)
+        ax.legend(loc="upper left", fontsize=7, ncol=2)
+        ax.margins(x=0)
+        fig.tight_layout()
+
+        machine_dir = os.path.join(OUTPUT_DIR, machine or "unknown")
+        os.makedirs(machine_dir, exist_ok=True)
+        rel_path = os.path.join(machine or "unknown", "{}.png".format(job or "unknown"))
+        fig.savefig(os.path.join(OUTPUT_DIR, rel_path), dpi=100)
+        plt.close(fig)
+        chart_index.setdefault(machine or "unknown", []).append((job or "unknown", rel_path))
+
+    write_index(chart_index)
+
+
+def write_index(chart_index):
+    parts = [
+        "<!DOCTYPE html>",
+        "<html><head><meta charset='utf-8'>",
+        "<title>Umpire CI timing trends</title>",
+        "<style>body{font-family:sans-serif;margin:2rem;}"
+        "h2{margin-top:2rem;}img{max-width:100%;border:1px solid #ccc;margin:.5rem 0;}"
+        "</style></head><body>",
+        "<h1>Umpire CI timing trends</h1>",
+        "<p>Cumulative per-section build/test timings over commits, by machine and job.</p>",
+    ]
+    for machine in sorted(chart_index):
+        parts.append("<h2>{}</h2>".format(machine))
+        for job, rel_path in sorted(chart_index[machine]):
+            parts.append("<h3>{}</h3>".format(job))
+            parts.append("<img src='{}' alt='{} {}'>".format(rel_path, machine, job))
+    parts.append("</body></html>")
+    with open(os.path.join(OUTPUT_DIR, "index.html"), "w") as handle:
+        handle.write("\n".join(parts))
+    log("Wrote {}/index.html".format(OUTPUT_DIR))
+
+
+###############################################################################
+# Main
+###############################################################################
+
+def main():
+    if OFFLINE:
+        log("Running in OFFLINE mode")
+        new_records = gather_local_timings()
+        history = load_local_history()
+    else:
+        new_records = gather_pipeline_timings()
+        history = load_remote_history()
+
+    merged = merge_records(history, new_records)
+    if not merged:
+        log("No timing records available; nothing to chart.")
+        # Still emit history (empty) and an index so the pages job succeeds.
+        write_history(merged)
+        os.makedirs(OUTPUT_DIR, exist_ok=True)
+        write_index({})
+        return 0
+
+    write_history(merged)
+    render_charts(merged)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`scripts/gitlab/build_and_test.sh` already prints collapsible per-section timings into the job log. This PR additionally **persists those timings as data** and **charts how each section's duration evolves across commits**, so we can spot build/test regressions over time.

The chart is what was envisioned: one **cumulative (stacked-area) graph per `(machine, job)`** — commit on the X axis, seconds on the Y axis, one band per top-level section — published to GitLab Pages and regenerated by a dedicated job after the per-machine child pipelines.

## What changed

- **`scripts/gitlab/build_and_test.sh`** — `section_start`/`section_end` now also capture each section's title, nesting depth, and parent. A new `write_timings_file()` helper emits a machine-readable `timings.json` (commit SHA, machine, job, spec, pipeline id, `exit_code`, total seconds, and a `sections[]` array). It is registered as a `trap … EXIT` so timings are written **even when the build fails** (each completed section is recorded before any early `exit`).
- **`.gitlab/custom-jobs.yml`** — adds `timings.json` to the per-job artifacts and sets `artifacts:when: always` so the file (and junit.xml) is uploaded even on job failure.
- **`.gitlab-ci.yml`** — new `pages` job in the `radiuss-spack-testing` stage, gated to the default branch.
- **`scripts/gitlab/collect_and_chart_timings.py`** (new) — collects each child job's `timings.json` via the GitLab API, merges into a persistent `history.jsonl`, renders the charts, and writes an `index.html`.

## Design choices

- **Why a custom chart job, not GitLab's native performance tracking.** GitLab's `artifacts:reports:metrics` / browser-performance reports only render as **merge-request-vs-target-branch widgets** (and metrics reports are Premium) — they do not produce a cross-commit time series. The "evolution over commits" view therefore has to be built: collect → persist → render.
- **Persistence without an extra branch or token.** Each pipeline's artifacts are isolated and expire, so the accumulated history can't live in a single pipeline. Instead the `pages` job's own `history.jsonl` artifact *is* the store: each default-branch run downloads the **latest default-branch pipeline's** `history.jsonl`, appends the new data points (deduped by `sha|machine|job`, newest `ts` wins), and re-publishes it. This relies on GitLab's *"Keep artifacts from the most recent successful pipelines"* setting (default on); `expire_in: never` is set as belt-and-suspenders. No data branch, no push token.
- **Data format.** Per-job JSON + JSONL history — easy to append and to feed a plotting script. A `"schema": 1` version field is included for forward-compatibility if the record shape changes.
- **Scope.** Timings are collected from every child job on all machines; history accumulation + charting happen **only on the default branch**, so the trend line tracks mainline.
- **Robustness.** `needs:` on the trigger jobs is `optional: true`, so the `pages` job still runs (charting whatever exists) when a machine block is commented out or its availability check fails. Failed builds upload partial timings; each record carries `exit_code` for optional downstream filtering.

## Verification done locally

- `bash -n` and `py_compile` pass; both YAML files parse.
- Drove the real `write_timings_file` with populated records → valid JSON with correct nesting and quote-escaping (incl. the failure/EXIT-trap path).
- Ran the collector in offline mode end-to-end: history merged/deduped/sorted, per-`(machine, job)` PNGs + `index.html` generated, and the stacked chart renders as intended (nested depth-1 sections correctly excluded from the stack).

## To verify on real CI / left to do

- [x] **Child-pipeline completion.** The `pages` job assumes the `*-build-and-test` trigger jobs propagate downstream completion (GitLab `trigger:strategy: depend`). The RADIUSS `.build-and-test` template is expected to set this; if child artifacts are missing in `pages`, add `strategy: depend` to the trigger blocks. (Flagged in a comment on the job.)
- [x] **Runner prerequisites.** The `[shell, oslic]` runner needs `python3` + outbound network for the `venv`/`pip install matplotlib` step and the GitLab API calls. Confirm GitLab **Pages is enabled** and the **keep-latest-artifacts** setting is on.
- [ ] **(Follow-up, not in this PR) Cache the Python env** instead of reinstalling matplotlib each run — e.g. a pinned `requirements-charts.txt` + a `cache:` block, or a runner image with matplotlib preinstalled.
- [ ] **(Optional) Filter failed builds** out of trend lines using `exit_code`, if partial-timing data proves noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)