### PR TITLE
Alternative fix for FixedMallocPool touching unused pages

### DIFF
--- a/src/umpire/resource/NullMemoryResource.cpp
+++ b/src/umpire/resource/NullMemoryResource.cpp
@@ -48,14 +48,16 @@ void NullMemoryResource::deallocate(void* ptr, std::size_t UMPIRE_UNUSED_ARG(siz
   UMPIRE_LOG(Debug, "(ptr=" << ptr << ")");
 
   auto iter = m_size_map.find(ptr);
-  auto size = iter->second;
+  // Copy the size before erase() returns the map's value slot to its
+  // internal pool, which overwrites the slot's storage
+  const std::size_t size = *(iter->second);
 
   m_size_map.erase(ptr);
 
 #if !defined(_MSC_VER)
-  munmap(ptr, *size);
+  munmap(ptr, size);
 #else
-  VirtualFree(ptr, *size, MEM_RELEASE);
+  VirtualFree(ptr, size, MEM_RELEASE);
 #endif
 }
 

--- a/src/umpire/util/FixedMallocPool.cpp
+++ b/src/umpire/util/FixedMallocPool.cpp
@@ -48,7 +48,7 @@ FixedMallocPool::FixedMallocPool(const std::size_t object_bytes, const std::size
   // Free-list links are stored in the slots themselves
   UMPIRE_ASSERT(object_bytes >= sizeof(unsigned int));
   // Slot indices (free-list links and num_used) are unsigned int
-  UMPIRE_ASSERT(objects_per_pool <= std::numeric_limits<unsigned int>::max());
+  UMPIRE_ASSERT(objects_per_pool <= static_cast<std::size_t>(std::numeric_limits<unsigned int>::max()));
   newPool();
 }
 

--- a/src/umpire/util/FixedMallocPool.cpp
+++ b/src/umpire/util/FixedMallocPool.cpp
@@ -6,9 +6,10 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // FixedMallocPool hands out fixed-size slots from malloc()'d pools.
-// Recycled slots are kept on a LIFO free list linked through their own
-// storage; slots that have never been handed out are dispensed in order
-// with a bump pointer and are never read or written until allocated.
+// Recycled slots are kept on a LIFO free list of slot indices linked
+// through the slots' own storage; slots that have never been handed out
+// are dispensed in order with a bump pointer and are never read or
+// written until allocated.
 
 #include "umpire/util/FixedMallocPool.hpp"
 
@@ -28,8 +29,15 @@ inline unsigned char* FixedMallocPool::addr_from_index(const FixedMallocPool::Po
   return p.data + i * m_obj_bytes;
 }
 
+inline unsigned int FixedMallocPool::index_from_addr(const FixedMallocPool::Pool& p, const unsigned char* ptr) const
+{
+  return static_cast<unsigned int>((ptr - p.data) / m_obj_bytes);
+}
+
 FixedMallocPool::Pool::Pool(const std::size_t object_bytes, const std::size_t objects_per_pool)
-    : data(static_cast<unsigned char*>(std::malloc(object_bytes * objects_per_pool))), free_list(nullptr), num_used(0)
+    : data(static_cast<unsigned char*>(std::malloc(object_bytes * objects_per_pool))),
+      free_list(static_cast<unsigned int>(objects_per_pool)),
+      num_used(0)
 {
 }
 
@@ -37,7 +45,7 @@ FixedMallocPool::FixedMallocPool(const std::size_t object_bytes, const std::size
     : m_obj_bytes(object_bytes), m_obj_per_pool(objects_per_pool), m_data_bytes(m_obj_bytes * m_obj_per_pool), m_pool()
 {
   // Free-list links are stored in the slots themselves
-  UMPIRE_ASSERT(object_bytes >= sizeof(unsigned char*));
+  UMPIRE_ASSERT(object_bytes >= sizeof(unsigned int));
   newPool();
 }
 
@@ -54,10 +62,10 @@ void FixedMallocPool::newPool()
 
 void* FixedMallocPool::allocInPool(Pool& p) noexcept
 {
-  if (p.free_list) {
-    void* ret = static_cast<void*>(p.free_list);
-    p.free_list = *reinterpret_cast<unsigned char**>(p.free_list);
-    return ret;
+  if (p.free_list < m_obj_per_pool) {
+    unsigned char* ret = addr_from_index(p, p.free_list);
+    p.free_list = *reinterpret_cast<unsigned int*>(ret);
+    return static_cast<void*>(ret);
   }
 
   if (p.num_used < m_obj_per_pool) {
@@ -101,8 +109,8 @@ void FixedMallocPool::deallocate(void* ptr)
     const unsigned char* t_ptr = reinterpret_cast<unsigned char*>(ptr);
     const ptrdiff_t offset = t_ptr - p.data;
     if ((offset >= 0) && (offset < static_cast<ptrdiff_t>(m_data_bytes))) {
-      *reinterpret_cast<unsigned char**>(ptr) = p.free_list;
-      p.free_list = reinterpret_cast<unsigned char*>(ptr);
+      *reinterpret_cast<unsigned int*>(ptr) = p.free_list;
+      p.free_list = index_from_addr(p, t_ptr);
       return;
     }
   }

--- a/src/umpire/util/FixedMallocPool.cpp
+++ b/src/umpire/util/FixedMallocPool.cpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 
 #include "umpire/util/Macros.hpp"
 #include "umpire/util/error.hpp"
@@ -46,6 +47,8 @@ FixedMallocPool::FixedMallocPool(const std::size_t object_bytes, const std::size
 {
   // Free-list links are stored in the slots themselves
   UMPIRE_ASSERT(object_bytes >= sizeof(unsigned int));
+  // Slot indices (free-list links and num_used) are unsigned int
+  UMPIRE_ASSERT(objects_per_pool <= std::numeric_limits<unsigned int>::max());
   newPool();
 }
 

--- a/src/umpire/util/FixedMallocPool.cpp
+++ b/src/umpire/util/FixedMallocPool.cpp
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier: (MIT)
 //////////////////////////////////////////////////////////////////////////////
 
-// FixedMallocPool follows the algorithm presented in
-// Fast Efficient Fixed-Size Memory Pool -- Ben Kenwright
+// FixedMallocPool hands out fixed-size slots from malloc()'d pools.
+// Recycled slots are kept on a LIFO free list linked through their own
+// storage; slots that have never been handed out are dispensed in order
+// with a bump pointer and are never read or written until allocated.
 
 #include "umpire/util/FixedMallocPool.hpp"
 
@@ -26,22 +28,16 @@ inline unsigned char* FixedMallocPool::addr_from_index(const FixedMallocPool::Po
   return p.data + i * m_obj_bytes;
 }
 
-inline unsigned int FixedMallocPool::index_from_addr(const FixedMallocPool::Pool& p, const unsigned char* ptr) const
-{
-  return static_cast<unsigned int>((ptr - p.data) / m_obj_bytes);
-}
-
 FixedMallocPool::Pool::Pool(const std::size_t object_bytes, const std::size_t objects_per_pool)
-    : data(static_cast<unsigned char*>(std::malloc(object_bytes * objects_per_pool))),
-      next(data),
-      num_initialized(0),
-      num_free(objects_per_pool)
+    : data(static_cast<unsigned char*>(std::malloc(object_bytes * objects_per_pool))), free_list(nullptr), num_used(0)
 {
 }
 
 FixedMallocPool::FixedMallocPool(const std::size_t object_bytes, const std::size_t objects_per_pool)
     : m_obj_bytes(object_bytes), m_obj_per_pool(objects_per_pool), m_data_bytes(m_obj_bytes * m_obj_per_pool), m_pool()
 {
+  // Free-list links are stored in the slots themselves
+  UMPIRE_ASSERT(object_bytes >= sizeof(unsigned char*));
   newPool();
 }
 
@@ -58,20 +54,17 @@ void FixedMallocPool::newPool()
 
 void* FixedMallocPool::allocInPool(Pool& p) noexcept
 {
-  if (p.num_initialized < m_obj_per_pool) {
-    unsigned int* ptr = reinterpret_cast<unsigned int*>(addr_from_index(p, p.num_initialized));
-    *ptr = p.num_initialized + 1;
-    p.num_initialized++;
+  if (p.free_list) {
+    void* ret = static_cast<void*>(p.free_list);
+    p.free_list = *reinterpret_cast<unsigned char**>(p.free_list);
+    return ret;
   }
 
-  void* ret = nullptr;
-  if (p.num_free > 0) {
-    ret = static_cast<void*>(p.next);
-    --p.num_free;
-    p.next = (p.num_free != 0) ? addr_from_index(p, *reinterpret_cast<unsigned int*>(p.next)) : nullptr;
+  if (p.num_used < m_obj_per_pool) {
+    return static_cast<void*>(addr_from_index(p, p.num_used++));
   }
 
-  return ret;
+  return nullptr;
 }
 
 void* FixedMallocPool::allocate_impl(std::size_t bytes)
@@ -108,14 +101,8 @@ void FixedMallocPool::deallocate(void* ptr)
     const unsigned char* t_ptr = reinterpret_cast<unsigned char*>(ptr);
     const ptrdiff_t offset = t_ptr - p.data;
     if ((offset >= 0) && (offset < static_cast<ptrdiff_t>(m_data_bytes))) {
-      if (p.next != nullptr) {
-        *reinterpret_cast<unsigned int*>(ptr) = index_from_addr(p, p.next);
-        p.next = reinterpret_cast<unsigned char*>(ptr);
-      } else {
-        *reinterpret_cast<std::size_t*>(ptr) = m_obj_per_pool;
-        p.next = reinterpret_cast<unsigned char*>(ptr);
-      }
-      ++p.num_free;
+      *reinterpret_cast<unsigned char**>(ptr) = p.free_list;
+      p.free_list = reinterpret_cast<unsigned char*>(ptr);
       return;
     }
   }

--- a/src/umpire/util/FixedMallocPool.hpp
+++ b/src/umpire/util/FixedMallocPool.hpp
@@ -46,9 +46,8 @@ class FixedMallocPool {
  private:
   struct Pool {
     unsigned char* data;
-    unsigned char* next;
-    unsigned int num_initialized;
-    std::size_t num_free;
+    unsigned char* free_list;  // recycled slots, linked through their own storage
+    unsigned int num_used;     // high-water mark: slots ever handed out
     Pool(const std::size_t object_bytes, const std::size_t objects_per_pool);
   };
 
@@ -59,7 +58,6 @@ class FixedMallocPool {
   void* allocate_impl(std::size_t bytes);
 
   unsigned char* addr_from_index(const Pool& p, unsigned int i) const;
-  unsigned int index_from_addr(const Pool& p, const unsigned char* ptr) const;
 
   const std::size_t m_obj_bytes;
   const std::size_t m_obj_per_pool;

--- a/src/umpire/util/FixedMallocPool.hpp
+++ b/src/umpire/util/FixedMallocPool.hpp
@@ -46,8 +46,9 @@ class FixedMallocPool {
  private:
   struct Pool {
     unsigned char* data;
-    unsigned char* free_list;  // recycled slots, linked through their own storage
-    unsigned int num_used;     // high-water mark: slots ever handed out
+    unsigned int free_list;  // index of first recycled slot; linked through the
+                             // slots' own storage, objects_per_pool = end of list
+    unsigned int num_used;   // high-water mark: slots ever handed out
     Pool(const std::size_t object_bytes, const std::size_t objects_per_pool);
   };
 
@@ -58,6 +59,7 @@ class FixedMallocPool {
   void* allocate_impl(std::size_t bytes);
 
   unsigned char* addr_from_index(const Pool& p, unsigned int i) const;
+  unsigned int index_from_addr(const Pool& p, const unsigned char* ptr) const;
 
   const std::size_t m_obj_bytes;
   const std::size_t m_obj_per_pool;

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -81,3 +81,12 @@ blt_add_executable(
 blt_add_test(
   NAME node_memory_tests
   COMMAND node_memory_tests)
+
+blt_add_executable(
+  NAME fixed_malloc_pool_tests
+  SOURCES fixed_malloc_pool_tests.cpp
+  DEPENDS_ON umpire gtest)
+
+blt_add_test(
+  NAME fixed_malloc_pool_tests
+  COMMAND fixed_malloc_pool_tests)

--- a/tests/unit/util/fixed_malloc_pool_tests.cpp
+++ b/tests/unit/util/fixed_malloc_pool_tests.cpp
@@ -75,9 +75,10 @@ TEST_F(FixedMallocPoolTest, LifoReuse)
 
 TEST_F(FixedMallocPoolTest, Churn)
 {
-  // Regression test for the eager-initialization behavior fixed after
-  // PR #1082: churning a small live set must recycle slots rather than
-  // consuming never-used slots, so the pool never grows.
+  // Churning a small live set must recycle slots rather than consuming
+  // never-used slots, so the pool never grows. This guards against
+  // reintroducing eager initialization of the free list, which touched
+  // (and made resident) every page in the pool up front.
   constexpr std::size_t live_set = 4;
   const std::size_t initial_bytes = pool.totalBytes();
 

--- a/tests/unit/util/fixed_malloc_pool_tests.cpp
+++ b/tests/unit/util/fixed_malloc_pool_tests.cpp
@@ -1,0 +1,135 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and Umpire
+// project contributors. See the COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (MIT)
+//////////////////////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <cstring>
+#include <set>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "umpire/util/FixedMallocPool.hpp"
+#include "umpire/util/error.hpp"
+
+namespace {
+
+constexpr std::size_t object_bytes = 16;
+constexpr std::size_t objects_per_pool = 64;
+
+class FixedMallocPoolTest : public ::testing::Test {
+ protected:
+  FixedMallocPoolTest() : pool{object_bytes, objects_per_pool}
+  {
+  }
+
+  umpire::util::FixedMallocPool pool;
+};
+
+TEST_F(FixedMallocPoolTest, AllocateDeallocate)
+{
+  std::vector<void*> ptrs;
+  for (int i = 0; i < 8; ++i) {
+    void* ptr = pool.allocate(object_bytes);
+    ASSERT_NE(ptr, nullptr);
+    ptrs.push_back(ptr);
+  }
+
+  // All pointers are distinct
+  std::set<void*> unique{ptrs.begin(), ptrs.end()};
+  ASSERT_EQ(unique.size(), ptrs.size());
+
+  // Each allocation is fully writable without corrupting the others
+  for (std::size_t i = 0; i < ptrs.size(); ++i) {
+    std::memset(ptrs[i], static_cast<int>(i + 1), object_bytes);
+  }
+  for (std::size_t i = 0; i < ptrs.size(); ++i) {
+    const unsigned char* bytes = static_cast<const unsigned char*>(ptrs[i]);
+    for (std::size_t j = 0; j < object_bytes; ++j) {
+      ASSERT_EQ(bytes[j], static_cast<unsigned char>(i + 1));
+    }
+  }
+
+  for (void* ptr : ptrs) {
+    pool.deallocate(ptr);
+  }
+}
+
+TEST_F(FixedMallocPoolTest, LifoReuse)
+{
+  void* a = pool.allocate(object_bytes);
+  void* b = pool.allocate(object_bytes);
+
+  // Recycled slots are preferred over never-used slots, most recently
+  // freed first
+  pool.deallocate(a);
+  pool.deallocate(b);
+
+  ASSERT_EQ(pool.allocate(object_bytes), b);
+  ASSERT_EQ(pool.allocate(object_bytes), a);
+
+  pool.deallocate(a);
+  pool.deallocate(b);
+}
+
+TEST_F(FixedMallocPoolTest, Churn)
+{
+  // Regression test for the eager-initialization behavior fixed after
+  // PR #1082: churning a small live set must recycle slots rather than
+  // consuming never-used slots, so the pool never grows.
+  constexpr std::size_t live_set = 4;
+  const std::size_t initial_bytes = pool.totalBytes();
+
+  std::vector<void*> ptrs;
+  for (std::size_t i = 0; i < 10 * objects_per_pool; ++i) {
+    for (std::size_t j = 0; j < live_set; ++j) {
+      void* ptr = pool.allocate(object_bytes);
+      ASSERT_NE(ptr, nullptr);
+      ptrs.push_back(ptr);
+    }
+    for (void* ptr : ptrs) {
+      pool.deallocate(ptr);
+    }
+    ptrs.clear();
+
+    ASSERT_EQ(pool.numPools(), 1);
+    ASSERT_EQ(pool.totalBytes(), initial_bytes);
+  }
+}
+
+TEST_F(FixedMallocPoolTest, ExhaustionGrowsPool)
+{
+  std::vector<void*> ptrs;
+  for (std::size_t i = 0; i < objects_per_pool; ++i) {
+    ptrs.push_back(pool.allocate(object_bytes));
+  }
+
+  std::set<void*> unique{ptrs.begin(), ptrs.end()};
+  ASSERT_EQ(unique.size(), objects_per_pool);
+  ASSERT_EQ(pool.numPools(), 1);
+
+  // One more allocation than the pool holds triggers growth
+  void* extra = pool.allocate(object_bytes);
+  ASSERT_NE(extra, nullptr);
+  ASSERT_EQ(pool.numPools(), 2);
+
+  pool.deallocate(extra);
+  for (void* ptr : ptrs) {
+    pool.deallocate(ptr);
+  }
+
+  // Freed slots are recycled from the existing pools
+  for (std::size_t i = 0; i < objects_per_pool + 1; ++i) {
+    ASSERT_NE(pool.allocate(object_bytes), nullptr);
+  }
+  ASSERT_EQ(pool.numPools(), 2);
+}
+
+TEST_F(FixedMallocPoolTest, DeallocateUnknownPointer)
+{
+  int not_from_pool;
+  ASSERT_THROW(pool.deallocate(&not_from_pool), umpire::runtime_error);
+}
+
+} // namespace

--- a/tests/unit/util/fixed_malloc_pool_tests.cpp
+++ b/tests/unit/util/fixed_malloc_pool_tests.cpp
@@ -126,6 +126,28 @@ TEST_F(FixedMallocPoolTest, ExhaustionGrowsPool)
   ASSERT_EQ(pool.numPools(), 2);
 }
 
+TEST(FixedMallocPoolSmallObjectTest, IntSizedObjects)
+{
+  // MemoryMap<int> instantiates FixedMallocPool with sizeof(int); the
+  // free list must fit in a slot that small
+  umpire::util::FixedMallocPool small_pool{sizeof(int), objects_per_pool};
+
+  void* a = small_pool.allocate(sizeof(int));
+  void* b = small_pool.allocate(sizeof(int));
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+  ASSERT_NE(a, b);
+
+  small_pool.deallocate(a);
+  small_pool.deallocate(b);
+
+  ASSERT_EQ(small_pool.allocate(sizeof(int)), b);
+  ASSERT_EQ(small_pool.allocate(sizeof(int)), a);
+
+  small_pool.deallocate(a);
+  small_pool.deallocate(b);
+}
+
 TEST_F(FixedMallocPoolTest, DeallocateUnknownPointer)
 {
   int not_from_pool;


### PR DESCRIPTION
Uses free list for recycled slots and a bump pointer for fresh slots