### PR TITLE
Fix legacy CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,13 +203,6 @@ install(
   NAMESPACE umpire::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
 
-if (UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS)
-  install(
-    EXPORT umpire-targets
-    FILE umpire-non-namespaced-targets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umpire)
-endif()
-
 if (UMPIRE_ENABLE_TESTS)
   add_subdirectory(tests)
 endif ()

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -82,8 +82,9 @@ if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
     _umpire_copy_interface_properties(umpire umpire::umpire)
     set_target_properties(umpire PROPERTIES
       DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
+  endif()
 
-  if (NOT TARGET umpire_device AND TARGET umpire::umpire_device)
+  if (TARGET umpire::umpire_device AND NOT TARGET umpire_device)
     add_library(umpire_device INTERFACE IMPORTED)
     target_link_libraries(umpire_device INTERFACE umpire::umpire_device)
     set_target_properties(umpire_device PROPERTIES

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -64,7 +64,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
   add_library(umpire INTERFACE)
   target_link_libraries(umpire INTERFACE umpire::umpire)
-
   set_target_properties(umpire PROPERTIES
     DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
 

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -64,11 +64,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 function(_umpire_copy_interface_properties to_target from_target)
   foreach(_umpire_property
       INTERFACE_INCLUDE_DIRECTORIES
-      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
       INTERFACE_COMPILE_DEFINITIONS
       INTERFACE_COMPILE_OPTIONS
-      INTERFACE_COMPILE_FEATURES
-      INTERFACE_POSITION_INDEPENDENT_CODE)
+      INTERFACE_COMPILE_FEATURES)
     get_target_property(_umpire_property_value "${from_target}" "${_umpire_property}")
     if(DEFINED _umpire_property_value AND NOT _umpire_property_value MATCHES "-NOTFOUND$")
       set_target_properties("${to_target}" PROPERTIES

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -61,18 +61,34 @@ include("${CMAKE_CURRENT_LIST_DIR}/BLTSetupTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 
 # Provide backwards-compatible non-namespaced targets unless explicitly disabled.
+function(_umpire_copy_interface_properties to_target from_target)
+  foreach(_umpire_property
+      INTERFACE_INCLUDE_DIRECTORIES
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+      INTERFACE_COMPILE_DEFINITIONS
+      INTERFACE_COMPILE_OPTIONS
+      INTERFACE_COMPILE_FEATURES
+      INTERFACE_POSITION_INDEPENDENT_CODE)
+    get_target_property(_umpire_property_value "${from_target}" "${_umpire_property}")
+    if(DEFINED _umpire_property_value AND NOT _umpire_property_value MATCHES "-NOTFOUND$")
+      set_target_properties("${to_target}" PROPERTIES
+        "${_umpire_property}" "${_umpire_property_value}")
+    endif()
+  endforeach()
+endfunction()
+
 if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
   if (NOT TARGET umpire)
     add_library(umpire INTERFACE IMPORTED)
+    target_link_libraries(umpire INTERFACE umpire::umpire)
+    _umpire_copy_interface_properties(umpire umpire::umpire)
     set_target_properties(umpire PROPERTIES
-      INTERFACE_LINK_LIBRARIES umpire::umpire
       DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
-  endif()
 
-  if (TARGET umpire::umpire_device AND NOT TARGET umpire_device)
+  if (NOT TARGET umpire_device AND TARGET umpire::umpire_device)
     add_library(umpire_device INTERFACE IMPORTED)
+    target_link_libraries(umpire_device INTERFACE umpire::umpire_device)
     set_target_properties(umpire_device PROPERTIES
-      INTERFACE_LINK_LIBRARIES umpire::umpire_device
       DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
   endif()
 endif()

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -62,12 +62,15 @@ include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 
 # Provide backwards-compatible non-namespaced targets unless explicitly disabled.
 if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
-  include("${CMAKE_CURRENT_LIST_DIR}/umpire-non-namespaced-targets.cmake")
+  add_library(umpire INTERFACE)
+  target_link_libraries(umpire INTERFACE umpire::umpire)
 
   set_target_properties(umpire PROPERTIES
     DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
 
   if (TARGET umpire_device)
+    add_library(umpire_device INTERFACE)
+    target_link_libraries(umpire_device INTERFACE umpire::umpire_device)
     set_target_properties(umpire_device PROPERTIES
       DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
   endif()

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -62,15 +62,17 @@ include("${CMAKE_CURRENT_LIST_DIR}/umpire-targets.cmake")
 
 # Provide backwards-compatible non-namespaced targets unless explicitly disabled.
 if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
-  add_library(umpire INTERFACE)
-  target_link_libraries(umpire INTERFACE umpire::umpire)
-  set_target_properties(umpire PROPERTIES
-    DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
+  if (NOT TARGET umpire)
+    add_library(umpire INTERFACE IMPORTED)
+    set_target_properties(umpire PROPERTIES
+      INTERFACE_LINK_LIBRARIES umpire::umpire
+      DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
+  endif()
 
-  if (TARGET umpire::umpire_device)
-    add_library(umpire_device INTERFACE)
-    target_link_libraries(umpire_device INTERFACE umpire::umpire_device)
+  if (TARGET umpire::umpire_device AND NOT TARGET umpire_device)
+    add_library(umpire_device INTERFACE IMPORTED)
     set_target_properties(umpire_device PROPERTIES
+      INTERFACE_LINK_LIBRARIES umpire::umpire_device
       DEPRECATION "Target 'umpire_device' is deprecated. Please use 'umpire::umpire_device' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
   endif()
 endif()

--- a/umpire-config.cmake.in
+++ b/umpire-config.cmake.in
@@ -67,7 +67,7 @@ if (@UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS@)
   set_target_properties(umpire PROPERTIES
     DEPRECATION "Target 'umpire' is deprecated. Please use 'umpire::umpire' instead. To disable this warning and backwards-compatible targets, set UMPIRE_ENABLE_LEGACY_CMAKE_TARGETS=OFF when configuring Umpire.")
 
-  if (TARGET umpire_device)
+  if (TARGET umpire::umpire_device)
     add_library(umpire_device INTERFACE)
     target_link_libraries(umpire_device INTERFACE umpire::umpire_device)
     set_target_properties(umpire_device PROPERTIES


### PR DESCRIPTION
Apparently there are issues when trying to export targets twice even if they end up with different names. So now we try creating an INTERFACE library called "umpire" and link it to "umpire::umpire". We also copy some INTERFACE properties from "umpire::umpire" to "umpire". The same process is used for creating an "umpire_device" target from the "umpire::umpire_device" target.

The following is an error from exporting the "umpire" target twice:

```
CMake Error: install(EXPORT "chai-targets" ...) includes target "chai" which requires target "umpire" that is not in this export set, but in multiple other export sets: lib/cmake/umpire/umpire-targets.cmake, lib/cmake/umpire/umpire-non-namespaced-targets.cmake.
 
An exported target cannot depend upon another target which is exported multiple times. Consider consolidating the exports of the "umpire" target to a single export.
```

If the "umpire" target is not created as an "IMPORTED" library, then CHAI fails to export it's own targets:

```
CMake Error: install(EXPORT "chai-targets" ...) includes target "chai" which requires target "umpire" that is not in any export set.
```

If INTERFACE_INCLUDE_DIRECTORIES are not copied from "umpire::umpire" to "umpire", then downstream clients can't locate the umpire headers.

Link information is supposed to be transitive, so we link "umpire" to "umpire::umpire" and don't copy INTERFACE properties related to linking.

CMake has no internal way to just copy all target properties, or even to get a list of all the properties on a target. We just copy a few of the most common and important ones. INTERFACE_INCLUDE_DIRECTORIES and INTERFACE_COMPILE_DEFINITIONS are known to be needed.

See #1102, #1101, #1100, #1083, #1067