### PR TITLE
Fix memory resource traits device enumeration

### DIFF
--- a/tests/integration/memory_resource_traits_tests.cpp
+++ b/tests/integration/memory_resource_traits_tests.cpp
@@ -77,7 +77,7 @@ std::vector<std::string> memory_resource_strings()
 #if defined(UMPIRE_ENABLE_DEVICE)
   resources.push_back("DEVICE");
   auto& rm = umpire::ResourceManager::getInstance();
-  for (int id = 0; id < rm.getNumDevices(); id++) {
+  for (int id = 1; id < rm.getNumDevices(); id++) {
     resources.push_back(std::string{"DEVICE::" + std::to_string(id)});
   }
 #endif

--- a/tests/integration/memory_resource_traits_tests.cpp
+++ b/tests/integration/memory_resource_traits_tests.cpp
@@ -35,8 +35,8 @@ class MemoryResourceTraitsTest : public ::testing::TestWithParam<std::string> {
       delete m_allocator_pool;
   }
 
-  umpire::Allocator* m_allocator;
-  umpire::Allocator* m_allocator_pool;
+  umpire::Allocator* m_allocator{nullptr};
+  umpire::Allocator* m_allocator_pool{nullptr};
   std::string m_resource;
 };
 
@@ -77,7 +77,7 @@ std::vector<std::string> memory_resource_strings()
 #if defined(UMPIRE_ENABLE_DEVICE)
   resources.push_back("DEVICE");
   auto& rm = umpire::ResourceManager::getInstance();
-  for (int id = 1; id == rm.getNumDevices(); id++) {
+  for (int id = 0; id < rm.getNumDevices(); id++) {
     resources.push_back(std::string{"DEVICE::" + std::to_string(id)});
   }
 #endif


### PR DESCRIPTION
## Summary
- enumerate only additional per-device memory resources as DEVICE::1 through DEVICE::N-1, leaving DEVICE as the primary device case
- avoid asserting DEVICE::0 has a distinct canonical allocator name when it aliases DEVICE
- initialize memory resource traits test fixture allocator pointers before SetUp can throw

## Background
The original CUDA failure occurred when a one-visible-GPU job generated DEVICE::1, which was not registered. After changing the loop to include DEVICE::0, an AMD GPU job showed that DEVICE::0 can resolve to the canonical DEVICE allocator, so the test should not treat DEVICE::0 as a separate named allocator.

Assisted by Codex with ChatGPT 5.5