### PR TITLE
Export legacy CMake targets

### DIFF
--- a/.github/hubcast.yml
+++ b/.github/hubcast.yml
@@ -5,7 +5,7 @@ Repo:
 
   check_name: gitlab-ci
 
-  check_types: [pipelines, child-pipelines]
+  check_types: [pipeline, child-pipelines]
 
   delete_closed: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,18 @@ install(FILES
   "${PROJECT_BINARY_DIR}/umpire-config-version.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
 
-install(EXPORT umpire-targets NAMESPACE umpire:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
+install(
+  EXPORT umpire-targets
+  FILE umpire-targets.cmake
+  NAMESPACE umpire::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
+
+if (UMPIRE_ENABLE_ALIAS_TARGETS)
+  install(
+    EXPORT umpire-targets
+    FILE umpire-non-namespaced-targets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
+endif()
 
 if (UMPIRE_ENABLE_TESTS)
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ install(
   NAMESPACE umpire::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
 
-if (UMPIRE_ENABLE_ALIAS_TARGETS)
+if (UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS)
   install(
     EXPORT umpire-targets
     FILE umpire-non-namespaced-targets.cmake

--- a/cmake/SetupUmpireOptions.cmake
+++ b/cmake/SetupUmpireOptions.cmake
@@ -39,7 +39,7 @@ option(UMPIRE_ENABLE_SANITIZER_TESTS "Enable address sanitizer tests" Off)
 option(UMPIRE_ENABLE_DEVICE_ALLOCATOR "Enable Device Allocator" Off)
 option(UMPIRE_ENABLE_SQLITE_EXPERIMENTAL "Build with sqlite event integration (experimental)" Off)
 option(UMPIRE_DISABLE_ALLOCATIONMAP_DEBUG "Disable verbose output from AllocationMap during debug builds" Off)
-option(UMPIRE_ENABLE_ALIAS_TARGETS "Enable non-namespaced alias targets (e.g., umpire) for backwards compatibility" On)
+option(UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS "Enable non-namespaced alias targets (e.g., umpire) for backwards compatibility" On)
 set(UMPIRE_FMT_TARGET fmt::fmt-header-only CACHE STRING "Name of fmt target to use") 
 
 if (UMPIRE_ENABLE_INACCESSIBILITY_TESTS)

--- a/cmake/SetupUmpireOptions.cmake
+++ b/cmake/SetupUmpireOptions.cmake
@@ -39,7 +39,7 @@ option(UMPIRE_ENABLE_SANITIZER_TESTS "Enable address sanitizer tests" Off)
 option(UMPIRE_ENABLE_DEVICE_ALLOCATOR "Enable Device Allocator" Off)
 option(UMPIRE_ENABLE_SQLITE_EXPERIMENTAL "Build with sqlite event integration (experimental)" Off)
 option(UMPIRE_DISABLE_ALLOCATIONMAP_DEBUG "Disable verbose output from AllocationMap during debug builds" Off)
-option(UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS "Enable non-namespaced alias targets (e.g., umpire) for backwards compatibility" On)
+option(UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS "Enable legacy non-namespaced targets (e.g., umpire) for backwards compatibility" On)
 set(UMPIRE_FMT_TARGET fmt::fmt-header-only CACHE STRING "Name of fmt target to use") 
 
 if (UMPIRE_ENABLE_INACCESSIBILITY_TESTS)

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -63,6 +63,14 @@ include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 # Provide backwards-compatible non-namespaced targets unless explicitly disabled.
 if (@UMPIRE_ENABLE_ALIAS_TARGETS@)
   include("${CMAKE_CURRENT_LIST_DIR}/umpire-non-namespaced-targets.cmake")
+
+  set_target_properties(umpire PROPERTIES
+    DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_ALIAS_TARGETS=OFF when configuring Umpire.")
+
+  if (TARGET umpire_device)
+    set_target_properties(umpire_device PROPERTIES
+      DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_ALIAS_TARGETS=OFF when configuring Umpire.")
+  endif()
 endif()
 
 check_required_components(@PROJECT_NAME@)

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -60,41 +60,9 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/BLTSetupTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 
-# Provide backwards-compatible non-namespaced targets unless explicitly disabled
+# Provide backwards-compatible non-namespaced targets unless explicitly disabled.
 if (@UMPIRE_ENABLE_ALIAS_TARGETS@)
-  if (NOT TARGET umpire)
-    add_library(umpire INTERFACE IMPORTED)
-
-    # Get properties from the namespaced target to forward them
-    get_target_property(_umpire_include_dirs umpire::umpire INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(_umpire_compile_defs umpire::umpire INTERFACE_COMPILE_DEFINITIONS)
-
-    set_target_properties(umpire PROPERTIES
-      INTERFACE_LINK_LIBRARIES umpire::umpire
-      INTERFACE_INCLUDE_DIRECTORIES "${_umpire_include_dirs}"
-      INTERFACE_COMPILE_DEFINITIONS "${_umpire_compile_defs}"
-      DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_ALIAS_TARGETS=OFF when configuring Umpire.")
-
-    unset(_umpire_include_dirs)
-    unset(_umpire_compile_defs)
-  endif()
-
-  if (TARGET umpire::umpire_device AND NOT TARGET umpire_device)
-    add_library(umpire_device INTERFACE IMPORTED)
-
-    # Get properties from the namespaced target to forward them
-    get_target_property(_umpire_device_include_dirs umpire::umpire_device INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(_umpire_device_compile_defs umpire::umpire_device INTERFACE_COMPILE_DEFINITIONS)
-
-    set_target_properties(umpire_device PROPERTIES
-      INTERFACE_LINK_LIBRARIES umpire::umpire_device
-      INTERFACE_INCLUDE_DIRECTORIES "${_umpire_device_include_dirs}"
-      INTERFACE_COMPILE_DEFINITIONS "${_umpire_device_compile_defs}"
-      DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_ALIAS_TARGETS=OFF when configuring Umpire.")
-
-    unset(_umpire_device_include_dirs)
-    unset(_umpire_device_compile_defs)
-  endif()
+  include("${CMAKE_CURRENT_LIST_DIR}/umpire-non-namespaced-targets.cmake")
 endif()
 
 check_required_components(@PROJECT_NAME@)

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -61,15 +61,15 @@ include("${CMAKE_CURRENT_LIST_DIR}/BLTSetupTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 
 # Provide backwards-compatible non-namespaced targets unless explicitly disabled.
-if (@UMPIRE_ENABLE_ALIAS_TARGETS@)
+if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
   include("${CMAKE_CURRENT_LIST_DIR}/umpire-non-namespaced-targets.cmake")
 
   set_target_properties(umpire PROPERTIES
-    DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_ALIAS_TARGETS=OFF when configuring Umpire.")
+    DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
 
   if (TARGET umpire_device)
     set_target_properties(umpire_device PROPERTIES
-      DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_ALIAS_TARGETS=OFF when configuring Umpire.")
+      DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
   endif()
 endif()
 


### PR DESCRIPTION
Having namespaced targets such as "umpire::umpire" is the current best practice (because if it is not found, it is an error rather than just inserting -lumpire on the link line).

But we still want to support the legacy "umpire" target for a transition period. We tried making "umpire" an alias to "umpire::umpire", but downstream projects were setting properties on the "umpire" target, so this approach fails because properties can't be set on an alias target.

We tried making a new target and copying properties manually, but that is verbose and error prone. More checking was needed.

An alternative approach is to create an INTERFACE library called umpire and link it to umpire::umpire. But then it gains properties only transitively, not on the target itself.

To have the exact same behavior for the "umpire" target as before, we can export both namespaced and non-namespaced targets fairly easily, and that is what this pull request does.