### PR TITLE
Stop setting spack-packages builtin repo ref in shared environment

### DIFF
--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -17,7 +17,12 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
-# No overridden jobs so far.
+# We need to set the fortran compiler to enforce coherent CXX support accross build and link:
+rocmcc_6_4_3_hip:
+  variables:
+    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %c=llvm-amdgpu@=6.4.3 %cxx=llvm-amdgpu@=6.4.3 %fortran=gcc@13: ^hip@6.4.3 ${PROJECT_CORONA_DEPS}"
+    MODULE_LIST: "rocm/6.4.3"
+  extends: .job_on_corona
 
 ############
 # Extra jobs

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -7,5 +7,7 @@
 "spack_branch": "v1.1.1",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
+"spack_packages_url": "https://github.com/spack/spack-packages.git",
+"spack_packages_commit": "e4c0b2d275f9b4714f80156f79f1e29347dedf16",
 "spack_setup_clingo": false
 }

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,10 +4,10 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "v1.1.1",
+"spack_branch": "v1.2.2",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
 "spack_packages_url": "https://github.com/spack/spack-packages.git",
-"spack_packages_commit": "e4c0b2d275f9b4714f80156f79f1e29347dedf16",
+"spack_packages_commit": "24f9524eea69c7763d25acbe99681bde3cef28a9",
 "spack_setup_clingo": false
 }

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -8,6 +8,6 @@
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
 "spack_packages_url": "https://github.com/spack/spack-packages.git",
-"spack_packages_commit": "24f9524eea69c7763d25acbe99681bde3cef28a9",
+"spack_packages_commit": "4b6b842d494ab86ebef5304e6bfe766aa421a66b",
 "spack_setup_clingo": false
 }

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -8,6 +8,6 @@
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
 "spack_packages_url": "https://github.com/spack/spack-packages.git",
-"spack_packages_commit": "4b6b842d494ab86ebef5304e6bfe766aa421a66b",
+"spack_packages_commit": "9a3f42ce82c64c7113be24447df76a10184d3b24",
 "spack_setup_clingo": false
 }


### PR DESCRIPTION
In this PR, the definition of the spack-packages reference to use in CI is transferred from the shared environment configuration in Radiuss-Spack-Configs to the uberenv settings file .uberenv_config.json.

This will allow developers to easily change the spack-packages used in the project CI (and build_and_test.sh use in general).

This required an update of radiuss-spack-configs to remove the reference from the shared environment.